### PR TITLE
feat(cli): add CLI commands for KEK management

### DIFF
--- a/internal/app/di_test.go
+++ b/internal/app/di_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"encoding/base64"
+	"os"
 	"testing"
 	"time"
 
@@ -127,6 +129,246 @@ func TestContainerShutdown(t *testing.T) {
 	container := NewContainer(cfg)
 
 	// Shutdown should not fail even if no components are initialized
+	if err := container.Shutdown(context.TODO()); err != nil {
+		t.Errorf("unexpected error during shutdown: %v", err)
+	}
+}
+
+// TestContainerAEADManager verifies that the AEAD manager can be retrieved from the container.
+func TestContainerAEADManager(t *testing.T) {
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	container := NewContainer(cfg)
+	aeadManager := container.AEADManager()
+
+	if aeadManager == nil {
+		t.Fatal("expected non-nil AEAD manager")
+	}
+
+	// Calling AEADManager() again should return the same instance (singleton)
+	aeadManager2 := container.AEADManager()
+	if aeadManager != aeadManager2 {
+		t.Error("expected same AEAD manager instance on multiple calls")
+	}
+}
+
+// TestContainerKeyManager verifies that the key manager can be retrieved from the container.
+func TestContainerKeyManager(t *testing.T) {
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	container := NewContainer(cfg)
+	keyManager := container.KeyManager()
+
+	if keyManager == nil {
+		t.Fatal("expected non-nil key manager")
+	}
+
+	// Calling KeyManager() again should return the same instance (singleton)
+	keyManager2 := container.KeyManager()
+	if keyManager != keyManager2 {
+		t.Error("expected same key manager instance on multiple calls")
+	}
+}
+
+// TestContainerKekRepositoryErrors verifies that KEK repository initialization errors are properly handled.
+func TestContainerKekRepositoryErrors(t *testing.T) {
+	// Create a container with invalid database configuration
+	cfg := &config.Config{
+		DBDriver:           "invalid_driver",
+		DBConnectionString: "",
+	}
+
+	container := NewContainer(cfg)
+
+	// Attempting to get KEK repository should return an error
+	_, err := container.KekRepository()
+	if err == nil {
+		t.Error("expected error when connecting with invalid config")
+	}
+
+	// Attempting to get KEK repository again should return the same error
+	_, err2 := container.KekRepository()
+	if err2 == nil {
+		t.Error("expected error on second call to KekRepository()")
+	}
+}
+
+// TestContainerKekUseCaseErrors verifies that KEK use case initialization errors are properly handled.
+func TestContainerKekUseCaseErrors(t *testing.T) {
+	// Create a container with invalid database configuration
+	cfg := &config.Config{
+		DBDriver:           "invalid_driver",
+		DBConnectionString: "",
+	}
+
+	container := NewContainer(cfg)
+
+	// Attempting to get KEK use case should return an error (due to DB error)
+	_, err := container.KekUseCase()
+	if err == nil {
+		t.Error("expected error when connecting with invalid config")
+	}
+
+	// Attempting to get KEK use case again should return the same error
+	_, err2 := container.KekUseCase()
+	if err2 == nil {
+		t.Error("expected error on second call to KekUseCase()")
+	}
+}
+
+// TestContainerMasterKeyChain verifies that the master key chain can be retrieved from the container.
+func TestContainerMasterKeyChain(t *testing.T) {
+	// Generate valid 32-byte key encoded in base64
+	key1 := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
+
+	// Set up environment variables for master keys
+	t.Setenv("MASTER_KEYS", "test-key-1:"+key1)
+	t.Setenv("ACTIVE_MASTER_KEY_ID", "test-key-1")
+
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	container := NewContainer(cfg)
+	masterKeyChain, err := container.MasterKeyChain()
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if masterKeyChain == nil {
+		t.Fatal("expected non-nil master key chain")
+	}
+
+	// Verify active key ID
+	if masterKeyChain.ActiveMasterKeyID() != "test-key-1" {
+		t.Errorf("expected active key ID 'test-key-1', got '%s'", masterKeyChain.ActiveMasterKeyID())
+	}
+
+	// Calling MasterKeyChain() again should return the same instance (singleton)
+	masterKeyChain2, err := container.MasterKeyChain()
+	if err != nil {
+		t.Fatalf("expected no error on second call, got: %v", err)
+	}
+	if masterKeyChain != masterKeyChain2 {
+		t.Error("expected same master key chain instance on multiple calls")
+	}
+}
+
+// TestContainerMasterKeyChainErrors verifies that master key chain initialization errors are properly handled.
+func TestContainerMasterKeyChainErrors(t *testing.T) {
+	// Clear environment variables to trigger an error
+	originalMasterKeys := os.Getenv("MASTER_KEYS")
+	originalActiveID := os.Getenv("ACTIVE_MASTER_KEY_ID")
+	defer func() {
+		if originalMasterKeys != "" {
+			_ = os.Setenv("MASTER_KEYS", originalMasterKeys)
+		}
+		if originalActiveID != "" {
+			_ = os.Setenv("ACTIVE_MASTER_KEY_ID", originalActiveID)
+		}
+	}()
+
+	_ = os.Unsetenv("MASTER_KEYS")
+	_ = os.Unsetenv("ACTIVE_MASTER_KEY_ID")
+
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	container := NewContainer(cfg)
+
+	// Attempting to get master key chain should return an error
+	_, err := container.MasterKeyChain()
+	if err == nil {
+		t.Error("expected error when MASTER_KEYS is not set")
+	}
+
+	// Attempting to get master key chain again should return the same error
+	_, err2 := container.MasterKeyChain()
+	if err2 == nil {
+		t.Error("expected error on second call to MasterKeyChain()")
+	}
+}
+
+// TestContainerMasterKeyChainMultipleKeys verifies that multiple master keys can be loaded.
+func TestContainerMasterKeyChainMultipleKeys(t *testing.T) {
+	// Generate valid 32-byte keys encoded in base64
+	key1 := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
+	key2 := base64.StdEncoding.EncodeToString([]byte("abcdefghijklmnopqrstuvwxyz123456"))
+
+	// Set up environment variables for multiple master keys
+	t.Setenv("MASTER_KEYS", "key1:"+key1+",key2:"+key2)
+	t.Setenv("ACTIVE_MASTER_KEY_ID", "key2")
+
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	container := NewContainer(cfg)
+	masterKeyChain, err := container.MasterKeyChain()
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if masterKeyChain == nil {
+		t.Fatal("expected non-nil master key chain")
+	}
+
+	// Verify active key ID
+	if masterKeyChain.ActiveMasterKeyID() != "key2" {
+		t.Errorf("expected active key ID 'key2', got '%s'", masterKeyChain.ActiveMasterKeyID())
+	}
+
+	// Verify both keys are accessible
+	key1Obj, ok := masterKeyChain.Get("key1")
+	if !ok {
+		t.Error("expected to find key1 in master key chain")
+	}
+	if key1Obj == nil {
+		t.Error("expected non-nil key1")
+	}
+
+	key2Obj, ok := masterKeyChain.Get("key2")
+	if !ok {
+		t.Error("expected to find key2 in master key chain")
+	}
+	if key2Obj == nil {
+		t.Error("expected non-nil key2")
+	}
+}
+
+// TestContainerShutdownWithMasterKeyChain verifies that shutdown properly closes the master key chain.
+func TestContainerShutdownWithMasterKeyChain(t *testing.T) {
+	// Generate valid 32-byte key encoded in base64
+	key1 := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
+
+	// Set up environment variables for master keys
+	t.Setenv("MASTER_KEYS", "test-key-1:"+key1)
+	t.Setenv("ACTIVE_MASTER_KEY_ID", "test-key-1")
+
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	container := NewContainer(cfg)
+
+	// Initialize master key chain
+	masterKeyChain, err := container.MasterKeyChain()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if masterKeyChain == nil {
+		t.Fatal("expected non-nil master key chain")
+	}
+
+	// Shutdown should close the master key chain
 	if err := container.Shutdown(context.TODO()); err != nil {
 		t.Errorf("unexpected error during shutdown: %v", err)
 	}


### PR DESCRIPTION
Add create-kek and rotate-kek CLI commands to enable command-line management of Key Encryption Keys. This allows operators to initialize and rotate KEKs without requiring API calls, simplifying initial system setup and security operations.

Changes:
- Add create-kek command with --algorithm flag to create initial KEK during setup
- Add rotate-kek command with --algorithm flag for periodic key rotation
- Extend DI container with crypto layer dependencies (repositories, services, use cases)
- Add comprehensive README documentation with usage examples and best practices
- Implement singleton pattern for all crypto components in DI container
- Add master key chain initialization and cleanup in container lifecycle

The commands support both AES-GCM (default) and ChaCha20-Poly1305 encryption algorithms, and integrate with the existing master key chain from environment variables.