### PR TITLE
feat(cli): add create-master-key command and improve setup documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,10 @@ SERVER_PORT=8080
 # Logging
 LOG_LEVEL=info
 
-# Master keys
+# Master keys (Envelope Encryption)
+# Generate a new master key using: ./bin/app create-master-key
+# Each key must be exactly 32 bytes (256 bits), base64-encoded
+# Format: id1:base64key1,id2:base64key2 (comma-separated for multiple keys)
 MASTER_KEYS=default:bEu+O/9NOFAsWf1dhVB9aprmumKhhBcE6o7UPVmI43Y=
 ACTIVE_MASTER_KEY_ID=default
 


### PR DESCRIPTION
Add a new CLI command to generate cryptographically secure master keys and enhance documentation to guide users through the initial setup workflow.

Changes:
- Add create-master-key CLI command with optional --id flag
- Generate 32-byte keys using crypto/rand with automatic memory zeroing
- Output environment variables in copy-ready format for .env files
- Add comprehensive "Initial Setup Workflow" section to README
- Update installation instructions to use built-in key generation
- Document all available CLI commands with usage examples and purposes
- Enhance .env.example with detailed master key configuration comments
- Include security best practices for master key management

The new command simplifies onboarding by eliminating the need for external tools like OpenSSL and provides a secure, standardized way to generate master keys for envelope encryption.