### PR TITLE
feat(transit): add transit encryption module with key repository layer

### DIFF
--- a/internal/secrets/repository/postgresql_secret_repository_test.go
+++ b/internal/secrets/repository/postgresql_secret_repository_test.go
@@ -898,12 +898,130 @@ func TestPostgreSQLSecretRepository_GetByPath_WithDeletedSecret(t *testing.T) {
 	err = repo.Delete(ctx, secret.ID)
 	require.NoError(t, err)
 
-	// GetByPath should still return the secret (including deleted_at timestamp)
+	// GetByPath should return ErrNotFound for deleted secrets
 	retrievedSecret, err := repo.GetByPath(ctx, "/app/deleted-secret")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedSecret)
+	assert.ErrorIs(t, err, apperrors.ErrNotFound)
+}
+
+func TestPostgreSQLSecretRepository_GetByPath_MultipleVersions_LatestDeleted(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	path := "/app/versioned-secret"
+
+	// Create version 1
+	secret1 := &secretsDomain.Secret{
+		ID:         uuid.Must(uuid.NewV7()),
+		Path:       path,
+		Version:    1,
+		DekID:      dekID,
+		Ciphertext: []byte("encrypted-v1"),
+		Nonce:      []byte("nonce-v1"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	err := repo.Create(ctx, secret1)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	secret2 := &secretsDomain.Secret{
+		ID:         uuid.Must(uuid.NewV7()),
+		Path:       path,
+		Version:    2,
+		DekID:      dekID,
+		Ciphertext: []byte("encrypted-v2"),
+		Nonce:      []byte("nonce-v2"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	err = repo.Create(ctx, secret2)
+	require.NoError(t, err)
+
+	// Create version 3
+	time.Sleep(time.Millisecond)
+	secret3 := &secretsDomain.Secret{
+		ID:         uuid.Must(uuid.NewV7()),
+		Path:       path,
+		Version:    3,
+		DekID:      dekID,
+		Ciphertext: []byte("encrypted-v3"),
+		Nonce:      []byte("nonce-v3"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	err = repo.Create(ctx, secret3)
+	require.NoError(t, err)
+
+	// Delete version 3 (the latest)
+	err = repo.Delete(ctx, secret3.ID)
+	require.NoError(t, err)
+
+	// GetByPath should return version 2 (the latest non-deleted version)
+	retrievedSecret, err := repo.GetByPath(ctx, path)
 	require.NoError(t, err)
 	assert.NotNil(t, retrievedSecret)
-	assert.NotNil(t, retrievedSecret.DeletedAt)
-	assert.WithinDuration(t, time.Now().UTC(), *retrievedSecret.DeletedAt, 2*time.Second)
+	assert.Equal(t, secret2.ID, retrievedSecret.ID)
+	assert.Equal(t, uint(2), retrievedSecret.Version)
+	assert.Equal(t, []byte("encrypted-v2"), retrievedSecret.Ciphertext)
+	assert.Nil(t, retrievedSecret.DeletedAt, "returned secret should not be deleted")
+}
+
+func TestPostgreSQLSecretRepository_GetByPath_MultipleVersions_AllDeleted(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	path := "/app/all-deleted-secret"
+
+	// Create version 1
+	secret1 := &secretsDomain.Secret{
+		ID:         uuid.Must(uuid.NewV7()),
+		Path:       path,
+		Version:    1,
+		DekID:      dekID,
+		Ciphertext: []byte("encrypted-v1"),
+		Nonce:      []byte("nonce-v1"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	err := repo.Create(ctx, secret1)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	secret2 := &secretsDomain.Secret{
+		ID:         uuid.Must(uuid.NewV7()),
+		Path:       path,
+		Version:    2,
+		DekID:      dekID,
+		Ciphertext: []byte("encrypted-v2"),
+		Nonce:      []byte("nonce-v2"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	err = repo.Create(ctx, secret2)
+	require.NoError(t, err)
+
+	// Delete both versions
+	err = repo.Delete(ctx, secret1.ID)
+	require.NoError(t, err)
+	err = repo.Delete(ctx, secret2.ID)
+	require.NoError(t, err)
+
+	// GetByPath should return ErrNotFound when all versions are deleted
+	retrievedSecret, err := repo.GetByPath(ctx, path)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedSecret)
+	assert.ErrorIs(t, err, apperrors.ErrNotFound)
 }
 
 func TestPostgreSQLSecretRepository_GetByPath_WithTransaction(t *testing.T) {

--- a/internal/transit/domain/encrypted_blob.go
+++ b/internal/transit/domain/encrypted_blob.go
@@ -1,0 +1,101 @@
+package domain
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// EncryptedBlob represents an encrypted data blob in the transit encryption system.
+//
+// The blob contains the transit key name, version, and encrypted ciphertext.
+// It can be serialized to and deserialized from the format: "name:version:ciphertext-base64"
+//
+// Fields:
+//   - Name: The transit key name (e.g., "payment-encryption")
+//   - Version: The transit key version used for encryption
+//   - Ciphertext: The encrypted data as raw bytes
+type EncryptedBlob struct {
+	Name       string
+	Version    uint
+	Ciphertext []byte
+}
+
+// NewEncryptedBlob creates an EncryptedBlob from its string representation.
+//
+// The input string must be in the format: "name:version:ciphertext-base64"
+// where:
+//   - name: non-empty string identifying the transit key
+//   - version: non-negative integer (uint)
+//   - ciphertext-base64: base64-encoded encrypted data (can be empty)
+//
+// Parameters:
+//   - content: String in format "name:version:ciphertext-base64"
+//
+// Returns:
+//   - EncryptedBlob instance if parsing succeeds
+//   - ErrInvalidBlobFormat if the format is incorrect (not 3 colon-separated parts)
+//   - ErrEmptyBlobName if the name field is empty
+//   - ErrInvalidBlobVersion if the version cannot be parsed as uint
+//   - ErrInvalidBlobBase64 if the ciphertext is not valid base64
+//
+// Example:
+//
+//	blob, err := NewEncryptedBlob("payment-key:1:SGVsbG8gV29ybGQ=")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Name: %s, Version: %d\n", blob.Name, blob.Version)
+func NewEncryptedBlob(content string) (EncryptedBlob, error) {
+	// Split by ":" - expect exactly 3 parts: name:version:ciphertext
+	parts := strings.Split(content, ":")
+	if len(parts) != 3 {
+		return EncryptedBlob{}, fmt.Errorf(
+			"%w: expected format 'name:version:ciphertext', got %d parts",
+			ErrInvalidBlobFormat,
+			len(parts),
+		)
+	}
+
+	name := parts[0]
+	if name == "" {
+		return EncryptedBlob{}, ErrEmptyBlobName
+	}
+
+	// Parse version as uint
+	version, err := strconv.ParseUint(parts[1], 10, 0)
+	if err != nil {
+		return EncryptedBlob{}, fmt.Errorf("%w: %v", ErrInvalidBlobVersion, err)
+	}
+
+	// Decode base64 ciphertext
+	ciphertext, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return EncryptedBlob{}, fmt.Errorf("%w: %v", ErrInvalidBlobBase64, err)
+	}
+
+	return EncryptedBlob{
+		Name:       name,
+		Version:    uint(version),
+		Ciphertext: ciphertext,
+	}, nil
+}
+
+// String serializes the EncryptedBlob to its string representation.
+//
+// The output format is: "name:version:ciphertext-base64"
+//
+// This method provides round-trip serialization with NewEncryptedBlob:
+//
+//	original := EncryptedBlob{Name: "key", Version: 1, Ciphertext: []byte("data")}
+//	serialized := original.String()
+//	parsed, _ := NewEncryptedBlob(serialized)
+//	// parsed equals original
+//
+// Returns:
+//   - String representation in format "name:version:ciphertext-base64"
+func (eb EncryptedBlob) String() string {
+	encodedCiphertext := base64.StdEncoding.EncodeToString(eb.Ciphertext)
+	return fmt.Sprintf("%s:%d:%s", eb.Name, eb.Version, encodedCiphertext)
+}

--- a/internal/transit/domain/encrypted_blob_test.go
+++ b/internal/transit/domain/encrypted_blob_test.go
@@ -1,0 +1,384 @@
+package domain_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apperrors "github.com/allisson/secrets/internal/errors"
+	"github.com/allisson/secrets/internal/transit/domain"
+)
+
+func TestNewEncryptedBlob_Success(t *testing.T) {
+	t.Run("ValidInput_WithCiphertext", func(t *testing.T) {
+		// Arrange
+		plaintext := []byte("Hello, World!")
+		ciphertext := base64.StdEncoding.EncodeToString(plaintext)
+		input := "payment-key:1:" + ciphertext
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "payment-key", blob.Name)
+		assert.Equal(t, uint(1), blob.Version)
+		assert.Equal(t, plaintext, blob.Ciphertext)
+	})
+
+	t.Run("ValidInput_Version0", func(t *testing.T) {
+		// Arrange
+		input := "test-key:0:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "test-key", blob.Name)
+		assert.Equal(t, uint(0), blob.Version)
+		assert.Equal(t, []byte("test"), blob.Ciphertext)
+	})
+
+	t.Run("ValidInput_LargeVersion", func(t *testing.T) {
+		// Arrange
+		input := "key:999999:ZGF0YQ=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "key", blob.Name)
+		assert.Equal(t, uint(999999), blob.Version)
+		assert.Equal(t, []byte("data"), blob.Ciphertext)
+	})
+
+	t.Run("ValidInput_EmptyCiphertext", func(t *testing.T) {
+		// Arrange - empty string is valid base64
+		input := "my-key:5:"
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "my-key", blob.Name)
+		assert.Equal(t, uint(5), blob.Version)
+		assert.Empty(t, blob.Ciphertext)
+	})
+
+	t.Run("ValidInput_NameWithHyphens", func(t *testing.T) {
+		// Arrange
+		input := "payment-encryption-key:1:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "payment-encryption-key", blob.Name)
+	})
+
+	t.Run("ValidInput_NameWithUnderscores", func(t *testing.T) {
+		// Arrange
+		input := "payment_encryption_key:1:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "payment_encryption_key", blob.Name)
+	})
+
+	t.Run("ValidInput_NameWithNumbers", func(t *testing.T) {
+		// Arrange
+		input := "key123:42:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "key123", blob.Name)
+		assert.Equal(t, uint(42), blob.Version)
+	})
+
+	t.Run("ValidInput_ComplexBase64", func(t *testing.T) {
+		// Arrange - complex data with padding
+		data := []byte("This is a longer test message that will encode to a longer base64 string!")
+		ciphertext := base64.StdEncoding.EncodeToString(data)
+		input := "long-key:10:" + ciphertext
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "long-key", blob.Name)
+		assert.Equal(t, uint(10), blob.Version)
+		assert.Equal(t, data, blob.Ciphertext)
+	})
+}
+
+func TestNewEncryptedBlob_Errors(t *testing.T) {
+	t.Run("Error_EmptyString", func(t *testing.T) {
+		// Arrange
+		input := ""
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobFormat)
+		assert.ErrorIs(t, err, apperrors.ErrInvalidInput)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_OnePart", func(t *testing.T) {
+		// Arrange
+		input := "just-name"
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobFormat)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_TwoParts", func(t *testing.T) {
+		// Arrange
+		input := "name:1"
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobFormat)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_FourParts", func(t *testing.T) {
+		// Arrange
+		input := "name:1:data:extra"
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobFormat)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_EmptyName", func(t *testing.T) {
+		// Arrange
+		input := ":1:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrEmptyBlobName)
+		assert.ErrorIs(t, err, apperrors.ErrInvalidInput)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_InvalidVersion_NonNumeric", func(t *testing.T) {
+		// Arrange
+		input := "key:abc:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobVersion)
+		assert.ErrorIs(t, err, apperrors.ErrInvalidInput)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_InvalidVersion_Negative", func(t *testing.T) {
+		// Arrange
+		input := "key:-1:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobVersion)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_InvalidVersion_Float", func(t *testing.T) {
+		// Arrange
+		input := "key:1.5:dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobVersion)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_InvalidBase64_InvalidCharacters", func(t *testing.T) {
+		// Arrange
+		input := "key:1:not-valid-base64!!!"
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobBase64)
+		assert.ErrorIs(t, err, apperrors.ErrInvalidInput)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_InvalidBase64_IncorrectPadding", func(t *testing.T) {
+		// Arrange
+		input := "key:1:dGVzd==="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobBase64)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+
+	t.Run("Error_VersionWithSpaces", func(t *testing.T) {
+		// Arrange
+		input := "key: 1 :dGVzdA=="
+
+		// Act
+		blob, err := domain.NewEncryptedBlob(input)
+
+		// Assert
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrInvalidBlobVersion)
+		assert.Equal(t, domain.EncryptedBlob{}, blob)
+	})
+}
+
+func TestEncryptedBlob_String(t *testing.T) {
+	t.Run("Success_SerializesCorrectly", func(t *testing.T) {
+		// Arrange
+		plaintext := []byte("Hello, World!")
+		blob := domain.EncryptedBlob{
+			Name:       "test-key",
+			Version:    42,
+			Ciphertext: plaintext,
+		}
+		expected := "test-key:42:" + base64.StdEncoding.EncodeToString(plaintext)
+
+		// Act
+		result := blob.String()
+
+		// Assert
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("Success_EmptyCiphertext", func(t *testing.T) {
+		// Arrange
+		blob := domain.EncryptedBlob{
+			Name:       "empty-key",
+			Version:    1,
+			Ciphertext: []byte{},
+		}
+		expected := "empty-key:1:"
+
+		// Act
+		result := blob.String()
+
+		// Assert
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("Success_Version0", func(t *testing.T) {
+		// Arrange
+		blob := domain.EncryptedBlob{
+			Name:       "v0-key",
+			Version:    0,
+			Ciphertext: []byte("data"),
+		}
+
+		// Act
+		result := blob.String()
+
+		// Assert
+		assert.Contains(t, result, "v0-key:0:")
+	})
+
+	t.Run("Success_RoundTrip", func(t *testing.T) {
+		// Arrange
+		original := domain.EncryptedBlob{
+			Name:       "round-trip-key",
+			Version:    123,
+			Ciphertext: []byte("This is test data for round trip!"),
+		}
+
+		// Act
+		serialized := original.String()
+		parsed, err := domain.NewEncryptedBlob(serialized)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, original.Name, parsed.Name)
+		assert.Equal(t, original.Version, parsed.Version)
+		assert.Equal(t, original.Ciphertext, parsed.Ciphertext)
+	})
+
+	t.Run("Success_RoundTrip_MultipleIterations", func(t *testing.T) {
+		// Arrange
+		original := domain.EncryptedBlob{
+			Name:       "multi-key",
+			Version:    5,
+			Ciphertext: []byte("test data"),
+		}
+
+		// Act - serialize and parse multiple times
+		current := original
+		for i := 0; i < 5; i++ {
+			serialized := current.String()
+			parsed, err := domain.NewEncryptedBlob(serialized)
+			require.NoError(t, err)
+			current = parsed
+		}
+
+		// Assert - should still equal original
+		assert.Equal(t, original.Name, current.Name)
+		assert.Equal(t, original.Version, current.Version)
+		assert.Equal(t, original.Ciphertext, current.Ciphertext)
+	})
+
+	t.Run("Success_ComplexData", func(t *testing.T) {
+		// Arrange - binary data with various byte values
+		complexData := []byte{0x00, 0x01, 0xFF, 0xAB, 0xCD, 0xEF}
+		blob := domain.EncryptedBlob{
+			Name:       "binary-key",
+			Version:    99,
+			Ciphertext: complexData,
+		}
+
+		// Act
+		serialized := blob.String()
+		parsed, err := domain.NewEncryptedBlob(serialized)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, complexData, parsed.Ciphertext)
+	})
+}

--- a/internal/transit/domain/errors.go
+++ b/internal/transit/domain/errors.go
@@ -1,0 +1,50 @@
+// Package domain defines the transit encryption domain models and types.
+package domain
+
+import (
+	"github.com/allisson/secrets/internal/errors"
+)
+
+// Transit encryption error definitions.
+//
+// These domain-specific errors wrap standard errors from internal/errors
+// to provide context for transit encryption failures.
+var (
+	// ErrInvalidBlobFormat indicates the encrypted blob format is invalid.
+	//
+	// The expected format is: "name:version:ciphertext-base64"
+	// This error is returned when the input string doesn't have exactly 3 parts
+	// separated by colons.
+	//
+	// HTTP Status: 422 Unprocessable Entity
+	ErrInvalidBlobFormat = errors.Wrap(errors.ErrInvalidInput, "invalid encrypted blob format")
+
+	// ErrEmptyBlobName indicates the encrypted blob name is empty.
+	//
+	// The name field must be a non-empty string to identify the transit key.
+	//
+	// HTTP Status: 422 Unprocessable Entity
+	ErrEmptyBlobName = errors.Wrap(errors.ErrInvalidInput, "encrypted blob name cannot be empty")
+
+	// ErrInvalidBlobVersion indicates the version string cannot be parsed.
+	//
+	// The version must be a valid non-negative integer that fits in a uint.
+	//
+	// HTTP Status: 422 Unprocessable Entity
+	ErrInvalidBlobVersion = errors.Wrap(errors.ErrInvalidInput, "invalid encrypted blob version")
+
+	// ErrInvalidBlobBase64 indicates the ciphertext is not valid base64.
+	//
+	// The ciphertext must be a valid base64-encoded string using standard encoding.
+	//
+	// HTTP Status: 422 Unprocessable Entity
+	ErrInvalidBlobBase64 = errors.Wrap(errors.ErrInvalidInput, "invalid encrypted blob base64")
+
+	// ErrTransitKeyNotFound indicates the transit key was not found.
+	//
+	// This error is returned when attempting to retrieve a transit key by name
+	// that either doesn't exist or has been soft-deleted.
+	//
+	// HTTP Status: 404 Not Found
+	ErrTransitKeyNotFound = errors.Wrap(errors.ErrNotFound, "transit key not found")
+)

--- a/internal/transit/domain/transit_key.go
+++ b/internal/transit/domain/transit_key.go
@@ -1,0 +1,16 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type TransitKey struct {
+	ID        uuid.UUID
+	Name      string
+	Version   uint
+	DekID     uuid.UUID
+	CreatedAt time.Time
+	DeletedAt *time.Time
+}

--- a/internal/transit/repository/mysql_transit_key_repository.go
+++ b/internal/transit/repository/mysql_transit_key_repository.go
@@ -1,0 +1,245 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+// MySQLTransitKeyRepository implements transit key persistence for MySQL databases.
+//
+// This repository handles storing and retrieving transit encryption keys using
+// MySQL's BINARY(16) for UUID storage and DATETIME for date fields. UUIDs are
+// marshaled/unmarshaled to/from binary format using uuid.MarshalBinary() and
+// uuid.UnmarshalBinary(). It supports transaction-aware operations via
+// database.GetTx(), enabling atomic operations across multiple transit key
+// modifications.
+//
+// Database schema requirements:
+//   - id: BINARY(16) PRIMARY KEY (UUID in binary format)
+//   - name: VARCHAR(255) (unique with version, identifies the key)
+//   - version: INTEGER (for tracking key versions during rotation)
+//   - dek_id: BINARY(16) (reference to the data encryption key)
+//   - created_at: DATETIME/TIMESTAMP
+//   - deleted_at: DATETIME/TIMESTAMP (nullable, for soft deletion)
+//   - UNIQUE KEY on (name, version)
+//
+// UUID handling:
+//
+//	MySQL doesn't have a native UUID type, so UUIDs are stored as BINARY(16).
+//	The repository handles marshaling/unmarshaling automatically using
+//	uuid.MarshalBinary() and uuid.UnmarshalBinary() methods.
+//
+// Soft deletion:
+//
+//	Transit keys are soft-deleted by setting the deleted_at timestamp.
+//	Queries automatically filter out soft-deleted records.
+//
+// Transaction support:
+//
+//	The repository automatically detects transaction context using database.GetTx().
+//	All methods work both within and outside of transactions seamlessly.
+//
+// Example usage:
+//
+//	repo := NewMySQLTransitKeyRepository(db)
+//
+//	// Create a transit key outside transaction
+//	err := repo.Create(ctx, transitKey)
+//
+//	// Or within a transaction
+//	err = txManager.WithTx(ctx, func(txCtx context.Context) error {
+//	    // Both operations use the same transaction
+//	    if err := repo.Create(txCtx, transitKey1); err != nil {
+//	        return err
+//	    }
+//	    return repo.Create(txCtx, transitKey2)
+//	})
+type MySQLTransitKeyRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new transit key into the MySQL database.
+//
+// The transit key's ID and DekID are marshaled to BINARY(16) format using
+// uuid.MarshalBinary(). This method supports transaction context via
+// database.GetTx(), enabling atomic multi-step operations.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - transitKey: The transit key to insert (must have all required fields populated)
+//
+// Returns:
+//   - An error if marshaling the UUID fails or the insert fails
+//
+// Example:
+//
+//	transitKey := &transitDomain.TransitKey{
+//	    ID:        uuid.Must(uuid.NewV7()),
+//	    Name:      "payment-encryption",
+//	    Version:   1,
+//	    DekID:     dekID,
+//	    CreatedAt: time.Now().UTC(),
+//	}
+//	err := repo.Create(ctx, transitKey)
+func (m *MySQLTransitKeyRepository) Create(ctx context.Context, transitKey *transitDomain.TransitKey) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `INSERT INTO transit_keys (id, name, version, dek_id, created_at, deleted_at) 
+			  VALUES (?, ?, ?, ?, ?, ?)`
+
+	id, err := transitKey.ID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal transit key id")
+	}
+
+	dekID, err := transitKey.DekID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal dek id")
+	}
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		id,
+		transitKey.Name,
+		transitKey.Version,
+		dekID,
+		transitKey.CreatedAt,
+		transitKey.DeletedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create transit key")
+	}
+	return nil
+}
+
+// Delete soft-deletes a transit key by setting its deleted_at timestamp.
+//
+// This method performs a soft delete by updating the deleted_at field to the
+// current timestamp. The transit key ID is marshaled to BINARY(16) format for
+// the WHERE clause using uuid.MarshalBinary(). The transit key remains in the
+// database but is filtered out from GetByName queries.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - transitKeyID: The UUID of the transit key to soft-delete
+//
+// Returns:
+//   - An error if marshaling the UUID fails or the update fails
+//
+// Example:
+//
+//	// Soft delete a transit key
+//	err := repo.Delete(ctx, transitKeyID)
+func (m *MySQLTransitKeyRepository) Delete(ctx context.Context, transitKeyID uuid.UUID) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `UPDATE transit_keys SET deleted_at = NOW() WHERE id = ?`
+
+	id, err := transitKeyID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal transit key id")
+	}
+
+	_, err = querier.ExecContext(ctx, query, id)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to delete transit key")
+	}
+
+	return nil
+}
+
+// GetByName retrieves the latest non-deleted version of a transit key by name.
+//
+// This method returns the transit key with the highest version number for the
+// given name, excluding any soft-deleted keys (where deleted_at IS NOT NULL).
+// Transit key IDs are automatically unmarshaled from BINARY(16) to uuid.UUID
+// using uuid.UnmarshalBinary(). This ensures clients always use the most recent
+// active version of a key.
+//
+// The method supports transaction context via database.GetTx(), allowing
+// consistent reads within a transaction.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - name: The name of the transit key to retrieve
+//
+// Returns:
+//   - A pointer to the transit key with the highest version number
+//   - transitDomain.ErrTransitKeyNotFound if no matching key exists or all versions are deleted
+//   - An error if the query fails or UUID unmarshaling fails
+//
+// Example:
+//
+//	// Get the latest version of a transit key
+//	transitKey, err := repo.GetByName(ctx, "payment-encryption")
+//	if errors.Is(err, transitDomain.ErrTransitKeyNotFound) {
+//	    // Handle key not found
+//	}
+func (m *MySQLTransitKeyRepository) GetByName(
+	ctx context.Context,
+	name string,
+) (*transitDomain.TransitKey, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, name, version, dek_id, created_at, deleted_at 
+			  FROM transit_keys 
+			  WHERE name = ? AND deleted_at IS NULL 
+			  ORDER BY version DESC 
+			  LIMIT 1`
+
+	var transitKey transitDomain.TransitKey
+	var id []byte
+	var dekID []byte
+
+	err := querier.QueryRowContext(ctx, query, name).Scan(
+		&id,
+		&transitKey.Name,
+		&transitKey.Version,
+		&dekID,
+		&transitKey.CreatedAt,
+		&transitKey.DeletedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, transitDomain.ErrTransitKeyNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get transit key by name")
+	}
+
+	if err := transitKey.ID.UnmarshalBinary(id); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal transit key id")
+	}
+
+	if err := transitKey.DekID.UnmarshalBinary(dekID); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal dek id")
+	}
+
+	return &transitKey, nil
+}
+
+// NewMySQLTransitKeyRepository creates a new MySQL transit key repository instance.
+//
+// Parameters:
+//   - db: A MySQL database connection
+//
+// Returns:
+//   - A new MySQLTransitKeyRepository ready for use
+//
+// Example:
+//
+//	db, err := sql.Open("mysql", dsn)
+//	if err != nil {
+//	    return nil, err
+//	}
+//	repo := NewMySQLTransitKeyRepository(db)
+func NewMySQLTransitKeyRepository(db *sql.DB) *MySQLTransitKeyRepository {
+	return &MySQLTransitKeyRepository{db: db}
+}

--- a/internal/transit/repository/mysql_transit_key_repository_test.go
+++ b/internal/transit/repository/mysql_transit_key_repository_test.go
@@ -1,0 +1,574 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	cryptoRepository "github.com/allisson/secrets/internal/crypto/repository"
+	"github.com/allisson/secrets/internal/testutil"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+func TestNewMySQLTransitKeyRepository(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &MySQLTransitKeyRepository{}, repo)
+}
+
+func TestMySQLTransitKeyRepository_Create(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	// Create prerequisite KEK and DEK
+	dekID := createTestDekMySQL(t, db)
+
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "payment-encryption",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Verify the transit key was created by reading it back
+	var readKey transitDomain.TransitKey
+	var id, dekIDBytes []byte
+	query := `SELECT id, name, version, dek_id, created_at, deleted_at FROM transit_keys WHERE id = ?`
+
+	transitKeyIDBytes, err := transitKey.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx, query, transitKeyIDBytes).Scan(
+		&id,
+		&readKey.Name,
+		&readKey.Version,
+		&dekIDBytes,
+		&readKey.CreatedAt,
+		&readKey.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	err = readKey.ID.UnmarshalBinary(id)
+	require.NoError(t, err)
+	err = readKey.DekID.UnmarshalBinary(dekIDBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, transitKey.ID, readKey.ID)
+	assert.Equal(t, transitKey.Name, readKey.Name)
+	assert.Equal(t, transitKey.Version, readKey.Version)
+	assert.Equal(t, transitKey.DekID, readKey.DekID)
+	assert.WithinDuration(t, transitKey.CreatedAt, readKey.CreatedAt, time.Second)
+	assert.Nil(t, readKey.DeletedAt)
+}
+
+func TestMySQLTransitKeyRepository_Create_MultipleVersions(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create version 1
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "api-encryption",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "api-encryption",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key2)
+	require.NoError(t, err)
+
+	// Create version 3
+	time.Sleep(time.Millisecond)
+	key3 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "api-encryption",
+		Version:   3,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key3)
+	require.NoError(t, err)
+
+	// Verify all three versions exist
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM transit_keys WHERE name = ?`, "api-encryption").
+		Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestMySQLTransitKeyRepository_Delete(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create a transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "test-key",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Delete the transit key (soft delete)
+	err = repo.Delete(ctx, transitKey.ID)
+	require.NoError(t, err)
+
+	// Verify the key still exists but has deleted_at set
+	var deletedAt *time.Time
+	transitKeyIDBytes, err := transitKey.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	query := `SELECT deleted_at FROM transit_keys WHERE id = ?`
+	err = db.QueryRowContext(ctx, query, transitKeyIDBytes).Scan(&deletedAt)
+	require.NoError(t, err)
+	assert.NotNil(t, deletedAt, "deleted_at should be set after soft delete")
+}
+
+func TestMySQLTransitKeyRepository_GetByName_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create a transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "user-data-encryption",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Retrieve the key by name
+	retrievedKey, err := repo.GetByName(ctx, "user-data-encryption")
+	require.NoError(t, err)
+	require.NotNil(t, retrievedKey)
+
+	assert.Equal(t, transitKey.ID, retrievedKey.ID)
+	assert.Equal(t, transitKey.Name, retrievedKey.Name)
+	assert.Equal(t, transitKey.Version, retrievedKey.Version)
+	assert.Equal(t, transitKey.DekID, retrievedKey.DekID)
+	assert.WithinDuration(t, transitKey.CreatedAt, retrievedKey.CreatedAt, time.Second)
+}
+
+func TestMySQLTransitKeyRepository_GetByName_LatestVersion(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create version 1
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "multi-version-key",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Create version 3 (out of order)
+	time.Sleep(time.Millisecond)
+	key3 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "multi-version-key",
+		Version:   3,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key3)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "multi-version-key",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key2)
+	require.NoError(t, err)
+
+	// GetByName should return version 3 (highest version)
+	retrievedKey, err := repo.GetByName(ctx, "multi-version-key")
+	require.NoError(t, err)
+	require.NotNil(t, retrievedKey)
+
+	assert.Equal(t, uint(3), retrievedKey.Version)
+	assert.Equal(t, key3.ID, retrievedKey.ID)
+}
+
+func TestMySQLTransitKeyRepository_GetByName_NotFound(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent key
+	retrievedKey, err := repo.GetByName(ctx, "non-existent-key")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedKey)
+	assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
+}
+
+func TestMySQLTransitKeyRepository_GetByName_IgnoresDeletedKeys(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create version 1
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "deleted-key-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "deleted-key-test",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key2)
+	require.NoError(t, err)
+
+	// Delete version 2 (the latest)
+	err = repo.Delete(ctx, key2.ID)
+	require.NoError(t, err)
+
+	// GetByName should return version 1 (since version 2 is deleted)
+	retrievedKey, err := repo.GetByName(ctx, "deleted-key-test")
+	require.NoError(t, err)
+	require.NotNil(t, retrievedKey)
+
+	assert.Equal(t, uint(1), retrievedKey.Version)
+	assert.Equal(t, key1.ID, retrievedKey.ID)
+}
+
+func TestMySQLTransitKeyRepository_GetByName_AllVersionsDeleted(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create a transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "all-deleted-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Delete the key
+	err = repo.Delete(ctx, transitKey.ID)
+	require.NoError(t, err)
+
+	// GetByName should return not found error
+	retrievedKey, err := repo.GetByName(ctx, "all-deleted-test")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedKey)
+	assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
+}
+
+func TestMySQLTransitKeyRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-test-key",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Marshal UUIDs
+	id, err := transitKey.ID.MarshalBinary()
+	require.NoError(t, err)
+	dekIDBytes, err := transitKey.DekID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Create transit key within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO transit_keys (id, name, version, dek_id, created_at, deleted_at) 
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id,
+		transitKey.Name,
+		transitKey.Version,
+		dekIDBytes,
+		transitKey.CreatedAt,
+		transitKey.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the transit key was not created (rollback worked)
+	retrievedKey, err := repo.GetByName(ctx, "tx-test-key")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedKey)
+	assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
+}
+
+func TestMySQLTransitKeyRepository_Delete_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create initial transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-delete-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Marshal UUID
+	id, err := transitKey.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Delete within transaction
+	_, err = tx.ExecContext(ctx, `UPDATE transit_keys SET deleted_at = NOW() WHERE id = ?`, id)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the transit key was not deleted (rollback worked)
+	retrievedKey, err := repo.GetByName(ctx, "tx-delete-test")
+	require.NoError(t, err)
+	assert.NotNil(t, retrievedKey)
+	assert.Equal(t, transitKey.ID, retrievedKey.ID)
+}
+
+func TestMySQLTransitKeyRepository_GetByName_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDekMySQL(t, db)
+
+	// Create a transit key outside transaction
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-read-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another version inside transaction
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-read-test",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Marshal UUIDs
+	id, err := key2.ID.MarshalBinary()
+	require.NoError(t, err)
+	dekIDBytes, err := key2.DekID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO transit_keys (id, name, version, dek_id, created_at, deleted_at) 
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id,
+		key2.Name,
+		key2.Version,
+		dekIDBytes,
+		key2.CreatedAt,
+		key2.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see version 2
+	var retrievedKey transitDomain.TransitKey
+	var idBytes, dekIDResult []byte
+	err = tx.QueryRowContext(
+		ctx,
+		`SELECT id, name, version, dek_id, created_at, deleted_at 
+		 FROM transit_keys 
+		 WHERE name = ? AND deleted_at IS NULL 
+		 ORDER BY version DESC 
+		 LIMIT 1`,
+		"tx-read-test",
+	).Scan(
+		&idBytes,
+		&retrievedKey.Name,
+		&retrievedKey.Version,
+		&dekIDResult,
+		&retrievedKey.CreatedAt,
+		&retrievedKey.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	err = retrievedKey.ID.UnmarshalBinary(idBytes)
+	require.NoError(t, err)
+	err = retrievedKey.DekID.UnmarshalBinary(dekIDResult)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint(2), retrievedKey.Version)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query outside transaction should also see version 2
+	retrievedKey2, err := repo.GetByName(ctx, "tx-read-test")
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), retrievedKey2.Version)
+}
+
+// createTestDekMySQL creates a KEK and DEK for testing transit keys with MySQL.
+func createTestDekMySQL(t *testing.T, db *sql.DB) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	// Create KEK
+	kekID := uuid.Must(uuid.NewV7())
+	kekRepo := cryptoRepository.NewMySQLKekRepository(db)
+	kek := &cryptoDomain.Kek{
+		ID:           kekID,
+		MasterKeyID:  "master-key-test",
+		Algorithm:    cryptoDomain.AESGCM,
+		EncryptedKey: []byte("encrypted-kek-data"),
+		Nonce:        []byte("kek-nonce"),
+		Version:      1,
+		CreatedAt:    time.Now().UTC(),
+	}
+	err := kekRepo.Create(ctx, kek)
+	require.NoError(t, err)
+
+	// Create DEK
+	dekID := uuid.Must(uuid.NewV7())
+	dekRepo := cryptoRepository.NewMySQLDekRepository(db)
+	dek := &cryptoDomain.Dek{
+		ID:           dekID,
+		KekID:        kekID,
+		Algorithm:    cryptoDomain.AESGCM,
+		EncryptedKey: []byte("encrypted-dek-data"),
+		Nonce:        []byte("dek-nonce"),
+		CreatedAt:    time.Now().UTC(),
+	}
+	err = dekRepo.Create(ctx, dek)
+	require.NoError(t, err)
+
+	return dekID
+}

--- a/internal/transit/repository/postgresql_transit_key_repository.go
+++ b/internal/transit/repository/postgresql_transit_key_repository.go
@@ -1,0 +1,259 @@
+// Package repository implements data persistence for transit encryption key management.
+//
+// This package provides repository implementations for storing and retrieving
+// transit encryption keys in PostgreSQL and MySQL databases. Transit keys enable
+// cryptographic operations (encrypt/decrypt) without exposing the actual key material
+// to clients. Repositories follow the Repository pattern and support both direct
+// database operations and transactional operations.
+//
+// # Key Components
+//
+// The package includes repositories for:
+//   - TransitKey: Versioned encryption keys for transit encryption operations
+//
+// # Database Support
+//
+// Each repository type has two implementations:
+//   - PostgreSQL: Uses native UUID type and BYTEA for binary data
+//   - MySQL: Uses BINARY(16) for UUIDs and BLOB for binary data
+//
+// # Transaction Support
+//
+// All repositories support transaction-aware operations via database.GetTx(),
+// enabling atomic multi-step operations. When called within a transaction context,
+// repositories automatically use the transaction connection.
+//
+// # Transit Key Versioning
+//
+// Transit keys support versioning to enable key rotation without breaking existing
+// encrypted data. Multiple versions of a key with the same name can coexist, but
+// only the latest (highest version number) is returned by GetByName.
+//
+// # Soft Deletion
+//
+// Transit keys use soft deletion via the deleted_at timestamp. Deleted keys remain
+// in the database but are filtered out from queries, allowing historical audit and
+// recovery while preventing accidental reuse.
+//
+// # Usage Example
+//
+//	// Create transit key repository
+//	transitKeyRepo := repository.NewPostgreSQLTransitKeyRepository(db)
+//
+//	// Use within a transaction
+//	txManager := database.NewTxManager(db)
+//	err := txManager.WithTx(ctx, func(txCtx context.Context) error {
+//	    return transitKeyRepo.Create(txCtx, transitKey)
+//	})
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+// PostgreSQLTransitKeyRepository implements transit key persistence for PostgreSQL databases.
+//
+// This repository handles storing and retrieving transit encryption keys using
+// PostgreSQL's native UUID type and timestamp with timezone for date fields.
+// It supports transaction-aware operations via database.GetTx(), enabling atomic
+// operations across multiple transit key modifications.
+//
+// Database schema requirements:
+//   - id: UUID PRIMARY KEY
+//   - name: TEXT (unique with version, identifies the key)
+//   - version: INTEGER (for tracking key versions during rotation)
+//   - dek_id: UUID (reference to the data encryption key)
+//   - created_at: TIMESTAMP WITH TIME ZONE
+//   - deleted_at: TIMESTAMP WITH TIME ZONE (nullable, for soft deletion)
+//   - UNIQUE constraint on (name, version)
+//
+// Soft deletion:
+//
+//	Transit keys are soft-deleted by setting the deleted_at timestamp.
+//	Queries automatically filter out soft-deleted records.
+//
+// Transaction support:
+//
+//	The repository automatically detects transaction context using database.GetTx().
+//	All methods work both within and outside of transactions seamlessly.
+//
+// Example usage:
+//
+//	repo := NewPostgreSQLTransitKeyRepository(db)
+//
+//	// Create a transit key outside transaction
+//	err := repo.Create(ctx, transitKey)
+//
+//	// Or within a transaction
+//	err = txManager.WithTx(ctx, func(txCtx context.Context) error {
+//	    // Both operations use the same transaction
+//	    if err := repo.Create(txCtx, transitKey1); err != nil {
+//	        return err
+//	    }
+//	    return repo.Create(txCtx, transitKey2)
+//	})
+type PostgreSQLTransitKeyRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new transit key into the PostgreSQL database.
+//
+// The transit key's ID and DekID are stored as native UUIDs, and timestamps
+// use TIMESTAMPTZ. This method supports transaction context via database.GetTx(),
+// enabling atomic multi-step operations.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - transitKey: The transit key to insert (must have all required fields populated)
+//
+// Returns:
+//   - An error if the insert fails (e.g., duplicate key, constraint violation)
+//
+// Example:
+//
+//	transitKey := &transitDomain.TransitKey{
+//	    ID:        uuid.Must(uuid.NewV7()),
+//	    Name:      "payment-encryption",
+//	    Version:   1,
+//	    DekID:     dekID,
+//	    CreatedAt: time.Now().UTC(),
+//	}
+//	err := repo.Create(ctx, transitKey)
+func (p *PostgreSQLTransitKeyRepository) Create(
+	ctx context.Context,
+	transitKey *transitDomain.TransitKey,
+) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `INSERT INTO transit_keys (id, name, version, dek_id, created_at, deleted_at) 
+			  VALUES ($1, $2, $3, $4, $5, $6)`
+
+	_, err := querier.ExecContext(
+		ctx,
+		query,
+		transitKey.ID,
+		transitKey.Name,
+		transitKey.Version,
+		transitKey.DekID,
+		transitKey.CreatedAt,
+		transitKey.DeletedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create transit key")
+	}
+	return nil
+}
+
+// Delete soft-deletes a transit key by setting its deleted_at timestamp.
+//
+// This method performs a soft delete by updating the deleted_at field to the
+// current timestamp. The transit key remains in the database but is filtered
+// out from GetByName queries. This approach preserves historical data while
+// preventing the key from being used for new operations.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - transitKeyID: The UUID of the transit key to soft-delete
+//
+// Returns:
+//   - An error if the update fails
+//
+// Example:
+//
+//	// Soft delete a transit key
+//	err := repo.Delete(ctx, transitKeyID)
+func (p *PostgreSQLTransitKeyRepository) Delete(ctx context.Context, transitKeyID uuid.UUID) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `UPDATE transit_keys SET deleted_at = NOW() WHERE id = $1`
+
+	_, err := querier.ExecContext(ctx, query, transitKeyID)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to delete transit key")
+	}
+
+	return nil
+}
+
+// GetByName retrieves the latest non-deleted version of a transit key by name.
+//
+// This method returns the transit key with the highest version number for the
+// given name, excluding any soft-deleted keys (where deleted_at IS NOT NULL).
+// This ensures clients always use the most recent active version of a key.
+//
+// The method supports transaction context via database.GetTx(), allowing
+// consistent reads within a transaction.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - name: The name of the transit key to retrieve
+//
+// Returns:
+//   - A pointer to the transit key with the highest version number
+//   - transitDomain.ErrTransitKeyNotFound if no matching key exists or all versions are deleted
+//   - An error if the query fails
+//
+// Example:
+//
+//	// Get the latest version of a transit key
+//	transitKey, err := repo.GetByName(ctx, "payment-encryption")
+//	if errors.Is(err, transitDomain.ErrTransitKeyNotFound) {
+//	    // Handle key not found
+//	}
+func (p *PostgreSQLTransitKeyRepository) GetByName(
+	ctx context.Context,
+	name string,
+) (*transitDomain.TransitKey, error) {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `SELECT id, name, version, dek_id, created_at, deleted_at 
+			  FROM transit_keys 
+			  WHERE name = $1 AND deleted_at IS NULL 
+			  ORDER BY version DESC 
+			  LIMIT 1`
+
+	var transitKey transitDomain.TransitKey
+	err := querier.QueryRowContext(ctx, query, name).Scan(
+		&transitKey.ID,
+		&transitKey.Name,
+		&transitKey.Version,
+		&transitKey.DekID,
+		&transitKey.CreatedAt,
+		&transitKey.DeletedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, transitDomain.ErrTransitKeyNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get transit key by name")
+	}
+
+	return &transitKey, nil
+}
+
+// NewPostgreSQLTransitKeyRepository creates a new PostgreSQL transit key repository instance.
+//
+// Parameters:
+//   - db: A PostgreSQL database connection
+//
+// Returns:
+//   - A new PostgreSQLTransitKeyRepository ready for use
+//
+// Example:
+//
+//	db, err := sql.Open("postgres", dsn)
+//	if err != nil {
+//	    return nil, err
+//	}
+//	repo := NewPostgreSQLTransitKeyRepository(db)
+func NewPostgreSQLTransitKeyRepository(db *sql.DB) *PostgreSQLTransitKeyRepository {
+	return &PostgreSQLTransitKeyRepository{db: db}
+}

--- a/internal/transit/repository/postgresql_transit_key_repository_test.go
+++ b/internal/transit/repository/postgresql_transit_key_repository_test.go
@@ -1,0 +1,537 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	cryptoRepository "github.com/allisson/secrets/internal/crypto/repository"
+	"github.com/allisson/secrets/internal/testutil"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+func TestNewPostgreSQLTransitKeyRepository(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &PostgreSQLTransitKeyRepository{}, repo)
+}
+
+func TestPostgreSQLTransitKeyRepository_Create(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	// Create prerequisite KEK and DEK
+	dekID := createTestDek(t, db)
+
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "payment-encryption",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Verify the transit key was created by reading it back
+	var readKey transitDomain.TransitKey
+	query := `SELECT id, name, version, dek_id, created_at, deleted_at FROM transit_keys WHERE id = $1`
+	err = db.QueryRowContext(ctx, query, transitKey.ID).Scan(
+		&readKey.ID,
+		&readKey.Name,
+		&readKey.Version,
+		&readKey.DekID,
+		&readKey.CreatedAt,
+		&readKey.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, transitKey.ID, readKey.ID)
+	assert.Equal(t, transitKey.Name, readKey.Name)
+	assert.Equal(t, transitKey.Version, readKey.Version)
+	assert.Equal(t, transitKey.DekID, readKey.DekID)
+	assert.WithinDuration(t, transitKey.CreatedAt, readKey.CreatedAt, time.Second)
+	assert.Nil(t, readKey.DeletedAt)
+}
+
+func TestPostgreSQLTransitKeyRepository_Create_MultipleVersions(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create version 1
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "api-encryption",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "api-encryption",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key2)
+	require.NoError(t, err)
+
+	// Create version 3
+	time.Sleep(time.Millisecond)
+	key3 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "api-encryption",
+		Version:   3,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key3)
+	require.NoError(t, err)
+
+	// Verify all three versions exist
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM transit_keys WHERE name = $1`, "api-encryption").
+		Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestPostgreSQLTransitKeyRepository_Delete(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create a transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "test-key",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Delete the transit key (soft delete)
+	err = repo.Delete(ctx, transitKey.ID)
+	require.NoError(t, err)
+
+	// Verify the key still exists but has deleted_at set
+	var deletedAt *time.Time
+	query := `SELECT deleted_at FROM transit_keys WHERE id = $1`
+	err = db.QueryRowContext(ctx, query, transitKey.ID).Scan(&deletedAt)
+	require.NoError(t, err)
+	assert.NotNil(t, deletedAt, "deleted_at should be set after soft delete")
+}
+
+func TestPostgreSQLTransitKeyRepository_GetByName_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create a transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "user-data-encryption",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Retrieve the key by name
+	retrievedKey, err := repo.GetByName(ctx, "user-data-encryption")
+	require.NoError(t, err)
+	require.NotNil(t, retrievedKey)
+
+	assert.Equal(t, transitKey.ID, retrievedKey.ID)
+	assert.Equal(t, transitKey.Name, retrievedKey.Name)
+	assert.Equal(t, transitKey.Version, retrievedKey.Version)
+	assert.Equal(t, transitKey.DekID, retrievedKey.DekID)
+	assert.WithinDuration(t, transitKey.CreatedAt, retrievedKey.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLTransitKeyRepository_GetByName_LatestVersion(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create version 1
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "multi-version-key",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Create version 3 (out of order)
+	time.Sleep(time.Millisecond)
+	key3 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "multi-version-key",
+		Version:   3,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key3)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "multi-version-key",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key2)
+	require.NoError(t, err)
+
+	// GetByName should return version 3 (highest version)
+	retrievedKey, err := repo.GetByName(ctx, "multi-version-key")
+	require.NoError(t, err)
+	require.NotNil(t, retrievedKey)
+
+	assert.Equal(t, uint(3), retrievedKey.Version)
+	assert.Equal(t, key3.ID, retrievedKey.ID)
+}
+
+func TestPostgreSQLTransitKeyRepository_GetByName_NotFound(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent key
+	retrievedKey, err := repo.GetByName(ctx, "non-existent-key")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedKey)
+	assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
+}
+
+func TestPostgreSQLTransitKeyRepository_GetByName_IgnoresDeletedKeys(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create version 1
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "deleted-key-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Create version 2
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "deleted-key-test",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err = repo.Create(ctx, key2)
+	require.NoError(t, err)
+
+	// Delete version 2 (the latest)
+	err = repo.Delete(ctx, key2.ID)
+	require.NoError(t, err)
+
+	// GetByName should return version 1 (since version 2 is deleted)
+	retrievedKey, err := repo.GetByName(ctx, "deleted-key-test")
+	require.NoError(t, err)
+	require.NotNil(t, retrievedKey)
+
+	assert.Equal(t, uint(1), retrievedKey.Version)
+	assert.Equal(t, key1.ID, retrievedKey.ID)
+}
+
+func TestPostgreSQLTransitKeyRepository_GetByName_AllVersionsDeleted(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create a transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "all-deleted-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Delete the key
+	err = repo.Delete(ctx, transitKey.ID)
+	require.NoError(t, err)
+
+	// GetByName should return not found error
+	retrievedKey, err := repo.GetByName(ctx, "all-deleted-test")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedKey)
+	assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
+}
+
+func TestPostgreSQLTransitKeyRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-test-key",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create transit key within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO transit_keys (id, name, version, dek_id, created_at, deleted_at) 
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		transitKey.ID,
+		transitKey.Name,
+		transitKey.Version,
+		transitKey.DekID,
+		transitKey.CreatedAt,
+		transitKey.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the transit key was not created (rollback worked)
+	retrievedKey, err := repo.GetByName(ctx, "tx-test-key")
+	assert.Error(t, err)
+	assert.Nil(t, retrievedKey)
+	assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
+}
+
+func TestPostgreSQLTransitKeyRepository_Delete_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create initial transit key
+	transitKey := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-delete-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, transitKey)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Delete within transaction
+	_, err = tx.ExecContext(ctx, `UPDATE transit_keys SET deleted_at = NOW() WHERE id = $1`, transitKey.ID)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the transit key was not deleted (rollback worked)
+	retrievedKey, err := repo.GetByName(ctx, "tx-delete-test")
+	require.NoError(t, err)
+	assert.NotNil(t, retrievedKey)
+	assert.Equal(t, transitKey.ID, retrievedKey.ID)
+}
+
+func TestPostgreSQLTransitKeyRepository_GetByName_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLTransitKeyRepository(db)
+	ctx := context.Background()
+
+	dekID := createTestDek(t, db)
+
+	// Create a transit key outside transaction
+	key1 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-read-test",
+		Version:   1,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := repo.Create(ctx, key1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another version inside transaction
+	time.Sleep(time.Millisecond)
+	key2 := &transitDomain.TransitKey{
+		ID:        uuid.Must(uuid.NewV7()),
+		Name:      "tx-read-test",
+		Version:   2,
+		DekID:     dekID,
+		CreatedAt: time.Now().UTC(),
+	}
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO transit_keys (id, name, version, dek_id, created_at, deleted_at) 
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		key2.ID,
+		key2.Name,
+		key2.Version,
+		key2.DekID,
+		key2.CreatedAt,
+		key2.DeletedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see version 2
+	var retrievedKey transitDomain.TransitKey
+	err = tx.QueryRowContext(
+		ctx,
+		`SELECT id, name, version, dek_id, created_at, deleted_at 
+		 FROM transit_keys 
+		 WHERE name = $1 AND deleted_at IS NULL 
+		 ORDER BY version DESC 
+		 LIMIT 1`,
+		"tx-read-test",
+	).Scan(
+		&retrievedKey.ID,
+		&retrievedKey.Name,
+		&retrievedKey.Version,
+		&retrievedKey.DekID,
+		&retrievedKey.CreatedAt,
+		&retrievedKey.DeletedAt,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), retrievedKey.Version)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query outside transaction should also see version 2
+	retrievedKey2, err := repo.GetByName(ctx, "tx-read-test")
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), retrievedKey2.Version)
+}
+
+// createTestDek creates a KEK and DEK for testing transit keys.
+func createTestDek(t *testing.T, db *sql.DB) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	// Create KEK
+	kekID := uuid.Must(uuid.NewV7())
+	kekRepo := cryptoRepository.NewPostgreSQLKekRepository(db)
+	kek := &cryptoDomain.Kek{
+		ID:           kekID,
+		MasterKeyID:  "master-key-test",
+		Algorithm:    cryptoDomain.AESGCM,
+		EncryptedKey: []byte("encrypted-kek-data"),
+		Nonce:        []byte("kek-nonce"),
+		Version:      1,
+		CreatedAt:    time.Now().UTC(),
+	}
+	err := kekRepo.Create(ctx, kek)
+	require.NoError(t, err)
+
+	// Create DEK
+	dekID := uuid.Must(uuid.NewV7())
+	dekRepo := cryptoRepository.NewPostgreSQLDekRepository(db)
+	dek := &cryptoDomain.Dek{
+		ID:           dekID,
+		KekID:        kekID,
+		Algorithm:    cryptoDomain.AESGCM,
+		EncryptedKey: []byte("encrypted-dek-data"),
+		Nonce:        []byte("dek-nonce"),
+		CreatedAt:    time.Now().UTC(),
+	}
+	err = dekRepo.Create(ctx, dek)
+	require.NoError(t, err)
+
+	return dekID
+}

--- a/internal/transit/usecase/interface.go
+++ b/internal/transit/usecase/interface.go
@@ -1,0 +1,15 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+type TransitKeyRepository interface {
+	Create(ctx context.Context, transitKey *transitDomain.TransitKey) error
+	Delete(ctx context.Context, transitKeyID uuid.UUID) error
+	GetByName(ctx context.Context, name string) (*transitDomain.TransitKey, error)
+}


### PR DESCRIPTION
Implement the foundation of the transit encryption module for encrypting data in transit. This module introduces transit keys (versioned encryption keys), encrypted blob serialization, and dual database support for PostgreSQL and MySQL.

Key additions:
- TransitKey domain model with version tracking for key rotation
- EncryptedBlob value object for serializing encrypted data in "name:version:ciphertext-base64" format with full validation
- Domain-specific errors for invalid blob formats and missing keys
- Repository layer with complete CRUD operations and soft deletion
- Comprehensive test coverage for all components (100% coverage target)
- Transaction-aware operations using database.GetTx() pattern

Behavioral changes:
- SecretRepository.GetByPath now excludes soft-deleted secrets, returning only the latest non-deleted version to prevent retrieving deleted data
- Added test coverage for multiple version scenarios with partial deletion