### PR TITLE
refactor(transit): remove key name from EncryptedBlob structure

### DIFF
--- a/internal/transit/domain/encrypted_blob_test.go
+++ b/internal/transit/domain/encrypted_blob_test.go
@@ -16,109 +16,79 @@ func TestNewEncryptedBlob_Success(t *testing.T) {
 		// Arrange
 		plaintext := []byte("Hello, World!")
 		ciphertext := base64.StdEncoding.EncodeToString(plaintext)
-		input := "payment-key:1:" + ciphertext
+		input := "1:" + ciphertext
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, "payment-key", blob.Name)
 		assert.Equal(t, uint(1), blob.Version)
 		assert.Equal(t, plaintext, blob.Ciphertext)
 	})
 
 	t.Run("ValidInput_Version0", func(t *testing.T) {
 		// Arrange
-		input := "test-key:0:dGVzdA=="
+		input := "0:dGVzdA=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, "test-key", blob.Name)
 		assert.Equal(t, uint(0), blob.Version)
 		assert.Equal(t, []byte("test"), blob.Ciphertext)
 	})
 
 	t.Run("ValidInput_LargeVersion", func(t *testing.T) {
 		// Arrange
-		input := "key:999999:ZGF0YQ=="
+		input := "999999:ZGF0YQ=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, "key", blob.Name)
 		assert.Equal(t, uint(999999), blob.Version)
 		assert.Equal(t, []byte("data"), blob.Ciphertext)
 	})
 
 	t.Run("ValidInput_EmptyCiphertext", func(t *testing.T) {
 		// Arrange - empty string is valid base64
-		input := "my-key:5:"
+		input := "5:"
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, "my-key", blob.Name)
 		assert.Equal(t, uint(5), blob.Version)
 		assert.Empty(t, blob.Ciphertext)
 	})
 
-	t.Run("ValidInput_NameWithHyphens", func(t *testing.T) {
-		// Arrange
-		input := "payment-encryption-key:1:dGVzdA=="
+	t.Run("ValidInput_WithColonsInBase64", func(t *testing.T) {
+		// Arrange - test that we split on first colon only
+		input := "1:dGVzdA=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, "payment-encryption-key", blob.Name)
-	})
-
-	t.Run("ValidInput_NameWithUnderscores", func(t *testing.T) {
-		// Arrange
-		input := "payment_encryption_key:1:dGVzdA=="
-
-		// Act
-		blob, err := domain.NewEncryptedBlob(input)
-
-		// Assert
-		require.NoError(t, err)
-		assert.Equal(t, "payment_encryption_key", blob.Name)
-	})
-
-	t.Run("ValidInput_NameWithNumbers", func(t *testing.T) {
-		// Arrange
-		input := "key123:42:dGVzdA=="
-
-		// Act
-		blob, err := domain.NewEncryptedBlob(input)
-
-		// Assert
-		require.NoError(t, err)
-		assert.Equal(t, "key123", blob.Name)
-		assert.Equal(t, uint(42), blob.Version)
+		assert.Equal(t, uint(1), blob.Version)
 	})
 
 	t.Run("ValidInput_ComplexBase64", func(t *testing.T) {
 		// Arrange - complex data with padding
 		data := []byte("This is a longer test message that will encode to a longer base64 string!")
 		ciphertext := base64.StdEncoding.EncodeToString(data)
-		input := "long-key:10:" + ciphertext
+		input := "10:" + ciphertext
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, "long-key", blob.Name)
 		assert.Equal(t, uint(10), blob.Version)
 		assert.Equal(t, data, blob.Ciphertext)
 	})
@@ -141,7 +111,7 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 
 	t.Run("Error_OnePart", func(t *testing.T) {
 		// Arrange
-		input := "just-name"
+		input := "1"
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -152,9 +122,9 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 		assert.Equal(t, domain.EncryptedBlob{}, blob)
 	})
 
-	t.Run("Error_TwoParts", func(t *testing.T) {
+	t.Run("Error_ThreeParts", func(t *testing.T) {
 		// Arrange
-		input := "name:1"
+		input := "1:data:extra"
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -162,39 +132,12 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 		// Assert
 		require.Error(t, err)
 		assert.ErrorIs(t, err, domain.ErrInvalidBlobFormat)
-		assert.Equal(t, domain.EncryptedBlob{}, blob)
-	})
-
-	t.Run("Error_FourParts", func(t *testing.T) {
-		// Arrange
-		input := "name:1:data:extra"
-
-		// Act
-		blob, err := domain.NewEncryptedBlob(input)
-
-		// Assert
-		require.Error(t, err)
-		assert.ErrorIs(t, err, domain.ErrInvalidBlobFormat)
-		assert.Equal(t, domain.EncryptedBlob{}, blob)
-	})
-
-	t.Run("Error_EmptyName", func(t *testing.T) {
-		// Arrange
-		input := ":1:dGVzdA=="
-
-		// Act
-		blob, err := domain.NewEncryptedBlob(input)
-
-		// Assert
-		require.Error(t, err)
-		assert.ErrorIs(t, err, domain.ErrEmptyBlobName)
-		assert.ErrorIs(t, err, apperrors.ErrInvalidInput)
 		assert.Equal(t, domain.EncryptedBlob{}, blob)
 	})
 
 	t.Run("Error_InvalidVersion_NonNumeric", func(t *testing.T) {
 		// Arrange
-		input := "key:abc:dGVzdA=="
+		input := "abc:dGVzdA=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -208,7 +151,7 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 
 	t.Run("Error_InvalidVersion_Negative", func(t *testing.T) {
 		// Arrange
-		input := "key:-1:dGVzdA=="
+		input := "-1:dGVzdA=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -221,7 +164,7 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 
 	t.Run("Error_InvalidVersion_Float", func(t *testing.T) {
 		// Arrange
-		input := "key:1.5:dGVzdA=="
+		input := "1.5:dGVzdA=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -234,7 +177,7 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 
 	t.Run("Error_InvalidBase64_InvalidCharacters", func(t *testing.T) {
 		// Arrange
-		input := "key:1:not-valid-base64!!!"
+		input := "1:not-valid-base64!!!"
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -248,7 +191,7 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 
 	t.Run("Error_InvalidBase64_IncorrectPadding", func(t *testing.T) {
 		// Arrange
-		input := "key:1:dGVzd==="
+		input := "1:dGVzd==="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -261,7 +204,7 @@ func TestNewEncryptedBlob_Errors(t *testing.T) {
 
 	t.Run("Error_VersionWithSpaces", func(t *testing.T) {
 		// Arrange
-		input := "key: 1 :dGVzdA=="
+		input := " 1 :dGVzdA=="
 
 		// Act
 		blob, err := domain.NewEncryptedBlob(input)
@@ -278,11 +221,10 @@ func TestEncryptedBlob_String(t *testing.T) {
 		// Arrange
 		plaintext := []byte("Hello, World!")
 		blob := domain.EncryptedBlob{
-			Name:       "test-key",
 			Version:    42,
 			Ciphertext: plaintext,
 		}
-		expected := "test-key:42:" + base64.StdEncoding.EncodeToString(plaintext)
+		expected := "42:" + base64.StdEncoding.EncodeToString(plaintext)
 
 		// Act
 		result := blob.String()
@@ -294,11 +236,10 @@ func TestEncryptedBlob_String(t *testing.T) {
 	t.Run("Success_EmptyCiphertext", func(t *testing.T) {
 		// Arrange
 		blob := domain.EncryptedBlob{
-			Name:       "empty-key",
 			Version:    1,
 			Ciphertext: []byte{},
 		}
-		expected := "empty-key:1:"
+		expected := "1:"
 
 		// Act
 		result := blob.String()
@@ -310,7 +251,6 @@ func TestEncryptedBlob_String(t *testing.T) {
 	t.Run("Success_Version0", func(t *testing.T) {
 		// Arrange
 		blob := domain.EncryptedBlob{
-			Name:       "v0-key",
 			Version:    0,
 			Ciphertext: []byte("data"),
 		}
@@ -319,13 +259,12 @@ func TestEncryptedBlob_String(t *testing.T) {
 		result := blob.String()
 
 		// Assert
-		assert.Contains(t, result, "v0-key:0:")
+		assert.Contains(t, result, "0:")
 	})
 
 	t.Run("Success_RoundTrip", func(t *testing.T) {
 		// Arrange
 		original := domain.EncryptedBlob{
-			Name:       "round-trip-key",
 			Version:    123,
 			Ciphertext: []byte("This is test data for round trip!"),
 		}
@@ -336,7 +275,6 @@ func TestEncryptedBlob_String(t *testing.T) {
 
 		// Assert
 		require.NoError(t, err)
-		assert.Equal(t, original.Name, parsed.Name)
 		assert.Equal(t, original.Version, parsed.Version)
 		assert.Equal(t, original.Ciphertext, parsed.Ciphertext)
 	})
@@ -344,7 +282,6 @@ func TestEncryptedBlob_String(t *testing.T) {
 	t.Run("Success_RoundTrip_MultipleIterations", func(t *testing.T) {
 		// Arrange
 		original := domain.EncryptedBlob{
-			Name:       "multi-key",
 			Version:    5,
 			Ciphertext: []byte("test data"),
 		}
@@ -359,7 +296,6 @@ func TestEncryptedBlob_String(t *testing.T) {
 		}
 
 		// Assert - should still equal original
-		assert.Equal(t, original.Name, current.Name)
 		assert.Equal(t, original.Version, current.Version)
 		assert.Equal(t, original.Ciphertext, current.Ciphertext)
 	})
@@ -368,7 +304,6 @@ func TestEncryptedBlob_String(t *testing.T) {
 		// Arrange - binary data with various byte values
 		complexData := []byte{0x00, 0x01, 0xFF, 0xAB, 0xCD, 0xEF}
 		blob := domain.EncryptedBlob{
-			Name:       "binary-key",
 			Version:    99,
 			Ciphertext: complexData,
 		}

--- a/internal/transit/domain/errors.go
+++ b/internal/transit/domain/errors.go
@@ -12,19 +12,12 @@ import (
 var (
 	// ErrInvalidBlobFormat indicates the encrypted blob format is invalid.
 	//
-	// The expected format is: "name:version:ciphertext-base64"
-	// This error is returned when the input string doesn't have exactly 3 parts
+	// The expected format is: "version:ciphertext-base64"
+	// This error is returned when the input string doesn't have exactly 2 parts
 	// separated by colons.
 	//
 	// HTTP Status: 422 Unprocessable Entity
 	ErrInvalidBlobFormat = errors.Wrap(errors.ErrInvalidInput, "invalid encrypted blob format")
-
-	// ErrEmptyBlobName indicates the encrypted blob name is empty.
-	//
-	// The name field must be a non-empty string to identify the transit key.
-	//
-	// HTTP Status: 422 Unprocessable Entity
-	ErrEmptyBlobName = errors.Wrap(errors.ErrInvalidInput, "encrypted blob name cannot be empty")
 
 	// ErrInvalidBlobVersion indicates the version string cannot be parsed.
 	//


### PR DESCRIPTION
Remove the Name field from EncryptedBlob as it's redundant - the transit key name is already passed separately in API calls (e.g., /transit/decrypt/{key_name}). This simplifies the blob format from "name:version:ciphertext" to just "version:ciphertext" and reduces serialization overhead.

Changes:
- Remove Name field from EncryptedBlob struct
- Update NewEncryptedBlob to parse 2-part format instead of 3-part
- Update String() method to serialize without name
- Remove ErrEmptyBlobName error and associated validation
- Update all tests to reflect new format
- Update documentation and examples