### PR TITLE
feat(secrets): add GetByPathAndVersion repository method

### DIFF
--- a/internal/secrets/repository/mysql_secret_repository.go
+++ b/internal/secrets/repository/mysql_secret_repository.go
@@ -192,6 +192,84 @@ func (m *MySQLSecretRepository) GetByPath(
 	return &secret, nil
 }
 
+// GetByPathAndVersion retrieves a specific version of a secret by its path and version number from the
+// MySQL database.
+//
+// This method fetches a secret using both its path identifier and version number, returning only
+// non-deleted versions. The secret is returned with all fields populated, including encrypted data.
+// UUIDs are unmarshaled from BINARY(16) format. This method supports transaction context via
+// database.GetTx(), enabling consistent reads within a transaction.
+//
+// Soft-deleted secrets (with deleted_at set) are excluded from results. If the specified version
+// at the given path is deleted or does not exist, this method returns ErrNotFound.
+//
+// Note: Unlike GetByPath which returns the latest version, this method returns a specific version
+// number, which is useful for accessing historical versions of a secret or for audit purposes.
+//
+// Parameters:
+//   - ctx: Context for cancellation, timeouts, and transaction propagation
+//   - path: The secret path identifier (e.g., "/app/database/password")
+//   - version: The specific version number to retrieve (e.g., 1, 2, 3)
+//
+// Returns:
+//   - The Secret if found with all encrypted fields populated
+//   - ErrNotFound if the secret doesn't exist at the specified path and version or is deleted
+//   - An error if the database query or UUID unmarshaling fails
+//
+// Example:
+//
+//	// Get version 2 of a secret
+//	secret, err := repo.GetByPathAndVersion(ctx, "/app/api-key", 2)
+//	if err != nil {
+//	    if errors.Is(err, apperrors.ErrNotFound) {
+//	        return nil, fmt.Errorf("secret version not found")
+//	    }
+//	    return nil, err
+//	}
+//	// Use secret.DekID to retrieve the DEK for decryption
+func (m *MySQLSecretRepository) GetByPathAndVersion(
+	ctx context.Context,
+	path string,
+	version uint,
+) (*secretsDomain.Secret, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, path, version, dek_id, ciphertext, nonce, created_at, deleted_at 
+			  FROM secrets 
+			  WHERE path = ? AND version = ? AND deleted_at IS NULL
+			  LIMIT 1`
+
+	var secret secretsDomain.Secret
+	var id, dekID []byte
+
+	err := querier.QueryRowContext(ctx, query, path, version).Scan(
+		&id,
+		&secret.Path,
+		&secret.Version,
+		&dekID,
+		&secret.Ciphertext,
+		&secret.Nonce,
+		&secret.CreatedAt,
+		&secret.DeletedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, apperrors.ErrNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get secret by path and version")
+	}
+
+	if err := secret.ID.UnmarshalBinary(id); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal secret id")
+	}
+
+	if err := secret.DekID.UnmarshalBinary(dekID); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal dek id")
+	}
+
+	return &secret, nil
+}
+
 // Delete performs a soft delete on a secret by setting the DeletedAt timestamp.
 //
 // This method does not physically remove the secret from the database. Instead, it sets

--- a/internal/secrets/repository/postgresql_secret_repository_test.go
+++ b/internal/secrets/repository/postgresql_secret_repository_test.go
@@ -1062,3 +1062,287 @@ func TestPostgreSQLSecretRepository_GetByPath_WithTransaction(t *testing.T) {
 	assert.Equal(t, secret.ID, retrievedSecret.ID)
 	assert.Equal(t, secret.Path, retrievedSecret.Path)
 }
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	// Create multiple versions
+	path := "/app/versioned-secret"
+	secrets := make([]*secretsDomain.Secret, 3)
+
+	for i := uint(0); i < 3; i++ {
+		time.Sleep(time.Millisecond)
+		secrets[i] = &secretsDomain.Secret{
+			ID:         uuid.Must(uuid.NewV7()),
+			Path:       path,
+			Version:    i + 1,
+			DekID:      dekID,
+			Ciphertext: []byte(fmt.Sprintf("encrypted-v%d", i+1)),
+			Nonce:      []byte(fmt.Sprintf("nonce-v%d", i+1)),
+			CreatedAt:  time.Now().UTC(),
+		}
+		err := repo.Create(ctx, secrets[i])
+		require.NoError(t, err)
+	}
+
+	// Get version 2 specifically
+	retrievedSecret, err := repo.GetByPathAndVersion(ctx, path, 2)
+	require.NoError(t, err)
+	assert.NotNil(t, retrievedSecret)
+
+	// Verify it's version 2
+	assert.Equal(t, secrets[1].ID, retrievedSecret.ID)
+	assert.Equal(t, secrets[1].Path, retrievedSecret.Path)
+	assert.Equal(t, uint(2), retrievedSecret.Version)
+	assert.Equal(t, secrets[1].DekID, retrievedSecret.DekID)
+	assert.Equal(t, []byte("encrypted-v2"), retrievedSecret.Ciphertext)
+	assert.Equal(t, []byte("nonce-v2"), retrievedSecret.Nonce)
+	assert.WithinDuration(t, secrets[1].CreatedAt, retrievedSecret.CreatedAt, time.Second)
+	assert.Nil(t, retrievedSecret.DeletedAt)
+}
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion_NotFound_InvalidPath(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent secret
+	secret, err := repo.GetByPathAndVersion(ctx, "/non/existent/path", 1)
+
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+	assert.ErrorIs(t, err, apperrors.ErrNotFound)
+}
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion_NotFound_InvalidVersion(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	// Create version 1 and 2
+	path := "/app/secret"
+	for i := uint(1); i <= 2; i++ {
+		time.Sleep(time.Millisecond)
+		secret := &secretsDomain.Secret{
+			ID:         uuid.Must(uuid.NewV7()),
+			Path:       path,
+			Version:    i,
+			DekID:      dekID,
+			Ciphertext: []byte(fmt.Sprintf("encrypted-v%d", i)),
+			Nonce:      []byte(fmt.Sprintf("nonce-v%d", i)),
+			CreatedAt:  time.Now().UTC(),
+		}
+		err := repo.Create(ctx, secret)
+		require.NoError(t, err)
+	}
+
+	// Try to get version 3 which doesn't exist
+	secret, err := repo.GetByPathAndVersion(ctx, path, 3)
+
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+	assert.ErrorIs(t, err, apperrors.ErrNotFound)
+}
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion_MultipleVersions(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	path := "/app/multi-version-secret"
+	versions := []uint{1, 2, 3, 4, 5}
+
+	// Create multiple versions
+	for _, version := range versions {
+		time.Sleep(time.Millisecond)
+		secret := &secretsDomain.Secret{
+			ID:         uuid.Must(uuid.NewV7()),
+			Path:       path,
+			Version:    version,
+			DekID:      dekID,
+			Ciphertext: []byte(fmt.Sprintf("encrypted-v%d", version)),
+			Nonce:      []byte(fmt.Sprintf("nonce-v%d", version)),
+			CreatedAt:  time.Now().UTC(),
+		}
+		err := repo.Create(ctx, secret)
+		require.NoError(t, err)
+	}
+
+	// Retrieve each version and verify correctness
+	for _, version := range versions {
+		retrievedSecret, err := repo.GetByPathAndVersion(ctx, path, version)
+		require.NoError(t, err, "failed to get version %d", version)
+		assert.NotNil(t, retrievedSecret)
+		assert.Equal(t, path, retrievedSecret.Path)
+		assert.Equal(t, version, retrievedSecret.Version)
+		assert.Equal(
+			t,
+			[]byte(fmt.Sprintf("encrypted-v%d", version)),
+			retrievedSecret.Ciphertext,
+			"ciphertext mismatch for version %d",
+			version,
+		)
+		assert.Equal(
+			t,
+			[]byte(fmt.Sprintf("nonce-v%d", version)),
+			retrievedSecret.Nonce,
+			"nonce mismatch for version %d",
+			version,
+		)
+	}
+}
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion_DeletedSecret(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	// Create version 1
+	secret := &secretsDomain.Secret{
+		ID:         uuid.Must(uuid.NewV7()),
+		Path:       "/app/deleted-secret",
+		Version:    1,
+		DekID:      dekID,
+		Ciphertext: []byte("encrypted-data"),
+		Nonce:      []byte("nonce"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	err := repo.Create(ctx, secret)
+	require.NoError(t, err)
+
+	// Verify we can get it before deletion
+	retrievedSecret, err := repo.GetByPathAndVersion(ctx, "/app/deleted-secret", 1)
+	require.NoError(t, err)
+	assert.NotNil(t, retrievedSecret)
+
+	// Delete the secret
+	err = repo.Delete(ctx, secret.ID)
+	require.NoError(t, err)
+
+	// GetByPathAndVersion should return ErrNotFound for deleted secrets
+	retrievedSecret, err = repo.GetByPathAndVersion(ctx, "/app/deleted-secret", 1)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedSecret)
+	assert.ErrorIs(t, err, apperrors.ErrNotFound)
+}
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion_MultipleVersions_OneDeleted(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	path := "/app/mixed-versions"
+
+	// Create versions 1, 2, and 3
+	secrets := make([]*secretsDomain.Secret, 3)
+	for i := uint(0); i < 3; i++ {
+		time.Sleep(time.Millisecond)
+		secrets[i] = &secretsDomain.Secret{
+			ID:         uuid.Must(uuid.NewV7()),
+			Path:       path,
+			Version:    i + 1,
+			DekID:      dekID,
+			Ciphertext: []byte(fmt.Sprintf("encrypted-v%d", i+1)),
+			Nonce:      []byte(fmt.Sprintf("nonce-v%d", i+1)),
+			CreatedAt:  time.Now().UTC(),
+		}
+		err := repo.Create(ctx, secrets[i])
+		require.NoError(t, err)
+	}
+
+	// Delete version 2
+	err := repo.Delete(ctx, secrets[1].ID)
+	require.NoError(t, err)
+
+	// Version 1 should still be accessible
+	v1, err := repo.GetByPathAndVersion(ctx, path, 1)
+	require.NoError(t, err)
+	assert.NotNil(t, v1)
+	assert.Equal(t, uint(1), v1.Version)
+
+	// Version 2 should not be accessible (deleted)
+	v2, err := repo.GetByPathAndVersion(ctx, path, 2)
+	assert.Error(t, err)
+	assert.Nil(t, v2)
+	assert.ErrorIs(t, err, apperrors.ErrNotFound)
+
+	// Version 3 should still be accessible
+	v3, err := repo.GetByPathAndVersion(ctx, path, 3)
+	require.NoError(t, err)
+	assert.NotNil(t, v3)
+	assert.Equal(t, uint(3), v3.Version)
+}
+
+func TestPostgreSQLSecretRepository_GetByPathAndVersion_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLSecretRepository(db)
+	ctx := context.Background()
+
+	_, dekID := createKekAndDek(t, db)
+
+	// Create secrets with multiple versions
+	path := "/app/transaction-secret"
+	for i := uint(1); i <= 2; i++ {
+		time.Sleep(time.Millisecond)
+		secret := &secretsDomain.Secret{
+			ID:         uuid.Must(uuid.NewV7()),
+			Path:       path,
+			Version:    i,
+			DekID:      dekID,
+			Ciphertext: []byte(fmt.Sprintf("encrypted-v%d", i)),
+			Nonce:      []byte(fmt.Sprintf("nonce-v%d", i)),
+			CreatedAt:  time.Now().UTC(),
+		}
+		err := repo.Create(ctx, secret)
+		require.NoError(t, err)
+	}
+
+	// Use TxManager to get the secret within a transaction
+	txManager := database.NewTxManager(db)
+	var retrievedSecret *secretsDomain.Secret
+
+	err := txManager.WithTx(ctx, func(txCtx context.Context) error {
+		var txErr error
+		retrievedSecret, txErr = repo.GetByPathAndVersion(txCtx, path, 1)
+		return txErr
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, retrievedSecret)
+	assert.Equal(t, path, retrievedSecret.Path)
+	assert.Equal(t, uint(1), retrievedSecret.Version)
+	assert.Equal(t, []byte("encrypted-v1"), retrievedSecret.Ciphertext)
+}

--- a/internal/secrets/usecase/interface.go
+++ b/internal/secrets/usecase/interface.go
@@ -91,6 +91,7 @@ type SecretRepository interface {
 	Create(ctx context.Context, secret *secretsDomain.Secret) error
 	Delete(ctx context.Context, secretID uuid.UUID) error
 	GetByPath(ctx context.Context, path string) (*secretsDomain.Secret, error)
+	GetByPathAndVersion(ctx context.Context, path string, version uint) (*secretsDomain.Secret, error)
 }
 
 // SecretUseCase defines the interface for secret management business logic.

--- a/internal/secrets/usecase/mocks/secret_repository.go
+++ b/internal/secrets/usecase/mocks/secret_repository.go
@@ -177,49 +177,62 @@ func (_c *MockSecretRepository_GetByPath_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
-// Update provides a mock function with given fields: ctx, secret
-func (_m *MockSecretRepository) Update(ctx context.Context, secret *domain.Secret) error {
-	ret := _m.Called(ctx, secret)
+// GetByPathAndVersion provides a mock function with given fields: ctx, path, version
+func (_m *MockSecretRepository) GetByPathAndVersion(ctx context.Context, path string, version uint) (*domain.Secret, error) {
+	ret := _m.Called(ctx, path, version)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Update")
+		panic("no return value specified for GetByPathAndVersion")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *domain.Secret) error); ok {
-		r0 = rf(ctx, secret)
+	var r0 *domain.Secret
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, uint) (*domain.Secret, error)); ok {
+		return rf(ctx, path, version)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, uint) *domain.Secret); ok {
+		r0 = rf(ctx, path, version)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*domain.Secret)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string, uint) error); ok {
+		r1 = rf(ctx, path, version)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// MockSecretRepository_Update_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Update'
-type MockSecretRepository_Update_Call struct {
+// MockSecretRepository_GetByPathAndVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetByPathAndVersion'
+type MockSecretRepository_GetByPathAndVersion_Call struct {
 	*mock.Call
 }
 
-// Update is a helper method to define mock.On call
+// GetByPathAndVersion is a helper method to define mock.On call
 //   - ctx context.Context
-//   - secret *domain.Secret
-func (_e *MockSecretRepository_Expecter) Update(ctx interface{}, secret interface{}) *MockSecretRepository_Update_Call {
-	return &MockSecretRepository_Update_Call{Call: _e.mock.On("Update", ctx, secret)}
+//   - path string
+//   - version uint
+func (_e *MockSecretRepository_Expecter) GetByPathAndVersion(ctx interface{}, path interface{}, version interface{}) *MockSecretRepository_GetByPathAndVersion_Call {
+	return &MockSecretRepository_GetByPathAndVersion_Call{Call: _e.mock.On("GetByPathAndVersion", ctx, path, version)}
 }
 
-func (_c *MockSecretRepository_Update_Call) Run(run func(ctx context.Context, secret *domain.Secret)) *MockSecretRepository_Update_Call {
+func (_c *MockSecretRepository_GetByPathAndVersion_Call) Run(run func(ctx context.Context, path string, version uint)) *MockSecretRepository_GetByPathAndVersion_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*domain.Secret))
+		run(args[0].(context.Context), args[1].(string), args[2].(uint))
 	})
 	return _c
 }
 
-func (_c *MockSecretRepository_Update_Call) Return(_a0 error) *MockSecretRepository_Update_Call {
-	_c.Call.Return(_a0)
+func (_c *MockSecretRepository_GetByPathAndVersion_Call) Return(_a0 *domain.Secret, _a1 error) *MockSecretRepository_GetByPathAndVersion_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockSecretRepository_Update_Call) RunAndReturn(run func(context.Context, *domain.Secret) error) *MockSecretRepository_Update_Call {
+func (_c *MockSecretRepository_GetByPathAndVersion_Call) RunAndReturn(run func(context.Context, string, uint) (*domain.Secret, error)) *MockSecretRepository_GetByPathAndVersion_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Add GetByPathAndVersion method to both PostgreSQL and MySQL secret repositories to enable retrieval of specific secret versions by path and version number. This complements the existing GetByPath method which only returns the latest version.

Key changes:
- Implement GetByPathAndVersion in PostgreSQLSecretRepository and MySQLSecretRepository
- Add transaction support via database.GetTx() for consistent reads
- Return ErrNotFound for non-existent or soft-deleted versions
- Add comprehensive test coverage including edge cases (deleted versions, non-existent paths, transaction support)
- Update SecretRepository interface in usecase layer
- Regenerate mock implementations

This method is useful for accessing historical versions of secrets and for audit purposes.