### PR TITLE
refactor(crypto): improve memory security by zeroing sensitive keys

### DIFF
--- a/internal/crypto/domain/kek.go
+++ b/internal/crypto/domain/kek.go
@@ -48,6 +48,13 @@ func (k *KekChain) Get(id uuid.UUID) (*Kek, bool) {
 
 // Close securely clears all KEKs from the chain and resets the active ID.
 func (k *KekChain) Close() {
+	// Zero all KEK keys before clearing
+	k.keys.Range(func(key, value interface{}) bool {
+		if kek, ok := value.(*Kek); ok {
+			Zero(kek.Key)
+		}
+		return true
+	})
 	k.activeID = uuid.Nil
 	k.keys.Clear()
 }

--- a/internal/crypto/domain/master_key.go
+++ b/internal/crypto/domain/master_key.go
@@ -71,7 +71,7 @@ func LoadMasterKeyChainFromEnv() (*MasterKeyChain, error) {
 			return nil, fmt.Errorf("%w for %s: %v", ErrInvalidMasterKeyBase64, id, err)
 		}
 		if len(key) != 32 {
-			zero(key)
+			Zero(key)
 			mkc.Close()
 			return nil, fmt.Errorf(
 				"%w: master key %s must be 32 bytes, got %d",
@@ -81,7 +81,7 @@ func LoadMasterKeyChainFromEnv() (*MasterKeyChain, error) {
 			)
 		}
 		mkc.keys.Store(id, &MasterKey{ID: id, Key: key})
-		zero(key)
+		Zero(key)
 	}
 
 	if _, ok := mkc.Get(active); !ok {

--- a/internal/crypto/domain/zero.go
+++ b/internal/crypto/domain/zero.go
@@ -1,7 +1,7 @@
 package domain
 
-// zero securely overwrites a byte slice with zeros to clear sensitive data from memory.
-func zero(b []byte) {
+// Zero securely overwrites a byte slice with zeros to clear sensitive data from memory.
+func Zero(b []byte) {
 	if b == nil {
 		return
 	}

--- a/internal/secrets/usecase/interface.go
+++ b/internal/secrets/usecase/interface.go
@@ -29,6 +29,10 @@ type SecretRepository interface {
 // SecretUseCase defines the interface for secret management business logic.
 type SecretUseCase interface {
 	CreateOrUpdate(ctx context.Context, path string, value []byte) (*secretsDomain.Secret, error)
+	// Get retrieves and decrypts a secret by its path.
+	//
+	// Security Note: The returned Secret contains plaintext data in the Plaintext field.
+	// Callers MUST zero this data after use by calling cryptoDomain.Zero(secret.Plaintext).
 	Get(ctx context.Context, path string) (*secretsDomain.Secret, error)
 	Delete(ctx context.Context, path string) error
 }

--- a/internal/secrets/usecase/secret_usecase.go
+++ b/internal/secrets/usecase/secret_usecase.go
@@ -79,6 +79,7 @@ func (s *secretUseCase) createOrUpdateSecret(
 		if err != nil {
 			return err
 		}
+		defer cryptoDomain.Zero(dekKey)
 
 		// Create cipher with the decrypted DEK key
 		cipher, err := s.aeadManager.CreateCipher(dekKey, s.dekAlgorithm)
@@ -143,6 +144,7 @@ func (s *secretUseCase) Get(ctx context.Context, path string) (*secretsDomain.Se
 	if err != nil {
 		return nil, err
 	}
+	defer cryptoDomain.Zero(dekKey)
 
 	// Create cipher with the decrypted DEK key
 	cipher, err := s.aeadManager.CreateCipher(dekKey, dek.Algorithm)

--- a/internal/transit/usecase/interface.go
+++ b/internal/transit/usecase/interface.go
@@ -29,5 +29,9 @@ type TransitKeyUseCase interface {
 	Rotate(ctx context.Context, name string, alg cryptoDomain.Algorithm) (*transitDomain.TransitKey, error)
 	Delete(ctx context.Context, transitKeyID uuid.UUID) error
 	Encrypt(ctx context.Context, name string, plaintext []byte) (*transitDomain.EncryptedBlob, error)
+	// Decrypt decrypts ciphertext using the version specified in the encrypted blob.
+	//
+	// Security Note: The returned EncryptedBlob contains plaintext data in the Plaintext field.
+	// Callers MUST zero this data after use by calling cryptoDomain.Zero(blob.Plaintext).
 	Decrypt(ctx context.Context, name string, ciphertext []byte) (*transitDomain.EncryptedBlob, error)
 }

--- a/internal/transit/usecase/transit_key_usecase.go
+++ b/internal/transit/usecase/transit_key_usecase.go
@@ -167,6 +167,7 @@ func (t *transitKeyUseCase) Encrypt(
 	if err != nil {
 		return nil, err
 	}
+	defer cryptoDomain.Zero(dekKey)
 
 	// Create AEAD cipher with decrypted DEK
 	cipher, err := t.aeadManager.CreateCipher(dekKey, dek.Algorithm)
@@ -227,6 +228,7 @@ func (t *transitKeyUseCase) Decrypt(
 	if err != nil {
 		return nil, err
 	}
+	defer cryptoDomain.Zero(dekKey)
 
 	// Create AEAD cipher with decrypted DEK
 	cipher, err := t.aeadManager.CreateCipher(dekKey, dek.Algorithm)


### PR DESCRIPTION
This commit enhances memory security across the cryptographic subsystems by ensuring all sensitive key material is properly zeroed after use to prevent potential memory disclosure attacks.

Key changes:
- Export Zero function in crypto/domain to make it reusable across packages
- Add deferred Zero calls in secret and transit use cases after DEK key decryption
- Implement proper key zeroing in KekChain.Close() before clearing the map
- Update LoadMasterKeyChainFromEnv to use exported Zero function
- Add security documentation to Decrypt methods warning callers to zero returned plaintext

This follows security best practices for cryptographic key handling by ensuring sensitive material is cleared from memory as soon as it's no longer needed, reducing the attack surface for memory disclosure vulnerabilities.