### PR TITLE
feat(auth): implement authentication module

### DIFF
--- a/internal/auth/domain/client.go
+++ b/internal/auth/domain/client.go
@@ -1,0 +1,15 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Client struct {
+	ID        uuid.UUID
+	Secret    string
+	Name      string
+	IsActive  bool
+	CreatedAt time.Time
+}

--- a/internal/auth/domain/client_policies.go
+++ b/internal/auth/domain/client_policies.go
@@ -1,0 +1,8 @@
+package domain
+
+import "github.com/google/uuid"
+
+type ClientPolicies struct {
+	ClientID uuid.UUID
+	PolicyID uuid.UUID
+}

--- a/internal/auth/domain/errors.go
+++ b/internal/auth/domain/errors.go
@@ -1,0 +1,20 @@
+package domain
+
+import (
+	"github.com/allisson/secrets/internal/errors"
+)
+
+// Authentication and authorization errors.
+var (
+	// ErrClientNotFound indicates a client with the specified ID was not found.
+	ErrClientNotFound = errors.Wrap(errors.ErrNotFound, "client not found")
+
+	// ErrTokenNotFound indicates a token with the specified ID was not found.
+	ErrTokenNotFound = errors.Wrap(errors.ErrNotFound, "token not found")
+
+	// ErrPolicyNotFound indicates a policy with the specified name was not found.
+	ErrPolicyNotFound = errors.Wrap(errors.ErrNotFound, "policy not found")
+
+	// ErrClientPoliciesNotFound indicates a client-policy relationship was not found.
+	ErrClientPoliciesNotFound = errors.Wrap(errors.ErrNotFound, "client policies not found")
+)

--- a/internal/auth/domain/policy.go
+++ b/internal/auth/domain/policy.go
@@ -1,0 +1,19 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PolicyDocument struct {
+	Path         string   `json:"path"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type Policy struct {
+	ID        uuid.UUID
+	Name      string
+	Document  PolicyDocument
+	CreatedAt time.Time
+}

--- a/internal/auth/domain/token.go
+++ b/internal/auth/domain/token.go
@@ -1,0 +1,16 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Token struct {
+	ID        uuid.UUID
+	TokenHash string
+	ClientID  uuid.UUID
+	ExpiresAt time.Time
+	RevokedAt *time.Time
+	CreatedAt time.Time
+}

--- a/internal/auth/repository/mysql_client_policies_repository.go
+++ b/internal/auth/repository/mysql_client_policies_repository.go
@@ -1,0 +1,86 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// MySQLClientPoliciesRepository implements ClientPolicies persistence for MySQL.
+// Uses BINARY(16) for UUIDs with transaction support via database.GetTx().
+type MySQLClientPoliciesRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new ClientPolicies relationship into the MySQL database.
+func (m *MySQLClientPoliciesRepository) Create(
+	ctx context.Context,
+	clientPolicies *authDomain.ClientPolicies,
+) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `INSERT INTO client_policies (client_id, policy_id) VALUES (?, ?)`
+
+	clientID, err := clientPolicies.ClientID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	policyID, err := clientPolicies.PolicyID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy id")
+	}
+
+	_, err = querier.ExecContext(ctx, query, clientID, policyID)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create client policies")
+	}
+	return nil
+}
+
+// Delete removes a ClientPolicies relationship from the MySQL database.
+func (m *MySQLClientPoliciesRepository) Delete(
+	ctx context.Context,
+	clientID uuid.UUID,
+	policyID uuid.UUID,
+) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `DELETE FROM client_policies WHERE client_id = ? AND policy_id = ?`
+
+	clientIDBytes, err := clientID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	policyIDBytes, err := policyID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy id")
+	}
+
+	result, err := querier.ExecContext(ctx, query, clientIDBytes, policyIDBytes)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to delete client policies")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return authDomain.ErrClientPoliciesNotFound
+	}
+
+	return nil
+}
+
+// NewMySQLClientPoliciesRepository creates a new MySQL ClientPolicies repository.
+func NewMySQLClientPoliciesRepository(db *sql.DB) *MySQLClientPoliciesRepository {
+	return &MySQLClientPoliciesRepository{db: db}
+}

--- a/internal/auth/repository/mysql_client_policies_repository_test.go
+++ b/internal/auth/repository/mysql_client_policies_repository_test.go
@@ -1,0 +1,508 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewMySQLClientPoliciesRepository(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewMySQLClientPoliciesRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &MySQLClientPoliciesRepository{}, repo)
+}
+
+func TestMySQLClientPoliciesRepository_Create(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	policyRepo := NewMySQLPolicyRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	require.NoError(t, err)
+
+	// Verify the relationship was created by querying the database
+	clientIDBytes, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+	policyIDBytes, err := policy.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = ? AND policy_id = ?`,
+		clientIDBytes,
+		policyIDBytes,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestMySQLClientPoliciesRepository_Create_Duplicate(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	policyRepo := NewMySQLPolicyRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	require.NoError(t, err)
+
+	// Try to create the same relationship again - should fail
+	err = repo.Create(ctx, clientPolicies)
+	assert.Error(t, err)
+}
+
+func TestMySQLClientPoliciesRepository_Create_InvalidClientID(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	policyRepo := NewMySQLPolicyRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err := policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Try to create a relationship with a non-existent client ID
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: uuid.Must(uuid.NewV7()),
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	assert.Error(t, err)
+}
+
+func TestMySQLClientPoliciesRepository_Create_InvalidPolicyID(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Try to create a relationship with a non-existent policy ID
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: uuid.Must(uuid.NewV7()),
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	assert.Error(t, err)
+}
+
+func TestMySQLClientPoliciesRepository_Create_MultiplePoliciesToOneClient(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	policyRepo := NewMySQLPolicyRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create first policy
+	policy1 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-1",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app1/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second policy
+	policy2 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-2",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app2/*",
+			Capabilities: []string{"write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy2)
+	require.NoError(t, err)
+
+	// Attach both policies to the same client
+	err = repo.Create(ctx, &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy1.ID,
+	})
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy2.ID,
+	})
+	require.NoError(t, err)
+
+	// Verify both relationships exist
+	clientIDBytes, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = ?`,
+		clientIDBytes,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestMySQLClientPoliciesRepository_Delete_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	policyRepo := NewMySQLPolicyRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	require.NoError(t, err)
+
+	// Delete the relationship
+	err = repo.Delete(ctx, client.ID, policy.ID)
+	require.NoError(t, err)
+
+	// Verify the relationship was deleted
+	clientIDBytes, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+	policyIDBytes, err := policy.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = ? AND policy_id = ?`,
+		clientIDBytes,
+		policyIDBytes,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestMySQLClientPoliciesRepository_Delete_NonExistent(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Try to delete a non-existent relationship
+	clientID := uuid.Must(uuid.NewV7())
+	policyID := uuid.Must(uuid.NewV7())
+
+	err := repo.Delete(ctx, clientID, policyID)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, authDomain.ErrClientPoliciesNotFound)
+}
+
+func TestMySQLClientPoliciesRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	policyRepo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create relationship within transaction
+	clientIDBytes, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+	policyIDBytes, err := policy.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO client_policies (client_id, policy_id) VALUES (?, ?)`,
+		clientIDBytes,
+		policyIDBytes,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the relationship was not created (rollback worked)
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = ? AND policy_id = ?`,
+		clientIDBytes,
+		policyIDBytes,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestMySQLClientPoliciesRepository_Delete_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	clientRepo := NewMySQLClientRepository(db)
+	policyRepo := NewMySQLPolicyRepository(db)
+	repo := NewMySQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	err = repo.Create(ctx, &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	})
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Delete within transaction
+	clientIDBytes, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+	policyIDBytes, err := policy.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`DELETE FROM client_policies WHERE client_id = ? AND policy_id = ?`,
+		clientIDBytes,
+		policyIDBytes,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the relationship still exists (rollback worked)
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = ? AND policy_id = ?`,
+		clientIDBytes,
+		policyIDBytes,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}

--- a/internal/auth/repository/mysql_client_repository.go
+++ b/internal/auth/repository/mysql_client_repository.go
@@ -1,0 +1,118 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// MySQLClientRepository implements Client persistence for MySQL.
+// Uses BINARY(16) for UUIDs with transaction support via database.GetTx().
+type MySQLClientRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new Client into the MySQL database.
+func (m *MySQLClientRepository) Create(ctx context.Context, client *authDomain.Client) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `INSERT INTO clients (id, secret, name, is_active, created_at) 
+			  VALUES (?, ?, ?, ?, ?)`
+
+	id, err := client.ID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		id,
+		client.Secret,
+		client.Name,
+		client.IsActive,
+		client.CreatedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create client")
+	}
+	return nil
+}
+
+// Update modifies an existing Client in the MySQL database.
+func (m *MySQLClientRepository) Update(ctx context.Context, client *authDomain.Client) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `UPDATE clients 
+			  SET secret = ?, 
+			  	  name = ?,
+				  is_active = ?,
+				  created_at = ?
+			  WHERE id = ?`
+
+	id, err := client.ID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		client.Secret,
+		client.Name,
+		client.IsActive,
+		client.CreatedAt,
+		id,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to update client")
+	}
+
+	return nil
+}
+
+// Get retrieves a Client by ID from the MySQL database.
+func (m *MySQLClientRepository) Get(ctx context.Context, clientID uuid.UUID) (*authDomain.Client, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, secret, name, is_active, created_at FROM clients WHERE id = ?`
+
+	id, err := clientID.MarshalBinary()
+	if err != nil {
+		return nil, apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	var client authDomain.Client
+	var idBytes []byte
+
+	err = querier.QueryRowContext(ctx, query, id).Scan(
+		&idBytes,
+		&client.Secret,
+		&client.Name,
+		&client.IsActive,
+		&client.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrClientNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get client")
+	}
+
+	if err := client.ID.UnmarshalBinary(idBytes); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal client id")
+	}
+
+	return &client, nil
+}
+
+// NewMySQLClientRepository creates a new MySQL Client repository.
+func NewMySQLClientRepository(db *sql.DB) *MySQLClientRepository {
+	return &MySQLClientRepository{db: db}
+}

--- a/internal/auth/repository/mysql_client_repository_test.go
+++ b/internal/auth/repository/mysql_client_repository_test.go
@@ -1,0 +1,399 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewMySQLClientRepository(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &MySQLClientRepository{}, repo)
+}
+
+func TestMySQLClientRepository_Create(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret-hash",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Verify the client was created by retrieving it
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, client.ID, retrievedClient.ID)
+	assert.Equal(t, client.Secret, retrievedClient.Secret)
+	assert.Equal(t, client.Name, retrievedClient.Name)
+	assert.Equal(t, client.IsActive, retrievedClient.IsActive)
+	assert.WithinDuration(t, client.CreatedAt, retrievedClient.CreatedAt, time.Second)
+}
+
+func TestMySQLClientRepository_Create_InactiveClient(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "inactive-secret",
+		Name:      "inactive-client",
+		IsActive:  false,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Verify the client was created with correct is_active status
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+	assert.False(t, retrievedClient.IsActive)
+}
+
+func TestMySQLClientRepository_Create_MultipleClients(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create first client
+	client1 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-1",
+		Name:      "client-1",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second client
+	client2 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-2",
+		Name:      "client-2",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = repo.Create(ctx, client2)
+	require.NoError(t, err)
+
+	// Verify both clients can be retrieved
+	retrievedClient1, err := repo.Get(ctx, client1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client1.ID, retrievedClient1.ID)
+
+	retrievedClient2, err := repo.Get(ctx, client2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client2.ID, retrievedClient2.ID)
+}
+
+func TestMySQLClientRepository_Update(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create initial client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "original-secret",
+		Name:      "original-name",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Update the client
+	client.Secret = "updated-secret"
+	client.Name = "updated-name"
+	client.IsActive = false
+
+	err = repo.Update(ctx, client)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, client.ID, retrievedClient.ID)
+	assert.Equal(t, "updated-secret", retrievedClient.Secret)
+	assert.Equal(t, "updated-name", retrievedClient.Name)
+	assert.False(t, retrievedClient.IsActive)
+}
+
+func TestMySQLClientRepository_Update_NonExistent(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Try to update a non-existent client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret",
+		Name:      "name",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Update should not return an error even if no rows are affected
+	err := repo.Update(ctx, client)
+	assert.NoError(t, err)
+}
+
+func TestMySQLClientRepository_Get_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Retrieve the client
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedClient)
+
+	assert.Equal(t, client.ID, retrievedClient.ID)
+	assert.Equal(t, client.Secret, retrievedClient.Secret)
+	assert.Equal(t, client.Name, retrievedClient.Name)
+	assert.Equal(t, client.IsActive, retrievedClient.IsActive)
+	assert.WithinDuration(t, client.CreatedAt, retrievedClient.CreatedAt, time.Second)
+}
+
+func TestMySQLClientRepository_Get_NotFound(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent client
+	nonExistentID := uuid.Must(uuid.NewV7())
+	client, err := repo.Get(ctx, nonExistentID)
+
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.ErrorIs(t, err, authDomain.ErrClientNotFound)
+}
+
+func TestMySQLClientRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret",
+		Name:      "client-name-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Test rollback behavior using a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Marshal client ID
+	id, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Create client within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO clients (id, secret, name, is_active, created_at) VALUES (?, ?, ?, ?, ?)`,
+		id,
+		client.Secret,
+		client.Name,
+		client.IsActive,
+		client.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the client was not created (rollback worked)
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedClient)
+	assert.ErrorIs(t, err, authDomain.ErrClientNotFound)
+}
+
+func TestMySQLClientRepository_Update_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create initial client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "original-secret",
+		Name:      "original-name-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Marshal client ID
+	id, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Update within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`UPDATE clients SET secret = ?, name = ?, is_active = ?, created_at = ? WHERE id = ?`,
+		"updated-secret",
+		"updated-name",
+		false,
+		client.CreatedAt,
+		id,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the client was not updated (rollback worked)
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "original-secret", retrievedClient.Secret)
+	assert.Equal(t, "original-name-tx", retrievedClient.Name)
+	assert.True(t, retrievedClient.IsActive)
+}
+
+func TestMySQLClientRepository_Get_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create a client outside transaction
+	client1 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-1",
+		Name:      "client-1-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another client inside transaction
+	time.Sleep(time.Millisecond)
+	client2 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-2",
+		Name:      "client-2-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Marshal client ID
+	id2, err := client2.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO clients (id, secret, name, is_active, created_at) VALUES (?, ?, ?, ?, ?)`,
+		id2,
+		client2.Secret,
+		client2.Name,
+		client2.IsActive,
+		client2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see both clients
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM clients`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Get outside transaction should also see both clients
+	retrievedClient1, err := repo.Get(ctx, client1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client1.ID, retrievedClient1.ID)
+
+	retrievedClient2, err := repo.Get(ctx, client2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client2.ID, retrievedClient2.ID)
+}

--- a/internal/auth/repository/mysql_policy_repository.go
+++ b/internal/auth/repository/mysql_policy_repository.go
@@ -1,0 +1,139 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// MySQLPolicyRepository implements Policy persistence for MySQL.
+// Uses BINARY(16) for UUIDs with transaction support via database.GetTx().
+type MySQLPolicyRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new Policy into the MySQL database.
+func (m *MySQLPolicyRepository) Create(ctx context.Context, policy *authDomain.Policy) error {
+	querier := database.GetTx(ctx, m.db)
+
+	documentJSON, err := json.Marshal(policy.Document)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy document")
+	}
+
+	query := `INSERT INTO policies (id, name, document, created_at) 
+			  VALUES (?, ?, ?, ?)`
+
+	id, err := policy.ID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy id")
+	}
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		id,
+		policy.Name,
+		documentJSON,
+		policy.CreatedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create policy")
+	}
+	return nil
+}
+
+// Update modifies an existing Policy in the MySQL database.
+func (m *MySQLPolicyRepository) Update(ctx context.Context, policy *authDomain.Policy) error {
+	querier := database.GetTx(ctx, m.db)
+
+	documentJSON, err := json.Marshal(policy.Document)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy document")
+	}
+
+	query := `UPDATE policies 
+			  SET document = ?, 
+			  	  created_at = ?
+			  WHERE name = ?`
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		documentJSON,
+		policy.CreatedAt,
+		policy.Name,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to update policy")
+	}
+
+	return nil
+}
+
+// Get retrieves a Policy by name from the MySQL database.
+func (m *MySQLPolicyRepository) Get(ctx context.Context, name string) (*authDomain.Policy, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, name, document, created_at FROM policies WHERE name = ?`
+
+	var policy authDomain.Policy
+	var idBytes []byte
+	var documentJSON []byte
+
+	err := querier.QueryRowContext(ctx, query, name).Scan(
+		&idBytes,
+		&policy.Name,
+		&documentJSON,
+		&policy.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrPolicyNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get policy")
+	}
+
+	if err := policy.ID.UnmarshalBinary(idBytes); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal policy id")
+	}
+
+	if err := json.Unmarshal(documentJSON, &policy.Document); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal policy document")
+	}
+
+	return &policy, nil
+}
+
+// Delete removes a Policy by name from the MySQL database.
+func (m *MySQLPolicyRepository) Delete(ctx context.Context, name string) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `DELETE FROM policies WHERE name = ?`
+
+	result, err := querier.ExecContext(ctx, query, name)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to delete policy")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return authDomain.ErrPolicyNotFound
+	}
+
+	return nil
+}
+
+// NewMySQLPolicyRepository creates a new MySQL Policy repository.
+func NewMySQLPolicyRepository(db *sql.DB) *MySQLPolicyRepository {
+	return &MySQLPolicyRepository{db: db}
+}

--- a/internal/auth/repository/mysql_policy_repository_test.go
+++ b/internal/auth/repository/mysql_policy_repository_test.go
@@ -1,0 +1,458 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewMySQLPolicyRepository(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &MySQLPolicyRepository{}, repo)
+}
+
+func TestMySQLPolicyRepository_Create(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read", "write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify the policy was created by retrieving it
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+
+	assert.Equal(t, policy.ID, retrievedPolicy.ID)
+	assert.Equal(t, policy.Name, retrievedPolicy.Name)
+	assert.Equal(t, policy.Document.Path, retrievedPolicy.Document.Path)
+	assert.Equal(t, policy.Document.Capabilities, retrievedPolicy.Document.Capabilities)
+	assert.WithinDuration(t, policy.CreatedAt, retrievedPolicy.CreatedAt, time.Second)
+}
+
+func TestMySQLPolicyRepository_Create_WithComplexDocument(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "admin-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/admin/*",
+			Capabilities: []string{"read", "write", "delete", "list"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify the policy was created with all capabilities
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 4, len(retrievedPolicy.Document.Capabilities))
+	assert.Contains(t, retrievedPolicy.Document.Capabilities, "delete")
+	assert.Contains(t, retrievedPolicy.Document.Capabilities, "list")
+}
+
+func TestMySQLPolicyRepository_Create_MultiplePolicies(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create first policy
+	policy1 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-1",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app1/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second policy
+	policy2 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-2",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app2/*",
+			Capabilities: []string{"write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = repo.Create(ctx, policy2)
+	require.NoError(t, err)
+
+	// Verify both policies can be retrieved
+	retrievedPolicy1, err := repo.Get(ctx, policy1.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy1.Name, retrievedPolicy1.Name)
+
+	retrievedPolicy2, err := repo.Get(ctx, policy2.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy2.Name, retrievedPolicy2.Name)
+}
+
+func TestMySQLPolicyRepository_Update(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create initial policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "update-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/original/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Update the policy
+	policy.Document.Path = "/updated/*"
+	policy.Document.Capabilities = []string{"read", "write", "delete"}
+
+	err = repo.Update(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+
+	assert.Equal(t, policy.Name, retrievedPolicy.Name)
+	assert.Equal(t, "/updated/*", retrievedPolicy.Document.Path)
+	assert.Equal(t, 3, len(retrievedPolicy.Document.Capabilities))
+	assert.Contains(t, retrievedPolicy.Document.Capabilities, "delete")
+}
+
+func TestMySQLPolicyRepository_Update_NonExistent(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Try to update a non-existent policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "non-existent-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/test/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Update should not return an error even if no rows are affected
+	err := repo.Update(ctx, policy)
+	assert.NoError(t, err)
+}
+
+func TestMySQLPolicyRepository_Get_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "get-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/api/*",
+			Capabilities: []string{"read", "write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Retrieve the policy
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedPolicy)
+
+	assert.Equal(t, policy.ID, retrievedPolicy.ID)
+	assert.Equal(t, policy.Name, retrievedPolicy.Name)
+	assert.Equal(t, policy.Document.Path, retrievedPolicy.Document.Path)
+	assert.Equal(t, policy.Document.Capabilities, retrievedPolicy.Document.Capabilities)
+	assert.WithinDuration(t, policy.CreatedAt, retrievedPolicy.CreatedAt, time.Second)
+}
+
+func TestMySQLPolicyRepository_Get_NotFound(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent policy
+	policy, err := repo.Get(ctx, "non-existent-policy")
+
+	assert.Error(t, err)
+	assert.Nil(t, policy)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestMySQLPolicyRepository_Delete_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "delete-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/temp/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Delete the policy
+	err = repo.Delete(ctx, policy.Name)
+	require.NoError(t, err)
+
+	// Verify the policy was deleted
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedPolicy)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestMySQLPolicyRepository_Delete_NonExistent(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Try to delete a non-existent policy
+	err := repo.Delete(ctx, "non-existent-policy")
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestMySQLPolicyRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "tx-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/tx/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Test rollback behavior using a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	id, err := policy.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Create policy within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO policies (id, name, document, created_at) VALUES (?, ?, ?, ?)`,
+		id,
+		policy.Name,
+		`{"path":"/tx/*","capabilities":["read"]}`,
+		policy.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the policy was not created (rollback worked)
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedPolicy)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestMySQLPolicyRepository_Update_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create initial policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "tx-update-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/original/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Update within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`UPDATE policies SET document = ?, created_at = ? WHERE name = ?`,
+		`{"path":"/updated/*","capabilities":["read","write"]}`,
+		policy.CreatedAt,
+		policy.Name,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the policy was not updated (rollback worked)
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "/original/*", retrievedPolicy.Document.Path)
+	assert.Equal(t, 1, len(retrievedPolicy.Document.Capabilities))
+}
+
+func TestMySQLPolicyRepository_Get_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a policy outside transaction
+	policy1 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-outside-tx",
+		Document: authDomain.PolicyDocument{
+			Path:         "/outside/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another policy inside transaction
+	time.Sleep(time.Millisecond)
+	policy2 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-inside-tx",
+		Document: authDomain.PolicyDocument{
+			Path:         "/inside/*",
+			Capabilities: []string{"write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	id, err := policy2.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO policies (id, name, document, created_at) VALUES (?, ?, ?, ?)`,
+		id,
+		policy2.Name,
+		`{"path":"/inside/*","capabilities":["write"]}`,
+		policy2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see both policies
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM policies`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Get outside transaction should also see both policies
+	retrievedPolicy1, err := repo.Get(ctx, policy1.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy1.Name, retrievedPolicy1.Name)
+
+	retrievedPolicy2, err := repo.Get(ctx, policy2.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy2.Name, retrievedPolicy2.Name)
+}

--- a/internal/auth/repository/mysql_token_repository.go
+++ b/internal/auth/repository/mysql_token_repository.go
@@ -1,0 +1,138 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// MySQLTokenRepository implements Token persistence for MySQL.
+// Uses BINARY(16) for UUIDs with transaction support via database.GetTx().
+type MySQLTokenRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new Token into the MySQL database.
+func (m *MySQLTokenRepository) Create(ctx context.Context, token *authDomain.Token) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+			  VALUES (?, ?, ?, ?, ?, ?)`
+
+	id, err := token.ID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal token id")
+	}
+
+	clientID, err := token.ClientID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		id,
+		token.TokenHash,
+		clientID,
+		token.ExpiresAt,
+		token.RevokedAt,
+		token.CreatedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create token")
+	}
+	return nil
+}
+
+// Update modifies an existing Token in the MySQL database.
+func (m *MySQLTokenRepository) Update(ctx context.Context, token *authDomain.Token) error {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `UPDATE tokens 
+			  SET token_hash = ?, 
+			  	  client_id = ?,
+				  expires_at = ?,
+				  revoked_at = ?,
+				  created_at = ?
+			  WHERE id = ?`
+
+	id, err := token.ID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal token id")
+	}
+
+	clientID, err := token.ClientID.MarshalBinary()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal client id")
+	}
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		token.TokenHash,
+		clientID,
+		token.ExpiresAt,
+		token.RevokedAt,
+		token.CreatedAt,
+		id,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to update token")
+	}
+
+	return nil
+}
+
+// Get retrieves a Token by ID from the MySQL database.
+func (m *MySQLTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, token_hash, client_id, expires_at, revoked_at, created_at 
+			  FROM tokens WHERE id = ?`
+
+	id, err := tokenID.MarshalBinary()
+	if err != nil {
+		return nil, apperrors.Wrap(err, "failed to marshal token id")
+	}
+
+	var token authDomain.Token
+	var idBytes []byte
+	var clientIDBytes []byte
+
+	err = querier.QueryRowContext(ctx, query, id).Scan(
+		&idBytes,
+		&token.TokenHash,
+		&clientIDBytes,
+		&token.ExpiresAt,
+		&token.RevokedAt,
+		&token.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrTokenNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get token")
+	}
+
+	if err := token.ID.UnmarshalBinary(idBytes); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal token id")
+	}
+
+	if err := token.ClientID.UnmarshalBinary(clientIDBytes); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal client id")
+	}
+
+	return &token, nil
+}
+
+// NewMySQLTokenRepository creates a new MySQL Token repository.
+func NewMySQLTokenRepository(db *sql.DB) *MySQLTokenRepository {
+	return &MySQLTokenRepository{db: db}
+}

--- a/internal/auth/repository/mysql_token_repository_test.go
+++ b/internal/auth/repository/mysql_token_repository_test.go
@@ -1,0 +1,554 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewMySQLTokenRepository(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewMySQLTokenRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &MySQLTokenRepository{}, repo)
+}
+
+func TestMySQLTokenRepository_Create(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Now create a token
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "test-token-hash-mysql-1",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Verify the token was created by retrieving it
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	assert.WithinDuration(t, token.ExpiresAt, retrievedToken.ExpiresAt, time.Second)
+	assert.Nil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, token.CreatedAt, retrievedToken.CreatedAt, time.Second)
+}
+
+func TestMySQLTokenRepository_Create_WithRevokedAt(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-revoked-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a revoked token
+	tokenRepo := NewMySQLTokenRepository(db)
+	revokedAt := time.Now().UTC()
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "revoked-token-hash-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: &revokedAt,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Verify the token was created with revoked_at set
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, revokedAt, *retrievedToken.RevokedAt, time.Second)
+}
+
+func TestMySQLTokenRepository_Create_MultipleTokens(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-multiple-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	// Create first token
+	token1 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-mysql-1",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second token
+	token2 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-mysql-2",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(48 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token2)
+	require.NoError(t, err)
+
+	// Verify both tokens can be retrieved
+	retrievedToken1, err := tokenRepo.Get(ctx, token1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token1.ID, retrievedToken1.ID)
+
+	retrievedToken2, err := tokenRepo.Get(ctx, token2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token2.ID, retrievedToken2.ID)
+}
+
+func TestMySQLTokenRepository_Update(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-update-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create initial token
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "original-hash-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Update the token (revoke it)
+	revokedAt := time.Now().UTC()
+	token.RevokedAt = &revokedAt
+	token.TokenHash = "updated-hash-mysql"
+
+	err = tokenRepo.Update(ctx, token)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, "updated-hash-mysql", retrievedToken.TokenHash)
+	require.NotNil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, revokedAt, *retrievedToken.RevokedAt, time.Second)
+}
+
+func TestMySQLTokenRepository_Update_NonExistent(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-nonexist-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	// Try to update a non-existent token
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "hash-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Update should not return an error even if no rows are affected
+	err = tokenRepo.Update(ctx, token)
+	assert.NoError(t, err)
+}
+
+func TestMySQLTokenRepository_Get_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a token
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "get-test-hash-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Retrieve the token
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	assert.WithinDuration(t, token.ExpiresAt, retrievedToken.ExpiresAt, time.Second)
+	assert.Nil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, token.CreatedAt, retrievedToken.CreatedAt, time.Second)
+}
+
+func TestMySQLTokenRepository_Get_NotFound(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent token
+	nonExistentID := uuid.Must(uuid.NewV7())
+	token, err := tokenRepo.Get(ctx, nonExistentID)
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}
+
+func TestMySQLTokenRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-tx-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "tx-test-hash-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Test rollback behavior using a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Marshal UUIDs
+	id, err := token.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	clientID, err := token.ClientID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Create token within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id,
+		token.TokenHash,
+		clientID,
+		token.ExpiresAt,
+		token.RevokedAt,
+		token.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the token was not created (rollback worked)
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedToken)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}
+
+func TestMySQLTokenRepository_Update_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-update-tx-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create initial token
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "original-hash-tx-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	revokedAt := time.Now().UTC()
+
+	// Marshal UUIDs
+	id, err := token.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	clientID, err := token.ClientID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Update within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`UPDATE tokens SET token_hash = ?, client_id = ?, expires_at = ?, revoked_at = ?, 
+		 created_at = ? WHERE id = ?`,
+		"updated-hash-tx-mysql",
+		clientID,
+		token.ExpiresAt,
+		revokedAt,
+		token.CreatedAt,
+		id,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the token was not updated (rollback worked)
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "original-hash-tx-mysql", retrievedToken.TokenHash)
+	assert.Nil(t, retrievedToken.RevokedAt)
+}
+
+func TestMySQLTokenRepository_Get_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get-tx-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	// Create a token outside transaction
+	token1 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-1-tx-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another token inside transaction
+	time.Sleep(time.Millisecond)
+	token2 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-2-tx-mysql",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(48 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Marshal UUIDs
+	id2, err := token2.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	clientID, err := token2.ClientID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id2,
+		token2.TokenHash,
+		clientID,
+		token2.ExpiresAt,
+		token2.RevokedAt,
+		token2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Marshal client ID for query
+	clientIDQuery, err := client.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	// Query within transaction should see both tokens
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM tokens WHERE client_id = ?`, clientIDQuery).
+		Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Get outside transaction should also see both tokens
+	retrievedToken1, err := tokenRepo.Get(ctx, token1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token1.ID, retrievedToken1.ID)
+
+	retrievedToken2, err := tokenRepo.Get(ctx, token2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token2.ID, retrievedToken2.ID)
+}

--- a/internal/auth/repository/postgresql_client_policies_repository.go
+++ b/internal/auth/repository/postgresql_client_policies_repository.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// PostgreSQLClientPoliciesRepository implements ClientPolicies persistence for PostgreSQL.
+// Uses native UUID types with transaction support via database.GetTx().
+type PostgreSQLClientPoliciesRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new ClientPolicies relationship into the PostgreSQL database.
+func (p *PostgreSQLClientPoliciesRepository) Create(
+	ctx context.Context,
+	clientPolicies *authDomain.ClientPolicies,
+) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `INSERT INTO client_policies (client_id, policy_id) VALUES ($1, $2)`
+
+	_, err := querier.ExecContext(ctx, query, clientPolicies.ClientID, clientPolicies.PolicyID)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create client policies")
+	}
+	return nil
+}
+
+// Delete removes a ClientPolicies relationship from the PostgreSQL database.
+func (p *PostgreSQLClientPoliciesRepository) Delete(
+	ctx context.Context,
+	clientID uuid.UUID,
+	policyID uuid.UUID,
+) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `DELETE FROM client_policies WHERE client_id = $1 AND policy_id = $2`
+
+	result, err := querier.ExecContext(ctx, query, clientID, policyID)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to delete client policies")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return authDomain.ErrClientPoliciesNotFound
+	}
+
+	return nil
+}
+
+// NewPostgreSQLClientPoliciesRepository creates a new PostgreSQL ClientPolicies repository.
+func NewPostgreSQLClientPoliciesRepository(db *sql.DB) *PostgreSQLClientPoliciesRepository {
+	return &PostgreSQLClientPoliciesRepository{db: db}
+}

--- a/internal/auth/repository/postgresql_client_policies_repository_test.go
+++ b/internal/auth/repository/postgresql_client_policies_repository_test.go
@@ -1,0 +1,485 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewPostgreSQLClientPoliciesRepository(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &PostgreSQLClientPoliciesRepository{}, repo)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Create(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	require.NoError(t, err)
+
+	// Verify the relationship was created by querying the database
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = $1 AND policy_id = $2`,
+		client.ID,
+		policy.ID,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Create_Duplicate(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	require.NoError(t, err)
+
+	// Try to create the same relationship again - should fail
+	err = repo.Create(ctx, clientPolicies)
+	assert.Error(t, err)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Create_InvalidClientID(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err := policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Try to create a relationship with a non-existent client ID
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: uuid.Must(uuid.NewV7()),
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	assert.Error(t, err)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Create_InvalidPolicyID(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Try to create a relationship with a non-existent policy ID
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: uuid.Must(uuid.NewV7()),
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	assert.Error(t, err)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Create_MultiplePoliciesToOneClient(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create first policy
+	policy1 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-1",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app1/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second policy
+	policy2 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-2",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app2/*",
+			Capabilities: []string{"write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy2)
+	require.NoError(t, err)
+
+	// Attach both policies to the same client
+	err = repo.Create(ctx, &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy1.ID,
+	})
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy2.ID,
+	})
+	require.NoError(t, err)
+
+	// Verify both relationships exist
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = $1`,
+		client.ID,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Delete_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	clientPolicies := &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	}
+
+	err = repo.Create(ctx, clientPolicies)
+	require.NoError(t, err)
+
+	// Delete the relationship
+	err = repo.Delete(ctx, client.ID, policy.ID)
+	require.NoError(t, err)
+
+	// Verify the relationship was deleted
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = $1 AND policy_id = $2`,
+		client.ID,
+		policy.ID,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Delete_NonExistent(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Try to delete a non-existent relationship
+	clientID := uuid.Must(uuid.NewV7())
+	policyID := uuid.Must(uuid.NewV7())
+
+	err := repo.Delete(ctx, clientID, policyID)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, authDomain.ErrClientPoliciesNotFound)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create relationship within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO client_policies (client_id, policy_id) VALUES ($1, $2)`,
+		client.ID,
+		policy.ID,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the relationship was not created (rollback worked)
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = $1 AND policy_id = $2`,
+		client.ID,
+		policy.ID,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestPostgreSQLClientPoliciesRepository_Delete_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	clientRepo := NewPostgreSQLClientRepository(db)
+	policyRepo := NewPostgreSQLPolicyRepository(db)
+	repo := NewPostgreSQLClientPoliciesRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	err = policyRepo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Create the client-policy relationship
+	err = repo.Create(ctx, &authDomain.ClientPolicies{
+		ClientID: client.ID,
+		PolicyID: policy.ID,
+	})
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Delete within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`DELETE FROM client_policies WHERE client_id = $1 AND policy_id = $2`,
+		client.ID,
+		policy.ID,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the relationship still exists (rollback worked)
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM client_policies WHERE client_id = $1 AND policy_id = $2`,
+		client.ID,
+		policy.ID,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}

--- a/internal/auth/repository/postgresql_client_repository.go
+++ b/internal/auth/repository/postgresql_client_repository.go
@@ -1,0 +1,105 @@
+// Package repository implements data persistence for authentication and authorization entities.
+//
+// Provides PostgreSQL and MySQL implementations with transaction support via database.GetTx().
+// PostgreSQL uses native UUID types, MySQL uses BINARY(16) types.
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// PostgreSQLClientRepository implements Client persistence for PostgreSQL.
+// Uses native UUID types with transaction support via database.GetTx().
+type PostgreSQLClientRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new Client into the PostgreSQL database.
+func (p *PostgreSQLClientRepository) Create(ctx context.Context, client *authDomain.Client) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `INSERT INTO clients (id, secret, name, is_active, created_at) 
+			  VALUES ($1, $2, $3, $4, $5)`
+
+	_, err := querier.ExecContext(
+		ctx,
+		query,
+		client.ID,
+		client.Secret,
+		client.Name,
+		client.IsActive,
+		client.CreatedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create client")
+	}
+	return nil
+}
+
+// Update modifies an existing Client in the PostgreSQL database.
+func (p *PostgreSQLClientRepository) Update(ctx context.Context, client *authDomain.Client) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `UPDATE clients 
+			  SET secret = $1, 
+			  	  name = $2,
+				  is_active = $3,
+				  created_at = $4
+			  WHERE id = $5`
+
+	_, err := querier.ExecContext(
+		ctx,
+		query,
+		client.Secret,
+		client.Name,
+		client.IsActive,
+		client.CreatedAt,
+		client.ID,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to update client")
+	}
+
+	return nil
+}
+
+// Get retrieves a Client by ID from the PostgreSQL database.
+func (p *PostgreSQLClientRepository) Get(
+	ctx context.Context,
+	clientID uuid.UUID,
+) (*authDomain.Client, error) {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `SELECT id, secret, name, is_active, created_at FROM clients WHERE id = $1`
+
+	var client authDomain.Client
+
+	err := querier.QueryRowContext(ctx, query, clientID).Scan(
+		&client.ID,
+		&client.Secret,
+		&client.Name,
+		&client.IsActive,
+		&client.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrClientNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get client")
+	}
+
+	return &client, nil
+}
+
+// NewPostgreSQLClientRepository creates a new PostgreSQL Client repository.
+func NewPostgreSQLClientRepository(db *sql.DB) *PostgreSQLClientRepository {
+	return &PostgreSQLClientRepository{db: db}
+}

--- a/internal/auth/repository/postgresql_client_repository_test.go
+++ b/internal/auth/repository/postgresql_client_repository_test.go
@@ -1,0 +1,387 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewPostgreSQLClientRepository(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &PostgreSQLClientRepository{}, repo)
+}
+
+func TestPostgreSQLClientRepository_Create(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret-hash",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Verify the client was created by retrieving it
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, client.ID, retrievedClient.ID)
+	assert.Equal(t, client.Secret, retrievedClient.Secret)
+	assert.Equal(t, client.Name, retrievedClient.Name)
+	assert.Equal(t, client.IsActive, retrievedClient.IsActive)
+	assert.WithinDuration(t, client.CreatedAt, retrievedClient.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLClientRepository_Create_InactiveClient(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "inactive-secret",
+		Name:      "inactive-client",
+		IsActive:  false,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Verify the client was created with correct is_active status
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+	assert.False(t, retrievedClient.IsActive)
+}
+
+func TestPostgreSQLClientRepository_Create_MultipleClients(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create first client
+	client1 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-1",
+		Name:      "client-1",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second client
+	client2 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-2",
+		Name:      "client-2",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = repo.Create(ctx, client2)
+	require.NoError(t, err)
+
+	// Verify both clients can be retrieved
+	retrievedClient1, err := repo.Get(ctx, client1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client1.ID, retrievedClient1.ID)
+
+	retrievedClient2, err := repo.Get(ctx, client2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client2.ID, retrievedClient2.ID)
+}
+
+func TestPostgreSQLClientRepository_Update(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create initial client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "original-secret",
+		Name:      "original-name",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Update the client
+	client.Secret = "updated-secret"
+	client.Name = "updated-name"
+	client.IsActive = false
+
+	err = repo.Update(ctx, client)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, client.ID, retrievedClient.ID)
+	assert.Equal(t, "updated-secret", retrievedClient.Secret)
+	assert.Equal(t, "updated-name", retrievedClient.Name)
+	assert.False(t, retrievedClient.IsActive)
+}
+
+func TestPostgreSQLClientRepository_Update_NonExistent(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Try to update a non-existent client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret",
+		Name:      "name",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Update should not return an error even if no rows are affected
+	err := repo.Update(ctx, client)
+	assert.NoError(t, err)
+}
+
+func TestPostgreSQLClientRepository_Get_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create a client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Retrieve the client
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedClient)
+
+	assert.Equal(t, client.ID, retrievedClient.ID)
+	assert.Equal(t, client.Secret, retrievedClient.Secret)
+	assert.Equal(t, client.Name, retrievedClient.Name)
+	assert.Equal(t, client.IsActive, retrievedClient.IsActive)
+	assert.WithinDuration(t, client.CreatedAt, retrievedClient.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLClientRepository_Get_NotFound(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent client
+	nonExistentID := uuid.Must(uuid.NewV7())
+	client, err := repo.Get(ctx, nonExistentID)
+
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.ErrorIs(t, err, authDomain.ErrClientNotFound)
+}
+
+func TestPostgreSQLClientRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret",
+		Name:      "client-name",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Test rollback behavior using a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create client within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO clients (id, secret, name, is_active, created_at) VALUES ($1, $2, $3, $4, $5)`,
+		client.ID,
+		client.Secret,
+		client.Name,
+		client.IsActive,
+		client.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the client was not created (rollback worked)
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedClient)
+	assert.ErrorIs(t, err, authDomain.ErrClientNotFound)
+}
+
+func TestPostgreSQLClientRepository_Update_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create initial client
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "original-secret",
+		Name:      "original-name",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Update within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`UPDATE clients SET secret = $1, name = $2, is_active = $3, created_at = $4 WHERE id = $5`,
+		"updated-secret",
+		"updated-name",
+		false,
+		client.CreatedAt,
+		client.ID,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the client was not updated (rollback worked)
+	retrievedClient, err := repo.Get(ctx, client.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "original-secret", retrievedClient.Secret)
+	assert.Equal(t, "original-name", retrievedClient.Name)
+	assert.True(t, retrievedClient.IsActive)
+}
+
+func TestPostgreSQLClientRepository_Get_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create a client outside transaction
+	client1 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-1",
+		Name:      "client-1",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another client inside transaction
+	time.Sleep(time.Millisecond)
+	client2 := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "secret-2",
+		Name:      "client-2",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO clients (id, secret, name, is_active, created_at) VALUES ($1, $2, $3, $4, $5)`,
+		client2.ID,
+		client2.Secret,
+		client2.Name,
+		client2.IsActive,
+		client2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see both clients
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM clients`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Get outside transaction should also see both clients
+	retrievedClient1, err := repo.Get(ctx, client1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client1.ID, retrievedClient1.ID)
+
+	retrievedClient2, err := repo.Get(ctx, client2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, client2.ID, retrievedClient2.ID)
+}

--- a/internal/auth/repository/postgresql_policy_repository.go
+++ b/internal/auth/repository/postgresql_policy_repository.go
@@ -1,0 +1,129 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// PostgreSQLPolicyRepository implements Policy persistence for PostgreSQL.
+// Uses native UUID types with transaction support via database.GetTx().
+type PostgreSQLPolicyRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new Policy into the PostgreSQL database.
+func (p *PostgreSQLPolicyRepository) Create(ctx context.Context, policy *authDomain.Policy) error {
+	querier := database.GetTx(ctx, p.db)
+
+	documentJSON, err := json.Marshal(policy.Document)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy document")
+	}
+
+	query := `INSERT INTO policies (id, name, document, created_at) 
+			  VALUES ($1, $2, $3, $4)`
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		policy.ID,
+		policy.Name,
+		documentJSON,
+		policy.CreatedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create policy")
+	}
+	return nil
+}
+
+// Update modifies an existing Policy in the PostgreSQL database.
+func (p *PostgreSQLPolicyRepository) Update(ctx context.Context, policy *authDomain.Policy) error {
+	querier := database.GetTx(ctx, p.db)
+
+	documentJSON, err := json.Marshal(policy.Document)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to marshal policy document")
+	}
+
+	query := `UPDATE policies 
+			  SET document = $1, 
+			  	  created_at = $2
+			  WHERE name = $3`
+
+	_, err = querier.ExecContext(
+		ctx,
+		query,
+		documentJSON,
+		policy.CreatedAt,
+		policy.Name,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to update policy")
+	}
+
+	return nil
+}
+
+// Get retrieves a Policy by name from the PostgreSQL database.
+func (p *PostgreSQLPolicyRepository) Get(ctx context.Context, name string) (*authDomain.Policy, error) {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `SELECT id, name, document, created_at FROM policies WHERE name = $1`
+
+	var policy authDomain.Policy
+	var documentJSON []byte
+
+	err := querier.QueryRowContext(ctx, query, name).Scan(
+		&policy.ID,
+		&policy.Name,
+		&documentJSON,
+		&policy.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrPolicyNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get policy")
+	}
+
+	if err := json.Unmarshal(documentJSON, &policy.Document); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal policy document")
+	}
+
+	return &policy, nil
+}
+
+// Delete removes a Policy by name from the PostgreSQL database.
+func (p *PostgreSQLPolicyRepository) Delete(ctx context.Context, name string) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `DELETE FROM policies WHERE name = $1`
+
+	result, err := querier.ExecContext(ctx, query, name)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to delete policy")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return apperrors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return authDomain.ErrPolicyNotFound
+	}
+
+	return nil
+}
+
+// NewPostgreSQLPolicyRepository creates a new PostgreSQL Policy repository.
+func NewPostgreSQLPolicyRepository(db *sql.DB) *PostgreSQLPolicyRepository {
+	return &PostgreSQLPolicyRepository{db: db}
+}

--- a/internal/auth/repository/postgresql_policy_repository_test.go
+++ b/internal/auth/repository/postgresql_policy_repository_test.go
@@ -1,0 +1,452 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewPostgreSQLPolicyRepository(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &PostgreSQLPolicyRepository{}, repo)
+}
+
+func TestPostgreSQLPolicyRepository_Create(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/*",
+			Capabilities: []string{"read", "write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify the policy was created by retrieving it
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+
+	assert.Equal(t, policy.ID, retrievedPolicy.ID)
+	assert.Equal(t, policy.Name, retrievedPolicy.Name)
+	assert.Equal(t, policy.Document.Path, retrievedPolicy.Document.Path)
+	assert.Equal(t, policy.Document.Capabilities, retrievedPolicy.Document.Capabilities)
+	assert.WithinDuration(t, policy.CreatedAt, retrievedPolicy.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLPolicyRepository_Create_WithComplexDocument(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "admin-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/admin/*",
+			Capabilities: []string{"read", "write", "delete", "list"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify the policy was created with all capabilities
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 4, len(retrievedPolicy.Document.Capabilities))
+	assert.Contains(t, retrievedPolicy.Document.Capabilities, "delete")
+	assert.Contains(t, retrievedPolicy.Document.Capabilities, "list")
+}
+
+func TestPostgreSQLPolicyRepository_Create_MultiplePolicies(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create first policy
+	policy1 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-1",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app1/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second policy
+	policy2 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-2",
+		Document: authDomain.PolicyDocument{
+			Path:         "/secrets/app2/*",
+			Capabilities: []string{"write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = repo.Create(ctx, policy2)
+	require.NoError(t, err)
+
+	// Verify both policies can be retrieved
+	retrievedPolicy1, err := repo.Get(ctx, policy1.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy1.Name, retrievedPolicy1.Name)
+
+	retrievedPolicy2, err := repo.Get(ctx, policy2.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy2.Name, retrievedPolicy2.Name)
+}
+
+func TestPostgreSQLPolicyRepository_Update(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create initial policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "update-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/original/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Update the policy
+	policy.Document.Path = "/updated/*"
+	policy.Document.Capabilities = []string{"read", "write", "delete"}
+
+	err = repo.Update(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+
+	assert.Equal(t, policy.Name, retrievedPolicy.Name)
+	assert.Equal(t, "/updated/*", retrievedPolicy.Document.Path)
+	assert.Equal(t, 3, len(retrievedPolicy.Document.Capabilities))
+	assert.Contains(t, retrievedPolicy.Document.Capabilities, "delete")
+}
+
+func TestPostgreSQLPolicyRepository_Update_NonExistent(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Try to update a non-existent policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "non-existent-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/test/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Update should not return an error even if no rows are affected
+	err := repo.Update(ctx, policy)
+	assert.NoError(t, err)
+}
+
+func TestPostgreSQLPolicyRepository_Get_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "get-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/api/*",
+			Capabilities: []string{"read", "write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Retrieve the policy
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedPolicy)
+
+	assert.Equal(t, policy.ID, retrievedPolicy.ID)
+	assert.Equal(t, policy.Name, retrievedPolicy.Name)
+	assert.Equal(t, policy.Document.Path, retrievedPolicy.Document.Path)
+	assert.Equal(t, policy.Document.Capabilities, retrievedPolicy.Document.Capabilities)
+	assert.WithinDuration(t, policy.CreatedAt, retrievedPolicy.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLPolicyRepository_Get_NotFound(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent policy
+	policy, err := repo.Get(ctx, "non-existent-policy")
+
+	assert.Error(t, err)
+	assert.Nil(t, policy)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestPostgreSQLPolicyRepository_Delete_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "delete-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/temp/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Delete the policy
+	err = repo.Delete(ctx, policy.Name)
+	require.NoError(t, err)
+
+	// Verify the policy was deleted
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedPolicy)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestPostgreSQLPolicyRepository_Delete_NonExistent(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Try to delete a non-existent policy
+	err := repo.Delete(ctx, "non-existent-policy")
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestPostgreSQLPolicyRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "tx-test-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/tx/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Test rollback behavior using a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create policy within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO policies (id, name, document, created_at) VALUES ($1, $2, $3, $4)`,
+		policy.ID,
+		policy.Name,
+		`{"path":"/tx/*","capabilities":["read"]}`,
+		policy.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the policy was not created (rollback worked)
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedPolicy)
+	assert.ErrorIs(t, err, authDomain.ErrPolicyNotFound)
+}
+
+func TestPostgreSQLPolicyRepository_Update_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create initial policy
+	policy := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "tx-update-policy",
+		Document: authDomain.PolicyDocument{
+			Path:         "/original/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Update within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`UPDATE policies SET document = $1, created_at = $2 WHERE name = $3`,
+		`{"path":"/updated/*","capabilities":["read","write"]}`,
+		policy.CreatedAt,
+		policy.Name,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the policy was not updated (rollback worked)
+	retrievedPolicy, err := repo.Get(ctx, policy.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "/original/*", retrievedPolicy.Document.Path)
+	assert.Equal(t, 1, len(retrievedPolicy.Document.Capabilities))
+}
+
+func TestPostgreSQLPolicyRepository_Get_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	repo := NewPostgreSQLPolicyRepository(db)
+	ctx := context.Background()
+
+	// Create a policy outside transaction
+	policy1 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-outside-tx",
+		Document: authDomain.PolicyDocument{
+			Path:         "/outside/*",
+			Capabilities: []string{"read"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, policy1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another policy inside transaction
+	time.Sleep(time.Millisecond)
+	policy2 := &authDomain.Policy{
+		ID:   uuid.Must(uuid.NewV7()),
+		Name: "policy-inside-tx",
+		Document: authDomain.PolicyDocument{
+			Path:         "/inside/*",
+			Capabilities: []string{"write"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO policies (id, name, document, created_at) VALUES ($1, $2, $3, $4)`,
+		policy2.ID,
+		policy2.Name,
+		`{"path":"/inside/*","capabilities":["write"]}`,
+		policy2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see both policies
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM policies`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Get outside transaction should also see both policies
+	retrievedPolicy1, err := repo.Get(ctx, policy1.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy1.Name, retrievedPolicy1.Name)
+
+	retrievedPolicy2, err := repo.Get(ctx, policy2.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy2.Name, retrievedPolicy2.Name)
+}

--- a/internal/auth/repository/postgresql_token_repository.go
+++ b/internal/auth/repository/postgresql_token_repository.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/database"
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// PostgreSQLTokenRepository implements Token persistence for PostgreSQL.
+// Uses native UUID types with transaction support via database.GetTx().
+type PostgreSQLTokenRepository struct {
+	db *sql.DB
+}
+
+// Create inserts a new Token into the PostgreSQL database.
+func (p *PostgreSQLTokenRepository) Create(ctx context.Context, token *authDomain.Token) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+			  VALUES ($1, $2, $3, $4, $5, $6)`
+
+	_, err := querier.ExecContext(
+		ctx,
+		query,
+		token.ID,
+		token.TokenHash,
+		token.ClientID,
+		token.ExpiresAt,
+		token.RevokedAt,
+		token.CreatedAt,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to create token")
+	}
+	return nil
+}
+
+// Update modifies an existing Token in the PostgreSQL database.
+func (p *PostgreSQLTokenRepository) Update(ctx context.Context, token *authDomain.Token) error {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `UPDATE tokens 
+			  SET token_hash = $1, 
+			  	  client_id = $2,
+				  expires_at = $3,
+				  revoked_at = $4,
+				  created_at = $5
+			  WHERE id = $6`
+
+	_, err := querier.ExecContext(
+		ctx,
+		query,
+		token.TokenHash,
+		token.ClientID,
+		token.ExpiresAt,
+		token.RevokedAt,
+		token.CreatedAt,
+		token.ID,
+	)
+	if err != nil {
+		return apperrors.Wrap(err, "failed to update token")
+	}
+
+	return nil
+}
+
+// Get retrieves a Token by ID from the PostgreSQL database.
+func (p *PostgreSQLTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error) {
+	querier := database.GetTx(ctx, p.db)
+
+	query := `SELECT id, token_hash, client_id, expires_at, revoked_at, created_at 
+			  FROM tokens WHERE id = $1`
+
+	var token authDomain.Token
+
+	err := querier.QueryRowContext(ctx, query, tokenID).Scan(
+		&token.ID,
+		&token.TokenHash,
+		&token.ClientID,
+		&token.ExpiresAt,
+		&token.RevokedAt,
+		&token.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrTokenNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get token")
+	}
+
+	return &token, nil
+}
+
+// NewPostgreSQLTokenRepository creates a new PostgreSQL Token repository.
+func NewPostgreSQLTokenRepository(db *sql.DB) *PostgreSQLTokenRepository {
+	return &PostgreSQLTokenRepository{db: db}
+}

--- a/internal/auth/repository/postgresql_token_repository_test.go
+++ b/internal/auth/repository/postgresql_token_repository_test.go
@@ -1,0 +1,528 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/testutil"
+)
+
+func TestNewPostgreSQLTokenRepository(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+
+	repo := NewPostgreSQLTokenRepository(db)
+	assert.NotNil(t, repo)
+	assert.IsType(t, &PostgreSQLTokenRepository{}, repo)
+}
+
+func TestPostgreSQLTokenRepository_Create(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Now create a token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "test-token-hash-1",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Verify the token was created by retrieving it
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	assert.WithinDuration(t, token.ExpiresAt, retrievedToken.ExpiresAt, time.Second)
+	assert.Nil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, token.CreatedAt, retrievedToken.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLTokenRepository_Create_WithRevokedAt(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-revoked",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a revoked token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+	revokedAt := time.Now().UTC()
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "revoked-token-hash",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: &revokedAt,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Verify the token was created with revoked_at set
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, revokedAt, *retrievedToken.RevokedAt, time.Second)
+}
+
+func TestPostgreSQLTokenRepository_Create_MultipleTokens(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-multiple",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	// Create first token
+	token1 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-1",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token1)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Ensure different timestamp for UUIDv7
+
+	// Create second token
+	token2 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-2",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(48 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token2)
+	require.NoError(t, err)
+
+	// Verify both tokens can be retrieved
+	retrievedToken1, err := tokenRepo.Get(ctx, token1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token1.ID, retrievedToken1.ID)
+
+	retrievedToken2, err := tokenRepo.Get(ctx, token2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token2.ID, retrievedToken2.ID)
+}
+
+func TestPostgreSQLTokenRepository_Update(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-update",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create initial token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "original-hash",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Update the token (revoke it)
+	revokedAt := time.Now().UTC()
+	token.RevokedAt = &revokedAt
+	token.TokenHash = "updated-hash"
+
+	err = tokenRepo.Update(ctx, token)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, "updated-hash", retrievedToken.TokenHash)
+	require.NotNil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, revokedAt, *retrievedToken.RevokedAt, time.Second)
+}
+
+func TestPostgreSQLTokenRepository_Update_NonExistent(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-nonexist",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	// Try to update a non-existent token
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "hash",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Update should not return an error even if no rows are affected
+	err = tokenRepo.Update(ctx, token)
+	assert.NoError(t, err)
+}
+
+func TestPostgreSQLTokenRepository_Get_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "get-test-hash",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Retrieve the token
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	assert.WithinDuration(t, token.ExpiresAt, retrievedToken.ExpiresAt, time.Second)
+	assert.Nil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, token.CreatedAt, retrievedToken.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLTokenRepository_Get_NotFound(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+	ctx := context.Background()
+
+	// Try to get a non-existent token
+	nonExistentID := uuid.Must(uuid.NewV7())
+	token, err := tokenRepo.Get(ctx, nonExistentID)
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}
+
+func TestPostgreSQLTokenRepository_Create_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "tx-test-hash",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Test rollback behavior using a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create token within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		token.ID,
+		token.TokenHash,
+		token.ClientID,
+		token.ExpiresAt,
+		token.RevokedAt,
+		token.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the token was not created (rollback worked)
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedToken)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}
+
+func TestPostgreSQLTokenRepository_Update_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-update-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create initial token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "original-hash-tx",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	revokedAt := time.Now().UTC()
+
+	// Update within transaction
+	_, err = tx.ExecContext(
+		ctx,
+		`UPDATE tokens SET token_hash = $1, client_id = $2, expires_at = $3, revoked_at = $4, 
+		 created_at = $5 WHERE id = $6`,
+		"updated-hash-tx",
+		token.ClientID,
+		token.ExpiresAt,
+		revokedAt,
+		token.CreatedAt,
+		token.ID,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Verify the token was not updated (rollback worked)
+	retrievedToken, err := tokenRepo.Get(ctx, token.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "original-hash-tx", retrievedToken.TokenHash)
+	assert.Nil(t, retrievedToken.RevokedAt)
+}
+
+func TestPostgreSQLTokenRepository_Get_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	// Create a token outside transaction
+	token1 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-1-tx",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another token inside transaction
+	time.Sleep(time.Millisecond)
+	token2 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-2-tx",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(48 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		token2.ID,
+		token2.TokenHash,
+		token2.ClientID,
+		token2.ExpiresAt,
+		token2.RevokedAt,
+		token2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Query within transaction should see both tokens
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM tokens WHERE client_id = $1`, client.ID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Commit transaction
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Get outside transaction should also see both tokens
+	retrievedToken1, err := tokenRepo.Get(ctx, token1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token1.ID, retrievedToken1.ID)
+
+	retrievedToken2, err := tokenRepo.Get(ctx, token2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token2.ID, retrievedToken2.ID)
+}

--- a/internal/auth/usecase/interface.go
+++ b/internal/auth/usecase/interface.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+)
+
+type ClientRepository interface {
+	Create(ctx context.Context, client *authDomain.Client) error
+	Update(ctx context.Context, client *authDomain.Client) error
+	Get(ctx context.Context, clientID uuid.UUID) (*authDomain.Client, error)
+}
+
+type TokenRepository interface {
+	Create(ctx context.Context, token *authDomain.Token) error
+	Update(ctx context.Context, token *authDomain.Token) error
+	Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error)
+}
+
+type PolicyRepository interface {
+	Create(ctx context.Context, policy *authDomain.Policy) error
+	Update(ctx context.Context, policy *authDomain.Policy) error
+	Get(ctx context.Context, name string) (*authDomain.Policy, error)
+	Delete(ctx context.Context, name string) error
+}
+
+type ClientPoliciesRepository interface {
+	Create(ctx context.Context, clientPolicies *authDomain.ClientPolicies) error
+	Delete(ctx context.Context, clientID uuid.UUID, PolicyID uuid.UUID) error
+}


### PR DESCRIPTION
Add a new internal/auth module implementing authentication and authorization capabilities using Clean Architecture principles. This module provides client credential management, token-based authentication, and policy-based access control.

Domain Layer:
- Client entity with activation status tracking
- Token entity with expiration and revocation support
- Policy entity with structured document for path-based capabilities
- ClientPolicies join entity for many-to-many relationships
- Domain-specific errors (ErrClientNotFound, ErrTokenNotFound, ErrPolicyNotFound, ErrClientPoliciesNotFound)

Repository Layer:
- Dual database support (PostgreSQL and MySQL) for all entities
- Transaction-aware repositories using database.GetTx()
- UUID binary marshaling for efficient storage (BINARY(16) in MySQL, UUID in PostgreSQL)
- JSON serialization for policy documents
- Comprehensive test coverage with transaction rollback tests

Use Case Interfaces:
- ClientRepository: Create, Update, Get operations
- TokenRepository: Create, Update, Get, GetByTokenHash, List operations
- PolicyRepository: Create, Update, Get, Delete operations (keyed by name)
- ClientPoliciesRepository: Create, Delete operations