### PR TITLE
feat(auth): add policy-based authorization with capability system

### DIFF
--- a/internal/auth/domain/client.go
+++ b/internal/auth/domain/client.go
@@ -1,21 +1,75 @@
+// Package domain defines authentication and authorization domain models and business logic.
+//
+// It provides client-based authentication with policy-based authorization. Clients authenticate
+// using secrets and are authorized via capability-based policies that control access to resource paths.
 package domain
 
 import (
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+// PolicyDocument defines access control rules for a specific resource path.
+// Policies use prefix matching with wildcard support for flexible authorization.
 type PolicyDocument struct {
-	Path         string   `json:"path"`
-	Capabilities []string `json:"capabilities"`
+	Path         string       `json:"path"`         // Resource path pattern (supports "*" and "/*" wildcards)
+	Capabilities []Capability `json:"capabilities"` // List of allowed operations on the resource
 }
 
+// Client represents an authentication client with associated authorization policies.
+// Clients are used to authenticate API requests and enforce access control.
 type Client struct {
-	ID        uuid.UUID
-	Secret    string
-	Name      string
-	IsActive  bool
-	Policies  []PolicyDocument
+	ID        uuid.UUID        // Unique identifier (UUIDv7)
+	Secret    string           // Hashed client secret for authentication
+	Name      string           // Human-readable client name
+	IsActive  bool             // Whether the client can authenticate
+	Policies  []PolicyDocument // Authorization policies for this client
 	CreatedAt time.Time
+}
+
+// IsAllowed checks if the client's policies permit the given capability on the specified path.
+// Uses case-sensitive prefix matching with wildcard support. Returns true if any policy
+// matches the path and includes the capability.
+//
+// Wildcard patterns:
+//   - "*" matches everything (admin mode)
+//   - "secret/*" matches any path starting with "secret/"
+//   - "secret" matches exactly "secret"
+func (c *Client) IsAllowed(path string, capability Capability) bool {
+	// Edge case: empty path or capability
+	if path == "" || capability == "" {
+		return false
+	}
+
+	// Iterate through all policies
+	for _, policy := range c.Policies {
+		var pathMatches bool
+
+		// Check path matching based on pattern type
+		switch {
+		case policy.Path == "*":
+			// Wildcard matches everything
+			pathMatches = true
+		case strings.HasSuffix(policy.Path, "/*"):
+			// Prefix matching: strip "/*" and check if path starts with "prefix/"
+			prefix := strings.TrimSuffix(policy.Path, "/*")
+			pathMatches = strings.HasPrefix(path, prefix+"/")
+		default:
+			// Exact match
+			pathMatches = policy.Path == path
+		}
+
+		// If path matches, check if capability is in the list
+		if pathMatches {
+			if slices.Contains(policy.Capabilities, capability) {
+				return true
+			}
+		}
+	}
+
+	// No matching policy found
+	return false
 }

--- a/internal/auth/domain/client_test.go
+++ b/internal/auth/domain/client_test.go
@@ -1,0 +1,544 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// createTestClient creates a Client instance with the given policies for testing.
+func createTestClient(policies []PolicyDocument) *Client {
+	return &Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client",
+		IsActive:  true,
+		Policies:  policies,
+		CreatedAt: time.Now(),
+	}
+}
+
+func TestClient_IsAllowed_WildcardPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Success_WildcardMatchesAnyPath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "*",
+					Capabilities: []Capability{ReadCapability, WriteCapability},
+				},
+			}),
+			path:       "any/path/here",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Failure_WildcardWithWrongCapability",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "any/path/here",
+			capability: WriteCapability,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_IsAllowed_PrefixPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Success_PrefixMatchesNestedPath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_PrefixMatchesMultipleSubPaths",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app1/db/password",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_NestedPrefixMatch",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_DeepNestedPrefixMatch",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app/db/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_PrefixMatchesMultipleLevels",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/api/key",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Failure_PrefixDoesNotMatchExactPath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name: "Failure_PrefixWithWrongCapability",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: WriteCapability,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_IsAllowed_ExactMatches(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Success_ExactMatchSimplePath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_ExactMatchNestedPath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_ExactMatchWithCorrectCapability",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app/db/password",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Failure_ExactMatchDoesNotMatchPrefix",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name: "Failure_ExactMatchWithWrongCapability",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret",
+			capability: WriteCapability,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_IsAllowed_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Failure_EmptyPath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name: "Failure_EmptyCapability",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: "",
+			expected:   false,
+		},
+		{
+			name: "Failure_EmptyPathAndCapability",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "",
+			capability: "",
+			expected:   false,
+		},
+		{
+			name: "Failure_NoMatchingPolicy",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "config/app",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name: "Failure_PathMatchesButCapabilityMissing",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: DeleteCapability,
+			expected:   false,
+		},
+		{
+			name:       "Failure_EmptyPoliciesList",
+			client:     createTestClient([]PolicyDocument{}),
+			path:       "secret/app",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name:       "Failure_NilPoliciesList",
+			client:     createTestClient(nil),
+			path:       "secret/app",
+			capability: ReadCapability,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_IsAllowed_MultiplePolicies(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Success_FirstMatchingPolicyWins",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+				{
+					Path:         "secret/app/*",
+					Capabilities: []Capability{WriteCapability},
+				},
+			}),
+			path:       "secret/app/db",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_SecondPolicyMatches",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "config/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{WriteCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: WriteCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_MultipleCapabilitiesInSinglePolicy",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability, WriteCapability, DeleteCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: DeleteCapability,
+			expected:   true,
+		},
+		{
+			name: "Failure_MultiplePoliciesNoneMatch",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "config/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{WriteCapability},
+				},
+			}),
+			path:       "data/app",
+			capability: ReadCapability,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_IsAllowed_CaseSensitivity(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Failure_PathCaseMismatch",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "Secret",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name: "Failure_NestedPathCaseMismatch",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "Secret/App",
+			capability: ReadCapability,
+			expected:   false,
+		},
+		{
+			name: "Success_ExactCaseMatch",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/app",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app",
+			capability: ReadCapability,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_IsAllowed_RealWorldScenarios(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *Client
+		path       string
+		capability Capability
+		expected   bool
+	}{
+		{
+			name: "Success_ReadOnlyAccess",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: ReadCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_AdminAccess",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path: "*",
+					Capabilities: []Capability{
+						ReadCapability,
+						WriteCapability,
+						DeleteCapability,
+						EncryptCapability,
+						DecryptCapability,
+						RotateCapability,
+					},
+				},
+			}),
+			path:       "any/path/anywhere",
+			capability: RotateCapability,
+			expected:   true,
+		},
+		{
+			name: "Success_MultiplePathsWithDifferentCapabilities",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+				{
+					Path:         "config/*",
+					Capabilities: []Capability{ReadCapability, WriteCapability},
+				},
+			}),
+			path:       "config/app/settings",
+			capability: WriteCapability,
+			expected:   true,
+		},
+		{
+			name: "Failure_WriteAttemptOnReadOnlyPath",
+			client: createTestClient([]PolicyDocument{
+				{
+					Path:         "secret/*",
+					Capabilities: []Capability{ReadCapability},
+				},
+			}),
+			path:       "secret/app/db/password",
+			capability: WriteCapability,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsAllowed(tt.path, tt.capability)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/auth/domain/const.go
+++ b/internal/auth/domain/const.go
@@ -1,0 +1,25 @@
+package domain
+
+// Capability defines the types of operations that can be performed on resources.
+// Capabilities are used in policy documents to control client authorization.
+type Capability string
+
+const (
+	// ReadCapability allows reading resource data.
+	ReadCapability Capability = "read"
+
+	// WriteCapability allows creating or updating resource data.
+	WriteCapability Capability = "write"
+
+	// DeleteCapability allows removing resource data.
+	DeleteCapability Capability = "delete"
+
+	// EncryptCapability allows encrypting data using cryptographic keys.
+	EncryptCapability Capability = "encrypt"
+
+	// DecryptCapability allows decrypting data using cryptographic keys.
+	DecryptCapability Capability = "decrypt"
+
+	// RotateCapability allows rotating cryptographic keys.
+	RotateCapability Capability = "rotate"
+)

--- a/internal/auth/domain/token.go
+++ b/internal/auth/domain/token.go
@@ -6,11 +6,13 @@ import (
 	"github.com/google/uuid"
 )
 
+// Token represents an authentication token with expiration and revocation support.
+// Tokens are stored as hashes and associated with a client for authentication.
 type Token struct {
-	ID        uuid.UUID
-	TokenHash string
-	ClientID  uuid.UUID
-	ExpiresAt time.Time
-	RevokedAt *time.Time
+	ID        uuid.UUID  // Unique identifier (UUIDv7)
+	TokenHash string     // SHA-256 hash of the token string
+	ClientID  uuid.UUID  // ID of the client that owns this token
+	ExpiresAt time.Time  // Token expiration timestamp
+	RevokedAt *time.Time // Token revocation timestamp (nil if active)
 	CreatedAt time.Time
 }

--- a/internal/auth/repository/mysql_client_repository.go
+++ b/internal/auth/repository/mysql_client_repository.go
@@ -14,12 +14,14 @@ import (
 )
 
 // MySQLClientRepository implements Client persistence for MySQL.
-// Uses BINARY(16) for UUIDs with transaction support via database.GetTx().
+// Uses BINARY(16) for UUID storage with transaction support via database.GetTx().
 type MySQLClientRepository struct {
 	db *sql.DB
 }
 
-// Create inserts a new Client into the MySQL database.
+// Create inserts a new Client into the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns an error if UUID/policy
+// marshaling or database insertion fails.
 func (m *MySQLClientRepository) Create(ctx context.Context, client *authDomain.Client) error {
 	querier := database.GetTx(ctx, m.db)
 
@@ -52,7 +54,9 @@ func (m *MySQLClientRepository) Create(ctx context.Context, client *authDomain.C
 	return nil
 }
 
-// Update modifies an existing Client in the MySQL database.
+// Update modifies an existing Client in the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns an error if UUID/policy
+// marshaling or database update fails.
 func (m *MySQLClientRepository) Update(ctx context.Context, client *authDomain.Client) error {
 	querier := database.GetTx(ctx, m.db)
 
@@ -91,7 +95,9 @@ func (m *MySQLClientRepository) Update(ctx context.Context, client *authDomain.C
 	return nil
 }
 
-// Get retrieves a Client by ID from the MySQL database.
+// Get retrieves a Client by ID from the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns ErrClientNotFound if the client
+// doesn't exist, or an error if UUID/policy unmarshaling or database query fails.
 func (m *MySQLClientRepository) Get(ctx context.Context, clientID uuid.UUID) (*authDomain.Client, error) {
 	querier := database.GetTx(ctx, m.db)
 

--- a/internal/auth/repository/mysql_token_repository.go
+++ b/internal/auth/repository/mysql_token_repository.go
@@ -18,7 +18,9 @@ type MySQLTokenRepository struct {
 	db *sql.DB
 }
 
-// Create inserts a new Token into the MySQL database.
+// Create inserts a new Token into the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns an error if UUID marshaling
+// or database insertion fails.
 func (m *MySQLTokenRepository) Create(ctx context.Context, token *authDomain.Token) error {
 	querier := database.GetTx(ctx, m.db)
 
@@ -51,7 +53,9 @@ func (m *MySQLTokenRepository) Create(ctx context.Context, token *authDomain.Tok
 	return nil
 }
 
-// Update modifies an existing Token in the MySQL database.
+// Update modifies an existing Token in the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns an error if UUID marshaling
+// or database update fails.
 func (m *MySQLTokenRepository) Update(ctx context.Context, token *authDomain.Token) error {
 	querier := database.GetTx(ctx, m.db)
 
@@ -90,7 +94,9 @@ func (m *MySQLTokenRepository) Update(ctx context.Context, token *authDomain.Tok
 	return nil
 }
 
-// Get retrieves a Token by ID from the MySQL database.
+// Get retrieves a Token by ID from the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns ErrTokenNotFound if the token
+// doesn't exist, or an error if UUID unmarshaling or database query fails.
 func (m *MySQLTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error) {
 	querier := database.GetTx(ctx, m.db)
 

--- a/internal/auth/repository/postgresql_client_repository.go
+++ b/internal/auth/repository/postgresql_client_repository.go
@@ -23,7 +23,8 @@ type PostgreSQLClientRepository struct {
 	db *sql.DB
 }
 
-// Create inserts a new Client into the PostgreSQL database.
+// Create inserts a new Client into the PostgreSQL database. Uses transaction support
+// via database.GetTx(). Returns an error if policy marshaling or database insertion fails.
 func (p *PostgreSQLClientRepository) Create(ctx context.Context, client *authDomain.Client) error {
 	querier := database.GetTx(ctx, p.db)
 
@@ -51,7 +52,8 @@ func (p *PostgreSQLClientRepository) Create(ctx context.Context, client *authDom
 	return nil
 }
 
-// Update modifies an existing Client in the PostgreSQL database.
+// Update modifies an existing Client in the PostgreSQL database. Uses transaction support
+// via database.GetTx(). Returns an error if policy marshaling or database update fails.
 func (p *PostgreSQLClientRepository) Update(ctx context.Context, client *authDomain.Client) error {
 	querier := database.GetTx(ctx, p.db)
 
@@ -85,7 +87,9 @@ func (p *PostgreSQLClientRepository) Update(ctx context.Context, client *authDom
 	return nil
 }
 
-// Get retrieves a Client by ID from the PostgreSQL database.
+// Get retrieves a Client by ID from the PostgreSQL database. Uses transaction support
+// via database.GetTx(). Returns ErrClientNotFound if the client doesn't exist, or an error
+// if policy unmarshaling or database query fails.
 func (p *PostgreSQLClientRepository) Get(
 	ctx context.Context,
 	clientID uuid.UUID,

--- a/internal/auth/repository/postgresql_token_repository.go
+++ b/internal/auth/repository/postgresql_token_repository.go
@@ -18,7 +18,8 @@ type PostgreSQLTokenRepository struct {
 	db *sql.DB
 }
 
-// Create inserts a new Token into the PostgreSQL database.
+// Create inserts a new Token into the PostgreSQL database. Uses transaction support
+// via database.GetTx(). Returns an error if database insertion fails.
 func (p *PostgreSQLTokenRepository) Create(ctx context.Context, token *authDomain.Token) error {
 	querier := database.GetTx(ctx, p.db)
 
@@ -41,7 +42,8 @@ func (p *PostgreSQLTokenRepository) Create(ctx context.Context, token *authDomai
 	return nil
 }
 
-// Update modifies an existing Token in the PostgreSQL database.
+// Update modifies an existing Token in the PostgreSQL database. Uses transaction support
+// via database.GetTx(). Returns an error if database update fails.
 func (p *PostgreSQLTokenRepository) Update(ctx context.Context, token *authDomain.Token) error {
 	querier := database.GetTx(ctx, p.db)
 
@@ -70,7 +72,9 @@ func (p *PostgreSQLTokenRepository) Update(ctx context.Context, token *authDomai
 	return nil
 }
 
-// Get retrieves a Token by ID from the PostgreSQL database.
+// Get retrieves a Token by ID from the PostgreSQL database. Uses transaction support
+// via database.GetTx(). Returns ErrTokenNotFound if the token doesn't exist, or an error
+// if database query fails.
 func (p *PostgreSQLTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error) {
 	querier := database.GetTx(ctx, p.db)
 

--- a/internal/auth/usecase/interface.go
+++ b/internal/auth/usecase/interface.go
@@ -1,3 +1,4 @@
+// Package usecase defines business logic interfaces for authentication and authorization operations.
 package usecase
 
 import (
@@ -8,14 +9,28 @@ import (
 	authDomain "github.com/allisson/secrets/internal/auth/domain"
 )
 
+// ClientRepository defines persistence operations for authentication clients.
+// Implementations must support transaction-aware operations via context propagation.
 type ClientRepository interface {
+	// Create stores a new client in the repository.
 	Create(ctx context.Context, client *authDomain.Client) error
+
+	// Update modifies an existing client in the repository.
 	Update(ctx context.Context, client *authDomain.Client) error
+
+	// Get retrieves a client by ID. Returns ErrClientNotFound if not found.
 	Get(ctx context.Context, clientID uuid.UUID) (*authDomain.Client, error)
 }
 
+// TokenRepository defines persistence operations for authentication tokens.
+// Implementations must support transaction-aware operations via context propagation.
 type TokenRepository interface {
+	// Create stores a new token in the repository.
 	Create(ctx context.Context, token *authDomain.Token) error
+
+	// Update modifies an existing token in the repository.
 	Update(ctx context.Context, token *authDomain.Token) error
+
+	// Get retrieves a token by ID. Returns ErrTokenNotFound if not found.
 	Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error)
 }


### PR DESCRIPTION
Implement comprehensive authorization system with capability-based access control for authentication clients. Policies support wildcard patterns (*), prefix matching (path/*), and exact path matching to control resource access.

Key changes:
- Add Capability type with six operations (read, write, delete, encrypt, decrypt, rotate)
- Implement Client.IsAllowed() method for policy evaluation with pattern matching
- Add comprehensive test suite with 544 lines covering wildcards, prefixes, exact matches, edge cases, and real-world scenarios
- Enhance documentation across domain models (Client, Token, PolicyDocument) and repository methods
- Update all repository implementations (PostgreSQL and MySQL) with detailed method documentation