### PR TITLE
feat(auth): implement token issuance use case

### DIFF
--- a/internal/app/di_test.go
+++ b/internal/app/di_test.go
@@ -21,10 +21,7 @@ func TestNewContainer(t *testing.T) {
 		DBConnMaxLifetime:    time.Hour,
 		ServerHost:           "localhost",
 		ServerPort:           8080,
-		WorkerInterval:       time.Second,
-		WorkerBatchSize:      100,
-		WorkerMaxRetries:     3,
-		WorkerRetryInterval:  time.Second,
+		AuthTokenExpiration:  time.Second,
 	}
 
 	container := NewContainer(cfg)

--- a/internal/auth/domain/errors.go
+++ b/internal/auth/domain/errors.go
@@ -11,4 +11,13 @@ var (
 
 	// ErrTokenNotFound indicates a token with the specified ID was not found.
 	ErrTokenNotFound = errors.Wrap(errors.ErrNotFound, "token not found")
+
+	// ErrInvalidCredentials indicates the provided credentials are invalid.
+	// This error is returned for both non-existent clients and incorrect secrets
+	// to prevent user enumeration attacks.
+	ErrInvalidCredentials = errors.Wrap(errors.ErrUnauthorized, "invalid credentials")
+
+	// ErrClientInactive indicates the client exists but is not active.
+	// Inactive clients cannot authenticate or issue tokens.
+	ErrClientInactive = errors.Wrap(errors.ErrForbidden, "client is inactive")
 )

--- a/internal/auth/domain/token.go
+++ b/internal/auth/domain/token.go
@@ -16,3 +16,12 @@ type Token struct {
 	RevokedAt *time.Time // Token revocation timestamp (nil if active)
 	CreatedAt time.Time
 }
+
+type IssueTokenInput struct {
+	ClientID     uuid.UUID
+	ClientSecret string
+}
+
+type IssueTokenOutput struct {
+	PlainToken string
+}

--- a/internal/auth/service/interface.go
+++ b/internal/auth/service/interface.go
@@ -25,3 +25,20 @@ type SecretService interface {
 	// This is constant-time to prevent timing attacks.
 	CompareSecret(plainSecret string, hashedSecret string) bool
 }
+
+// TokenService defines operations for authentication token generation and hashing.
+// Implementations must use cryptographically secure random generation and
+// fast hashing algorithms suitable for short-lived tokens (e.g., SHA-256).
+type TokenService interface {
+	// GenerateToken creates a new cryptographically secure random token.
+	// Returns both the plain text token (to be shared with the client) and
+	// the hashed version (to be stored in the database).
+	//
+	// The plain token should be treated as sensitive data and only displayed
+	// once to the client during token issuance.
+	GenerateToken() (plainToken string, tokenHash string, error error)
+
+	// HashToken hashes a plain text token using SHA-256.
+	// Used for token validation by comparing hashes.
+	HashToken(plainToken string) string
+}

--- a/internal/auth/service/token_service.go
+++ b/internal/auth/service/token_service.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+
+	apperrors "github.com/allisson/secrets/internal/errors"
+)
+
+// tokenService implements TokenService using SHA-256 for token hashing.
+type tokenService struct{}
+
+// GenerateToken creates a new cryptographically secure 32-byte random token.
+// The token is base64 URL-encoded for easy transmission and storage.
+// Returns the plain token and its SHA-256 hash.
+func (t *tokenService) GenerateToken() (plainToken string, tokenHash string, error error) {
+	// Generate 32 random bytes (256 bits)
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", "", apperrors.Wrap(err, "failed to generate random token")
+	}
+
+	// Encode to base64 URL-safe string for text representation
+	plainToken = base64.URLEncoding.EncodeToString(randomBytes)
+
+	// Hash the token using SHA-256
+	tokenHash = t.HashToken(plainToken)
+
+	return plainToken, tokenHash, nil
+}
+
+// HashToken hashes a plain text token using SHA-256.
+// Returns the hash as a hexadecimal string.
+func (t *tokenService) HashToken(plainToken string) string {
+	hash := sha256.Sum256([]byte(plainToken))
+	return hex.EncodeToString(hash[:])
+}
+
+// NewTokenService creates a new TokenService instance using SHA-256 for token hashing.
+func NewTokenService() TokenService {
+	return &tokenService{}
+}

--- a/internal/auth/service/token_service_test.go
+++ b/internal/auth/service/token_service_test.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTokenService(t *testing.T) {
+	service := NewTokenService()
+	assert.NotNil(t, service)
+	assert.IsType(t, &tokenService{}, service)
+}
+
+func TestTokenService_GenerateToken(t *testing.T) {
+	service := NewTokenService()
+
+	t.Run("Success_GenerateToken", func(t *testing.T) {
+		plainToken, tokenHash, err := service.GenerateToken()
+
+		// Assert no error
+		require.NoError(t, err)
+
+		// Assert plain token is not empty
+		assert.NotEmpty(t, plainToken)
+
+		// Assert token hash is not empty
+		assert.NotEmpty(t, tokenHash)
+
+		// Assert plain token is base64 URL-encoded
+		decodedBytes, err := base64.URLEncoding.DecodeString(plainToken)
+		require.NoError(t, err)
+		assert.Len(t, decodedBytes, 32, "decoded token should be 32 bytes")
+
+		// Assert token hash is valid SHA-256 hex string (64 characters)
+		assert.Len(t, tokenHash, 64, "SHA-256 hash should be 64 hex characters")
+
+		// Assert hash matches manually hashed plain token
+		expectedHash := sha256.Sum256([]byte(plainToken))
+		expectedHashHex := hex.EncodeToString(expectedHash[:])
+		assert.Equal(t, expectedHashHex, tokenHash)
+	})
+
+	t.Run("Success_GenerateUniqueTokens", func(t *testing.T) {
+		plainToken1, tokenHash1, err1 := service.GenerateToken()
+		require.NoError(t, err1)
+
+		plainToken2, tokenHash2, err2 := service.GenerateToken()
+		require.NoError(t, err2)
+
+		// Assert tokens are different
+		assert.NotEqual(t, plainToken1, plainToken2, "generated tokens should be unique")
+		assert.NotEqual(t, tokenHash1, tokenHash2, "generated hashes should be unique")
+	})
+}
+
+func TestTokenService_HashToken(t *testing.T) {
+	service := NewTokenService()
+
+	t.Run("Success_HashToken", func(t *testing.T) {
+		plainToken := "test-token-abc123"
+
+		tokenHash := service.HashToken(plainToken)
+
+		// Assert hash is not empty
+		assert.NotEmpty(t, tokenHash)
+
+		// Assert hash is valid SHA-256 hex string (64 characters)
+		assert.Len(t, tokenHash, 64, "SHA-256 hash should be 64 hex characters")
+
+		// Assert hash matches expected SHA-256 hash
+		expectedHash := sha256.Sum256([]byte(plainToken))
+		expectedHashHex := hex.EncodeToString(expectedHash[:])
+		assert.Equal(t, expectedHashHex, tokenHash)
+	})
+
+	t.Run("Success_ConsistentHashing", func(t *testing.T) {
+		plainToken := "consistent-token-xyz789"
+
+		hash1 := service.HashToken(plainToken)
+		hash2 := service.HashToken(plainToken)
+
+		// Assert same input produces same hash
+		assert.Equal(t, hash1, hash2, "hashing should be deterministic")
+	})
+
+	t.Run("Success_DifferentTokensProduceDifferentHashes", func(t *testing.T) {
+		token1 := "token-one"
+		token2 := "token-two"
+
+		hash1 := service.HashToken(token1)
+		hash2 := service.HashToken(token2)
+
+		// Assert different inputs produce different hashes
+		assert.NotEqual(t, hash1, hash2, "different tokens should have different hashes")
+	})
+
+	t.Run("Success_EmptyStringProducesValidHash", func(t *testing.T) {
+		plainToken := ""
+
+		tokenHash := service.HashToken(plainToken)
+
+		// Assert hash is generated even for empty string
+		assert.NotEmpty(t, tokenHash)
+		assert.Len(t, tokenHash, 64)
+
+		// Verify it matches expected SHA-256 of empty string
+		expectedHash := sha256.Sum256([]byte(""))
+		expectedHashHex := hex.EncodeToString(expectedHash[:])
+		assert.Equal(t, expectedHashHex, tokenHash)
+	})
+}
+
+func TestTokenService_GenerateAndVerify(t *testing.T) {
+	service := NewTokenService()
+
+	t.Run("Success_GeneratedTokenHashMatchesManualHash", func(t *testing.T) {
+		plainToken, generatedHash, err := service.GenerateToken()
+		require.NoError(t, err)
+
+		// Manually hash the plain token
+		manualHash := service.HashToken(plainToken)
+
+		// Assert generated hash matches manual hash
+		assert.Equal(t, generatedHash, manualHash, "generated hash should match manual hash of plain token")
+	})
+}

--- a/internal/auth/usecase/interface.go
+++ b/internal/auth/usecase/interface.go
@@ -76,3 +76,10 @@ type ClientUseCase interface {
 	// Returns ErrClientNotFound if the specified client doesn't exist.
 	Delete(ctx context.Context, clientID uuid.UUID) error
 }
+
+type TokenUseCase interface {
+	Issue(
+		ctx context.Context,
+		issueTokenInput *authDomain.IssueTokenInput,
+	) (*authDomain.IssueTokenOutput, error)
+}

--- a/internal/auth/usecase/token_usecase.go
+++ b/internal/auth/usecase/token_usecase.go
@@ -1,0 +1,106 @@
+// Package usecase implements business logic orchestration for authentication operations.
+package usecase
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	authService "github.com/allisson/secrets/internal/auth/service"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// tokenUseCase implements TokenUseCase interface for managing authentication tokens.
+type tokenUseCase struct {
+	config        *config.Config
+	clientRepo    ClientRepository
+	tokenRepo     TokenRepository
+	secretService authService.SecretService
+	tokenService  authService.TokenService
+}
+
+// Issue authenticates a client and generates a new authentication token.
+//
+// This method:
+// 1. Validates the client exists and is active
+// 2. Verifies the client secret matches
+// 3. Generates a new token with expiration from config
+// 4. Stores the token hash in the database
+// 5. Returns the plain token to the caller (only shown once)
+//
+// Security Notes:
+//   - Returns ErrInvalidCredentials for both non-existent clients and wrong secrets
+//     to prevent user enumeration attacks
+//   - Returns ErrClientInactive if the client exists but is not active
+//   - The plain token is only returned once and should be transmitted securely
+//   - Token expiration is set from Config.AuthTokenExpiration
+func (t *tokenUseCase) Issue(
+	ctx context.Context,
+	issueTokenInput *authDomain.IssueTokenInput,
+) (*authDomain.IssueTokenOutput, error) {
+	// Get the client by ID
+	client, err := t.clientRepo.Get(ctx, issueTokenInput.ClientID)
+	if err != nil {
+		// If client not found, return generic error to prevent enumeration
+		if errors.Is(err, authDomain.ErrClientNotFound) {
+			return nil, authDomain.ErrInvalidCredentials
+		}
+		return nil, err
+	}
+
+	// Check if client is active
+	if !client.IsActive {
+		return nil, authDomain.ErrClientInactive
+	}
+
+	// Verify the client secret
+	if !t.secretService.CompareSecret(issueTokenInput.ClientSecret, client.Secret) {
+		return nil, authDomain.ErrInvalidCredentials
+	}
+
+	// Generate a new token
+	plainToken, tokenHash, err := t.tokenService.GenerateToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the token entity with expiration from config
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: tokenHash,
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(t.config.AuthTokenExpiration),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Persist the token
+	if err := t.tokenRepo.Create(ctx, token); err != nil {
+		return nil, err
+	}
+
+	// Return the plain token
+	return &authDomain.IssueTokenOutput{
+		PlainToken: plainToken,
+	}, nil
+}
+
+// NewTokenUseCase creates a new TokenUseCase with the provided dependencies.
+func NewTokenUseCase(
+	config *config.Config,
+	clientRepo ClientRepository,
+	tokenRepo TokenRepository,
+	secretService authService.SecretService,
+	tokenService authService.TokenService,
+) TokenUseCase {
+	return &tokenUseCase{
+		config:        config,
+		clientRepo:    clientRepo,
+		tokenRepo:     tokenRepo,
+		secretService: secretService,
+		tokenService:  tokenService,
+	}
+}

--- a/internal/auth/usecase/token_usecase_test.go
+++ b/internal/auth/usecase/token_usecase_test.go
@@ -1,0 +1,468 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// mockTokenService is a mock implementation of TokenService for testing.
+type mockTokenService struct {
+	mock.Mock
+}
+
+func (m *mockTokenService) GenerateToken() (plainToken string, tokenHash string, error error) {
+	args := m.Called()
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *mockTokenService) HashToken(plainToken string) string {
+	args := m.Called(plainToken)
+	return args.String(0)
+}
+
+// mockTokenRepository is a mock implementation of TokenRepository for testing.
+type mockTokenRepository struct {
+	mock.Mock
+}
+
+func (m *mockTokenRepository) Create(ctx context.Context, token *authDomain.Token) error {
+	args := m.Called(ctx, token)
+	return args.Error(0)
+}
+
+func (m *mockTokenRepository) Update(ctx context.Context, token *authDomain.Token) error {
+	args := m.Called(ctx, token)
+	return args.Error(0)
+}
+
+func (m *mockTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error) {
+	args := m.Called(ctx, tokenID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authDomain.Token), args.Error(1)
+}
+
+func TestTokenUseCase_Issue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success_IssueTokenWithValidCredentials", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		// Test data
+		clientID := uuid.Must(uuid.NewV7())
+		clientSecret := "test-client-secret-abc123"                //nolint:gosec // test fixture, not a real credential
+		hashedSecret := "$argon2id$v=19$m=65536,t=3,p=4$test-hash" //nolint:gosec // test fixture, not a real credential
+		plainToken := "test-token-xyz789"
+		tokenHash := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+		client := &authDomain.Client{
+			ID:       clientID,
+			Secret:   hashedSecret,
+			Name:     "test-client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+		}
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(client, nil).
+			Once()
+
+		mockSecretService.On("CompareSecret", clientSecret, hashedSecret).
+			Return(true).
+			Once()
+
+		mockTokenService.On("GenerateToken").
+			Return(plainToken, tokenHash, nil).
+			Once()
+
+		mockTokenRepo.On("Create", ctx, mock.MatchedBy(func(token *authDomain.Token) bool {
+			return token.TokenHash == tokenHash &&
+				token.ClientID == clientID &&
+				token.RevokedAt == nil &&
+				!token.ExpiresAt.IsZero() &&
+				!token.CreatedAt.IsZero()
+		})).
+			Return(nil).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, output)
+		assert.Equal(t, plainToken, output.PlainToken)
+		mockClientRepo.AssertExpectations(t)
+		mockSecretService.AssertExpectations(t)
+		mockTokenService.AssertExpectations(t)
+		mockTokenRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_ClientNotFound", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: "some-secret",
+		}
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(nil, authDomain.ErrClientNotFound).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert - should return generic error to prevent enumeration
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, authDomain.ErrInvalidCredentials, err)
+		mockClientRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_ClientInactive", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		client := &authDomain.Client{
+			ID:       clientID,
+			Secret:   "hashed-secret",
+			Name:     "inactive-client",
+			IsActive: false, // Client is inactive
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: "client-secret",
+		}
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(client, nil).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, authDomain.ErrClientInactive, err)
+		mockClientRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_InvalidClientSecret", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		wrongSecret := "wrong-secret"
+		hashedSecret := "$argon2id$v=19$m=65536,t=3,p=4$test-hash" //nolint:gosec // test fixture, not a real credential
+
+		client := &authDomain.Client{
+			ID:       clientID,
+			Secret:   hashedSecret,
+			Name:     "test-client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: wrongSecret,
+		}
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(client, nil).
+			Once()
+
+		mockSecretService.On("CompareSecret", wrongSecret, hashedSecret).
+			Return(false). // Secret doesn't match
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, authDomain.ErrInvalidCredentials, err)
+		mockClientRepo.AssertExpectations(t)
+		mockSecretService.AssertExpectations(t)
+	})
+
+	t.Run("Error_TokenGenerationFails", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		clientSecret := "test-client-secret"
+		hashedSecret := "$argon2id$v=19$m=65536,t=3,p=4$test-hash" //nolint:gosec // test fixture, not a real credential
+
+		client := &authDomain.Client{
+			ID:       clientID,
+			Secret:   hashedSecret,
+			Name:     "test-client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+		}
+
+		expectedErr := errors.New("failed to generate random token")
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(client, nil).
+			Once()
+
+		mockSecretService.On("CompareSecret", clientSecret, hashedSecret).
+			Return(true).
+			Once()
+
+		mockTokenService.On("GenerateToken").
+			Return("", "", expectedErr).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, expectedErr, err)
+		mockClientRepo.AssertExpectations(t)
+		mockSecretService.AssertExpectations(t)
+		mockTokenService.AssertExpectations(t)
+	})
+
+	t.Run("Error_RepositoryCreateFails", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		clientSecret := "test-client-secret"
+		hashedSecret := "$argon2id$v=19$m=65536,t=3,p=4$test-hash" //nolint:gosec // test fixture, not a real credential
+		plainToken := "test-token"
+		tokenHash := "token-hash"
+
+		client := &authDomain.Client{
+			ID:       clientID,
+			Secret:   hashedSecret,
+			Name:     "test-client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+		}
+
+		expectedErr := errors.New("database error")
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(client, nil).
+			Once()
+
+		mockSecretService.On("CompareSecret", clientSecret, hashedSecret).
+			Return(true).
+			Once()
+
+		mockTokenService.On("GenerateToken").
+			Return(plainToken, tokenHash, nil).
+			Once()
+
+		mockTokenRepo.On("Create", ctx, mock.AnythingOfType("*domain.Token")).
+			Return(expectedErr).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, expectedErr, err)
+		mockClientRepo.AssertExpectations(t)
+		mockSecretService.AssertExpectations(t)
+		mockTokenService.AssertExpectations(t)
+		mockTokenRepo.AssertExpectations(t)
+	})
+
+	t.Run("Success_TokenExpirationSetFromConfig", func(t *testing.T) {
+		// Setup mocks with specific expiration duration
+		customExpiration := 48 * time.Hour
+		mockConfig := &config.Config{
+			AuthTokenExpiration: customExpiration,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		clientSecret := "test-client-secret"
+		hashedSecret := "$argon2id$v=19$m=65536,t=3,p=4$test-hash" //nolint:gosec // test fixture, not a real credential
+		plainToken := "test-token"
+		tokenHash := "token-hash"
+
+		client := &authDomain.Client{
+			ID:       clientID,
+			Secret:   hashedSecret,
+			Name:     "test-client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+		}
+
+		// Capture the created token to verify expiration
+		var createdToken *authDomain.Token
+		now := time.Now().UTC()
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(client, nil).
+			Once()
+
+		mockSecretService.On("CompareSecret", clientSecret, hashedSecret).
+			Return(true).
+			Once()
+
+		mockTokenService.On("GenerateToken").
+			Return(plainToken, tokenHash, nil).
+			Once()
+
+		mockTokenRepo.On("Create", ctx, mock.MatchedBy(func(token *authDomain.Token) bool {
+			createdToken = token
+			return true
+		})).
+			Return(nil).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, output)
+		assert.NotNil(t, createdToken)
+
+		// Verify expiration is set correctly (within 1 second tolerance)
+		expectedExpiration := now.Add(customExpiration)
+		assert.WithinDuration(t, expectedExpiration, createdToken.ExpiresAt, time.Second)
+
+		mockClientRepo.AssertExpectations(t)
+		mockSecretService.AssertExpectations(t)
+		mockTokenService.AssertExpectations(t)
+		mockTokenRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_RepositoryGetReturnsUnexpectedError", func(t *testing.T) {
+		// Setup mocks
+		mockConfig := &config.Config{
+			AuthTokenExpiration: 24 * time.Hour,
+		}
+		mockClientRepo := &mockClientRepository{}
+		mockTokenRepo := &mockTokenRepository{}
+		mockSecretService := &mockSecretService{}
+		mockTokenService := &mockTokenService{}
+
+		clientID := uuid.Must(uuid.NewV7())
+		issueInput := &authDomain.IssueTokenInput{
+			ClientID:     clientID,
+			ClientSecret: "some-secret",
+		}
+
+		expectedErr := errors.New("unexpected database error")
+
+		// Setup expectations
+		mockClientRepo.On("Get", ctx, clientID).
+			Return(nil, expectedErr).
+			Once()
+
+		// Execute
+		uc := NewTokenUseCase(mockConfig, mockClientRepo, mockTokenRepo, mockSecretService, mockTokenService)
+		output, err := uc.Issue(ctx, issueInput)
+
+		// Assert - should return the original error, not ErrInvalidCredentials
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, expectedErr, err)
+		mockClientRepo.AssertExpectations(t)
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,11 +26,8 @@ type Config struct {
 	// Logging
 	LogLevel string
 
-	// Worker configuration
-	WorkerInterval      time.Duration
-	WorkerBatchSize     int
-	WorkerMaxRetries    int
-	WorkerRetryInterval time.Duration
+	// Auth
+	AuthTokenExpiration time.Duration
 }
 
 // Load loads configuration from environment variables and .env file.
@@ -56,11 +53,8 @@ func Load() *Config {
 		// Logging
 		LogLevel: env.GetString("LOG_LEVEL", "info"),
 
-		// Worker configuration
-		WorkerInterval:      env.GetDuration("WORKER_INTERVAL", 5, time.Second),
-		WorkerBatchSize:     env.GetInt("WORKER_BATCH_SIZE", 10),
-		WorkerMaxRetries:    env.GetInt("WORKER_MAX_RETRIES", 3),
-		WorkerRetryInterval: env.GetDuration("WORKER_RETRY_INTERVAL", 1, time.Minute),
+		// Auth
+		AuthTokenExpiration: env.GetDuration("AUTH_TOKEN_EXPIRATION_SECONDS", 86400, time.Second),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,10 +31,7 @@ func TestLoad(t *testing.T) {
 				assert.Equal(t, 5, cfg.DBMaxIdleConnections)
 				assert.Equal(t, 5*time.Minute, cfg.DBConnMaxLifetime)
 				assert.Equal(t, "info", cfg.LogLevel)
-				assert.Equal(t, 5*time.Second, cfg.WorkerInterval)
-				assert.Equal(t, 10, cfg.WorkerBatchSize)
-				assert.Equal(t, 3, cfg.WorkerMaxRetries)
-				assert.Equal(t, 1*time.Minute, cfg.WorkerRetryInterval)
+				assert.Equal(t, 86400*time.Second, cfg.AuthTokenExpiration)
 			},
 		},
 		{
@@ -66,18 +63,12 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name: "load custom worker configuration",
+			name: "load custom auth configuration",
 			envVars: map[string]string{
-				"WORKER_INTERVAL":       "10",
-				"WORKER_BATCH_SIZE":     "20",
-				"WORKER_MAX_RETRIES":    "5",
-				"WORKER_RETRY_INTERVAL": "2",
+				"AUTH_TOKEN_EXPIRATION_SECONDS": "10",
 			},
 			validate: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, 10*time.Second, cfg.WorkerInterval)
-				assert.Equal(t, 20, cfg.WorkerBatchSize)
-				assert.Equal(t, 5, cfg.WorkerMaxRetries)
-				assert.Equal(t, 2*time.Minute, cfg.WorkerRetryInterval)
+				assert.Equal(t, 10*time.Second, cfg.AuthTokenExpiration)
 			},
 		},
 		{


### PR DESCRIPTION
Add token generation and authentication flow to enable client authentication via client credentials. This implements the core token issuance logic required for API authentication.

Changes:
- Add TokenService with SHA-256 hashing for fast token generation and validation
- Implement TokenUseCase.Issue() to authenticate clients and generate tokens
- Add domain errors for invalid credentials and inactive clients
- Replace worker config with auth token expiration config (AuthTokenExpiration)
- Add comprehensive test coverage for both service and use case layers

The token service generates cryptographically secure 32-byte random tokens encoded as base64 URL-safe strings and hashes them with SHA-256 for storage. The token use case orchestrates client authentication, validates credentials using constant-time comparison to prevent timing attacks, and returns generic errors to prevent user enumeration.