### PR TITLE
feat(auth): add GetByTokenHash method to token repositories

### DIFF
--- a/internal/auth/repository/mysql_token_repository.go
+++ b/internal/auth/repository/mysql_token_repository.go
@@ -138,6 +138,48 @@ func (m *MySQLTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*aut
 	return &token, nil
 }
 
+// GetByTokenHash retrieves a Token by token hash from the MySQL database using BINARY(16) for UUIDs.
+// Uses transaction support via database.GetTx(). Returns ErrTokenNotFound if the token doesn't exist,
+// or an error if UUID unmarshaling or database query fails.
+func (m *MySQLTokenRepository) GetByTokenHash(
+	ctx context.Context,
+	tokenHash string,
+) (*authDomain.Token, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, token_hash, client_id, expires_at, revoked_at, created_at 
+			  FROM tokens WHERE token_hash = ?`
+
+	var token authDomain.Token
+	var idBytes []byte
+	var clientIDBytes []byte
+
+	err := querier.QueryRowContext(ctx, query, tokenHash).Scan(
+		&idBytes,
+		&token.TokenHash,
+		&clientIDBytes,
+		&token.ExpiresAt,
+		&token.RevokedAt,
+		&token.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, authDomain.ErrTokenNotFound
+		}
+		return nil, apperrors.Wrap(err, "failed to get token by hash")
+	}
+
+	if err := token.ID.UnmarshalBinary(idBytes); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal token id")
+	}
+
+	if err := token.ClientID.UnmarshalBinary(clientIDBytes); err != nil {
+		return nil, apperrors.Wrap(err, "failed to unmarshal client id")
+	}
+
+	return &token, nil
+}
+
 // NewMySQLTokenRepository creates a new MySQL Token repository.
 func NewMySQLTokenRepository(db *sql.DB) *MySQLTokenRepository {
 	return &MySQLTokenRepository{db: db}

--- a/internal/auth/repository/mysql_token_repository_test.go
+++ b/internal/auth/repository/mysql_token_repository_test.go
@@ -552,3 +552,199 @@ func TestMySQLTokenRepository_Get_WithTransaction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, token2.ID, retrievedToken2.ID)
 }
+
+func TestMySQLTokenRepository_GetByTokenHash_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get-by-hash-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a token
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "unique-token-hash-mysql-123",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Retrieve the token by hash
+	retrievedToken, err := tokenRepo.GetByTokenHash(ctx, token.TokenHash)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	assert.WithinDuration(t, token.ExpiresAt, retrievedToken.ExpiresAt, time.Second)
+	assert.Nil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, token.CreatedAt, retrievedToken.CreatedAt, time.Second)
+}
+
+func TestMySQLTokenRepository_GetByTokenHash_NotFound(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+	ctx := context.Background()
+
+	// Try to get a token with a non-existent hash
+	token, err := tokenRepo.GetByTokenHash(ctx, "non-existent-hash-mysql")
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}
+
+func TestMySQLTokenRepository_GetByTokenHash_WithRevokedToken(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-revoked-hash-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a revoked token
+	tokenRepo := NewMySQLTokenRepository(db)
+	revokedAt := time.Now().UTC()
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "revoked-token-hash-mysql-456",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: &revokedAt,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Retrieve the revoked token by hash
+	retrievedToken, err := tokenRepo.GetByTokenHash(ctx, token.TokenHash)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	require.NotNil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, revokedAt, *retrievedToken.RevokedAt, time.Second)
+}
+
+func TestMySQLTokenRepository_GetByTokenHash_WithTransaction(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-hash-tx-mysql",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewMySQLTokenRepository(db)
+
+	// Create a token outside transaction
+	token1 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-tx-mysql-1",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another token inside transaction
+	time.Sleep(time.Millisecond)
+	token2 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-tx-mysql-2",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(48 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Marshal UUIDs
+	id2, err := token2.ID.MarshalBinary()
+	require.NoError(t, err)
+
+	clientID, err := token2.ClientID.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id2,
+		token2.TokenHash,
+		clientID,
+		token2.ExpiresAt,
+		token2.RevokedAt,
+		token2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Token1 should be retrievable by hash
+	retrievedToken1, err := tokenRepo.GetByTokenHash(ctx, token1.TokenHash)
+	require.NoError(t, err)
+	assert.Equal(t, token1.ID, retrievedToken1.ID)
+	assert.Equal(t, token1.TokenHash, retrievedToken1.TokenHash)
+
+	// Token2 should not be retrievable (transaction was rolled back)
+	retrievedToken2, err := tokenRepo.GetByTokenHash(ctx, token2.TokenHash)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedToken2)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}

--- a/internal/auth/repository/postgresql_token_repository_test.go
+++ b/internal/auth/repository/postgresql_token_repository_test.go
@@ -526,3 +526,192 @@ func TestPostgreSQLTokenRepository_Get_WithTransaction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, token2.ID, retrievedToken2.ID)
 }
+
+func TestPostgreSQLTokenRepository_GetByTokenHash_Success(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-get-by-hash",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "unique-token-hash-123",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Retrieve the token by hash
+	retrievedToken, err := tokenRepo.GetByTokenHash(ctx, token.TokenHash)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	assert.WithinDuration(t, token.ExpiresAt, retrievedToken.ExpiresAt, time.Second)
+	assert.Nil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, token.CreatedAt, retrievedToken.CreatedAt, time.Second)
+}
+
+func TestPostgreSQLTokenRepository_GetByTokenHash_NotFound(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+	ctx := context.Background()
+
+	// Try to get a token with a non-existent hash
+	token, err := tokenRepo.GetByTokenHash(ctx, "non-existent-hash")
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}
+
+func TestPostgreSQLTokenRepository_GetByTokenHash_WithRevokedToken(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-revoked-hash",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// Create a revoked token
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+	revokedAt := time.Now().UTC()
+
+	token := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "revoked-token-hash-456",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: &revokedAt,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token)
+	require.NoError(t, err)
+
+	// Retrieve the revoked token by hash
+	retrievedToken, err := tokenRepo.GetByTokenHash(ctx, token.TokenHash)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedToken)
+
+	assert.Equal(t, token.ID, retrievedToken.ID)
+	assert.Equal(t, token.TokenHash, retrievedToken.TokenHash)
+	assert.Equal(t, token.ClientID, retrievedToken.ClientID)
+	require.NotNil(t, retrievedToken.RevokedAt)
+	assert.WithinDuration(t, revokedAt, *retrievedToken.RevokedAt, time.Second)
+}
+
+func TestPostgreSQLTokenRepository_GetByTokenHash_WithTransaction(t *testing.T) {
+	db := testutil.SetupPostgresDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupPostgresDB(t, db)
+
+	// First create a client for the foreign key
+	clientRepo := NewPostgreSQLClientRepository(db)
+	ctx := context.Background()
+
+	client := &authDomain.Client{
+		ID:        uuid.Must(uuid.NewV7()),
+		Secret:    "test-secret",
+		Name:      "test-client-hash-tx",
+		IsActive:  true,
+		CreatedAt: time.Now().UTC(),
+	}
+	err := clientRepo.Create(ctx, client)
+	require.NoError(t, err)
+
+	tokenRepo := NewPostgreSQLTokenRepository(db)
+
+	// Create a token outside transaction
+	token1 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-tx-1",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = tokenRepo.Create(ctx, token1)
+	require.NoError(t, err)
+
+	// Start a transaction
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// Create another token inside transaction
+	time.Sleep(time.Millisecond)
+	token2 := &authDomain.Token{
+		ID:        uuid.Must(uuid.NewV7()),
+		TokenHash: "token-hash-tx-2",
+		ClientID:  client.ID,
+		ExpiresAt: time.Now().UTC().Add(48 * time.Hour),
+		RevokedAt: nil,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tokens (id, token_hash, client_id, expires_at, revoked_at, created_at) 
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		token2.ID,
+		token2.TokenHash,
+		token2.ClientID,
+		token2.ExpiresAt,
+		token2.RevokedAt,
+		token2.CreatedAt,
+	)
+	require.NoError(t, err)
+
+	// Rollback transaction
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	// Token1 should be retrievable by hash
+	retrievedToken1, err := tokenRepo.GetByTokenHash(ctx, token1.TokenHash)
+	require.NoError(t, err)
+	assert.Equal(t, token1.ID, retrievedToken1.ID)
+	assert.Equal(t, token1.TokenHash, retrievedToken1.TokenHash)
+
+	// Token2 should not be retrievable (transaction was rolled back)
+	retrievedToken2, err := tokenRepo.GetByTokenHash(ctx, token2.TokenHash)
+	assert.Error(t, err)
+	assert.Nil(t, retrievedToken2)
+	assert.ErrorIs(t, err, authDomain.ErrTokenNotFound)
+}

--- a/internal/auth/usecase/interface.go
+++ b/internal/auth/usecase/interface.go
@@ -33,6 +33,8 @@ type TokenRepository interface {
 
 	// Get retrieves a token by ID. Returns ErrTokenNotFound if not found.
 	Get(ctx context.Context, tokenID uuid.UUID) (*authDomain.Token, error)
+
+	GetByTokenHash(ctx context.Context, tokenHash string) (*authDomain.Token, error)
 }
 
 // ClientUseCase defines business logic operations for managing authentication clients.

--- a/internal/auth/usecase/token_usecase_test.go
+++ b/internal/auth/usecase/token_usecase_test.go
@@ -52,6 +52,17 @@ func (m *mockTokenRepository) Get(ctx context.Context, tokenID uuid.UUID) (*auth
 	return args.Get(0).(*authDomain.Token), args.Error(1)
 }
 
+func (m *mockTokenRepository) GetByTokenHash(
+	ctx context.Context,
+	tokenHash string,
+) (*authDomain.Token, error) {
+	args := m.Called(ctx, tokenHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authDomain.Token), args.Error(1)
+}
+
 func TestTokenUseCase_Issue(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Add GetByTokenHash method to both PostgreSQL and MySQL token repositories to enable token lookup by hash value, supporting authentication workflows where tokens need to be verified by their hash rather than ID. Both implementations follow the existing repository pattern with transaction support via database.GetTx() and proper error handling with ErrTokenNotFound for missing tokens.