### PR TITLE
feat(auth): add authentication and authorization middleware for Gin

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -34,3 +34,4 @@ packages:
       ClientRepository:
       TokenRepository:
       ClientUseCase:
+      TokenUseCase:

--- a/internal/auth/http/context.go
+++ b/internal/auth/http/context.go
@@ -1,0 +1,25 @@
+// Package http provides HTTP middleware and utilities for authentication.
+package http
+
+import (
+	"context"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+)
+
+// clientKey is a context key type for storing authenticated clients.
+type clientKey struct{}
+
+// WithClient stores an authenticated client in the context.
+// This is typically called by the authentication middleware after successful token validation.
+func WithClient(ctx context.Context, client *authDomain.Client) context.Context {
+	return context.WithValue(ctx, clientKey{}, client)
+}
+
+// GetClient retrieves an authenticated client from the context.
+// Returns (client, true) if a client is present, or (nil, false) if no client was set.
+// This is typically called by handlers or subsequent middleware that need the authenticated client.
+func GetClient(ctx context.Context) (*authDomain.Client, bool) {
+	client, ok := ctx.Value(clientKey{}).(*authDomain.Client)
+	return client, ok
+}

--- a/internal/auth/http/middleware.go
+++ b/internal/auth/http/middleware.go
@@ -1,0 +1,183 @@
+// Package http provides HTTP middleware and utilities for authentication.
+package http
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	authService "github.com/allisson/secrets/internal/auth/service"
+	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
+	apperrors "github.com/allisson/secrets/internal/errors"
+	"github.com/allisson/secrets/internal/httputil"
+)
+
+// AuthenticationMiddleware provides authentication via Bearer token in the Authorization header.
+//
+// The middleware:
+// 1. Extracts the Bearer token from the Authorization header (case-insensitive)
+// 2. Hashes the token using tokenService.HashToken()
+// 3. Validates the token using tokenUseCase.Authenticate()
+// 4. Stores the authenticated client in the request context
+// 5. Allows downstream handlers to access the client via GetClient()
+//
+// Authorization header format: "Bearer <token>" (case-insensitive "bearer")
+//
+// Error handling:
+//   - Missing Authorization header → 401 Unauthorized
+//   - Malformed Authorization header → 401 Unauthorized
+//   - Invalid/expired/revoked token → 401 Unauthorized (from TokenUseCase.Authenticate)
+//   - Inactive client → 403 Forbidden (from TokenUseCase.Authenticate)
+//   - Other errors → 500 Internal Server Error
+//
+// Usage:
+//
+//	router.Use(AuthenticationMiddleware(tokenUseCase, tokenService, logger))
+//	router.GET("/protected", func(c *gin.Context) {
+//	    client, ok := GetClient(c.Request.Context())
+//	    if !ok {
+//	        // Should never happen if middleware is working correctly
+//	        c.JSON(401, gin.H{"error": "unauthorized"})
+//	        return
+//	    }
+//	    // Use client for authorization checks
+//	})
+func AuthenticationMiddleware(
+	tokenUseCase authUseCase.TokenUseCase,
+	tokenService authService.TokenService,
+	logger *slog.Logger,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Extract Authorization header
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			logger.Debug("authentication failed: missing authorization header")
+			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
+			c.Abort()
+			return
+		}
+
+		// Parse Bearer token (case-insensitive)
+		const bearerPrefix = "bearer "
+		if len(authHeader) < len(bearerPrefix) ||
+			!strings.EqualFold(authHeader[:len(bearerPrefix)], bearerPrefix) {
+			logger.Debug("authentication failed: malformed authorization header",
+				slog.String("header", authHeader))
+			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
+			c.Abort()
+			return
+		}
+
+		plainToken := authHeader[len(bearerPrefix):]
+		if plainToken == "" {
+			logger.Debug("authentication failed: empty bearer token")
+			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
+			c.Abort()
+			return
+		}
+
+		// Hash the token for lookup
+		tokenHash := tokenService.HashToken(plainToken)
+
+		// Authenticate using the token hash
+		client, err := tokenUseCase.Authenticate(c.Request.Context(), tokenHash)
+		if err != nil {
+			logger.Debug("authentication failed",
+				slog.String("error", err.Error()))
+			httputil.HandleErrorGin(c, err, logger)
+			c.Abort()
+			return
+		}
+
+		// Store authenticated client in context
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+
+		logger.Debug("authentication successful",
+			slog.String("client_id", client.ID.String()),
+			slog.String("client_name", client.Name))
+
+		// Continue to next handler
+		c.Next()
+	}
+}
+
+// AuthorizationMiddleware provides capability-based authorization for authenticated clients.
+//
+// This middleware MUST be used after AuthenticationMiddleware, as it requires an authenticated
+// client to be present in the request context. It checks if the client's policies permit the
+// requested capability on the current request path.
+//
+// The middleware:
+// 1. Retrieves the authenticated client from the request context via GetClient()
+// 2. Extracts the request path from c.Request.URL.Path
+// 3. Checks if the client is allowed to perform the specified capability on the path
+// 4. Uses Client.IsAllowed(path, capability) for policy-based authorization
+// 5. Returns 403 Forbidden if the client lacks the required permission
+// 6. Returns 401 Unauthorized if no authenticated client is found in context
+//
+// Path Matching:
+// The authorization check uses the Client.IsAllowed() method which supports:
+//   - Exact path matching: "/secrets/mykey" matches policy "/secrets/mykey"
+//   - Wildcard matching: "*" matches all paths (admin mode)
+//   - Prefix matching: "secret/*" matches any path starting with "secret/"
+//
+// Error handling:
+//   - No client in context → 401 Unauthorized (AuthenticationMiddleware not run)
+//   - Client lacks capability → 403 Forbidden
+//   - Path doesn't match any policy → 403 Forbidden
+//
+// Usage:
+//
+//	// Require read capability for GET /api/v1/secrets/:id
+//	router.GET("/api/v1/secrets/:id",
+//	    AuthenticationMiddleware(tokenUseCase, tokenService, logger),
+//	    AuthorizationMiddleware(authDomain.ReadCapability, logger),
+//	    handler)
+//
+//	// Require write capability for POST /api/v1/secrets
+//	router.POST("/api/v1/secrets",
+//	    AuthenticationMiddleware(tokenUseCase, tokenService, logger),
+//	    AuthorizationMiddleware(authDomain.WriteCapability, logger),
+//	    handler)
+func AuthorizationMiddleware(
+	capability authDomain.Capability,
+	logger *slog.Logger,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Retrieve authenticated client from context
+		client, ok := GetClient(c.Request.Context())
+		if !ok || client == nil {
+			logger.Debug("authorization failed: no authenticated client in context")
+			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
+			c.Abort()
+			return
+		}
+
+		// Extract request path
+		path := c.Request.URL.Path
+
+		// Check if client is allowed to perform the capability on the path
+		if !client.IsAllowed(path, capability) {
+			logger.Debug("authorization failed: insufficient permissions",
+				slog.String("client_id", client.ID.String()),
+				slog.String("client_name", client.Name),
+				slog.String("path", path),
+				slog.String("capability", string(capability)))
+			httputil.HandleErrorGin(c, apperrors.ErrForbidden, logger)
+			c.Abort()
+			return
+		}
+
+		logger.Debug("authorization successful",
+			slog.String("client_id", client.ID.String()),
+			slog.String("client_name", client.Name),
+			slog.String("path", path),
+			slog.String("capability", string(capability)))
+
+		// Continue to next handler
+		c.Next()
+	}
+}

--- a/internal/auth/http/middleware_test.go
+++ b/internal/auth/http/middleware_test.go
@@ -1,0 +1,923 @@
+// Package http provides HTTP middleware and utilities for authentication.
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/httputil"
+)
+
+// mockTokenUseCase is a mock implementation of TokenUseCase for testing.
+type mockTokenUseCase struct {
+	mock.Mock
+}
+
+func (m *mockTokenUseCase) Issue(
+	ctx context.Context,
+	issueTokenInput *authDomain.IssueTokenInput,
+) (*authDomain.IssueTokenOutput, error) {
+	args := m.Called(ctx, issueTokenInput)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authDomain.IssueTokenOutput), args.Error(1)
+}
+
+func (m *mockTokenUseCase) Authenticate(ctx context.Context, tokenHash string) (*authDomain.Client, error) {
+	args := m.Called(ctx, tokenHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authDomain.Client), args.Error(1)
+}
+
+// mockTokenService is a mock implementation of TokenService for testing.
+type mockTokenService struct {
+	mock.Mock
+}
+
+func (m *mockTokenService) GenerateToken() (plainToken string, tokenHash string, error error) {
+	args := m.Called()
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *mockTokenService) HashToken(plainToken string) string {
+	args := m.Called(plainToken)
+	return args.String(0)
+}
+
+// TestMain sets Gin to test mode for all tests in this package.
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	os.Exit(m.Run())
+}
+
+// createTestLogger creates a test logger that discards output.
+func createTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestAuthenticationMiddleware_Success tests successful authentication with valid Bearer token.
+func TestAuthenticationMiddleware_Success(t *testing.T) {
+	// Setup mocks
+	mockTokenUC := &mockTokenUseCase{}
+	mockTokenSvc := &mockTokenService{}
+	logger := createTestLogger()
+
+	// Test data
+	plainToken := "test-token-xyz789"
+	tokenHash := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	clientID := uuid.Must(uuid.NewV7())
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "test-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{},
+	}
+
+	// Setup expectations
+	mockTokenSvc.On("HashToken", plainToken).Return(tokenHash).Once()
+	mockTokenUC.On("Authenticate", mock.Anything, tokenHash).Return(client, nil).Once()
+
+	// Create test router with middleware
+	router := gin.New()
+	router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+	router.GET("/test", func(c *gin.Context) {
+		// Verify client is in context
+		retrievedClient, ok := GetClient(c.Request.Context())
+		require.True(t, ok, "client should be in context")
+		require.NotNil(t, retrievedClient, "client should not be nil")
+		assert.Equal(t, clientID, retrievedClient.ID)
+		assert.Equal(t, "test-client", retrievedClient.Name)
+
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+plainToken)
+	router.ServeHTTP(w, req)
+
+	// Assertions
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockTokenSvc.AssertExpectations(t)
+	mockTokenUC.AssertExpectations(t)
+}
+
+// TestAuthenticationMiddleware_Success_CaseInsensitiveBearer tests case-insensitive Bearer prefix.
+func TestAuthenticationMiddleware_Success_CaseInsensitiveBearer(t *testing.T) {
+	testCases := []struct {
+		name   string
+		prefix string
+	}{
+		{"lowercase_bearer", "bearer "},
+		{"uppercase_BEARER", "BEARER "},
+		{"mixedcase_BeArEr", "BeArEr "},
+		{"standard_Bearer", "Bearer "},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mocks
+			mockTokenUC := &mockTokenUseCase{}
+			mockTokenSvc := &mockTokenService{}
+			logger := createTestLogger()
+
+			plainToken := "test-token-xyz789"
+			tokenHash := "hash123"
+			client := &authDomain.Client{
+				ID:       uuid.Must(uuid.NewV7()),
+				Name:     "test-client",
+				IsActive: true,
+			}
+
+			mockTokenSvc.On("HashToken", plainToken).Return(tokenHash).Once()
+			mockTokenUC.On("Authenticate", mock.Anything, tokenHash).Return(client, nil).Once()
+
+			// Create test router
+			router := gin.New()
+			router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+			router.GET("/test", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"message": "success"})
+			})
+
+			// Make request with different case
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", tc.prefix+plainToken)
+			router.ServeHTTP(w, req)
+
+			// Should succeed regardless of case
+			assert.Equal(t, http.StatusOK, w.Code)
+			mockTokenSvc.AssertExpectations(t)
+			mockTokenUC.AssertExpectations(t)
+		})
+	}
+}
+
+// TestAuthenticationMiddleware_Error_MissingAuthorizationHeader tests missing Authorization header.
+func TestAuthenticationMiddleware_Error_MissingAuthorizationHeader(t *testing.T) {
+	mockTokenUC := &mockTokenUseCase{}
+	mockTokenSvc := &mockTokenService{}
+	logger := createTestLogger()
+
+	// Create test router with middleware
+	router := gin.New()
+	router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+	router.GET("/test", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authentication fails")
+	})
+
+	// Make request without Authorization header
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	router.ServeHTTP(w, req)
+
+	// Assertions
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unauthorized", response.Error)
+
+	// Verify no use case methods were called
+	mockTokenSvc.AssertNotCalled(t, "HashToken", mock.Anything)
+	mockTokenUC.AssertNotCalled(t, "Authenticate", mock.Anything, mock.Anything)
+}
+
+// TestAuthenticationMiddleware_Error_MalformedAuthorizationHeader tests malformed Authorization header.
+func TestAuthenticationMiddleware_Error_MalformedAuthorizationHeader(t *testing.T) {
+	testCases := []struct {
+		name   string
+		header string
+	}{
+		{"no_prefix", "just-a-token"},
+		{"wrong_prefix", "Basic username:password"},
+		{"missing_space", "Bearertoken"},
+		{"only_bearer", "Bearer"},
+		{"only_bearer_with_space", "Bearer "},
+		{"empty_token", "Bearer "},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockTokenUC := &mockTokenUseCase{}
+			mockTokenSvc := &mockTokenService{}
+			logger := createTestLogger()
+
+			// Create test router with middleware
+			router := gin.New()
+			router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+			router.GET("/test", func(c *gin.Context) {
+				t.Fatal("handler should not be called when authentication fails")
+			})
+
+			// Make request with malformed header
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", tc.header)
+			router.ServeHTTP(w, req)
+
+			// Assertions
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+			var response httputil.ErrorResponse
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, "unauthorized", response.Error)
+
+			// Verify no use case methods were called
+			mockTokenSvc.AssertNotCalled(t, "HashToken", mock.Anything)
+			mockTokenUC.AssertNotCalled(t, "Authenticate", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestAuthenticationMiddleware_Error_InvalidToken tests authentication with invalid token.
+func TestAuthenticationMiddleware_Error_InvalidToken(t *testing.T) {
+	mockTokenUC := &mockTokenUseCase{}
+	mockTokenSvc := &mockTokenService{}
+	logger := createTestLogger()
+
+	plainToken := "invalid-token"
+	tokenHash := "invalid-hash"
+
+	// Setup expectations - token is invalid
+	mockTokenSvc.On("HashToken", plainToken).Return(tokenHash).Once()
+	mockTokenUC.On("Authenticate", mock.Anything, tokenHash).
+		Return(nil, authDomain.ErrInvalidCredentials).Once()
+
+	// Create test router with middleware
+	router := gin.New()
+	router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+	router.GET("/test", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authentication fails")
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+plainToken)
+	router.ServeHTTP(w, req)
+
+	// Assertions
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unauthorized", response.Error)
+
+	mockTokenSvc.AssertExpectations(t)
+	mockTokenUC.AssertExpectations(t)
+}
+
+// TestAuthenticationMiddleware_Error_InactiveClient tests authentication with inactive client.
+func TestAuthenticationMiddleware_Error_InactiveClient(t *testing.T) {
+	mockTokenUC := &mockTokenUseCase{}
+	mockTokenSvc := &mockTokenService{}
+	logger := createTestLogger()
+
+	plainToken := "valid-token"
+	tokenHash := "valid-hash"
+
+	// Setup expectations - client is inactive
+	mockTokenSvc.On("HashToken", plainToken).Return(tokenHash).Once()
+	mockTokenUC.On("Authenticate", mock.Anything, tokenHash).
+		Return(nil, authDomain.ErrClientInactive).Once()
+
+	// Create test router with middleware
+	router := gin.New()
+	router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+	router.GET("/test", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authentication fails")
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+plainToken)
+	router.ServeHTTP(w, req)
+
+	// Assertions
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "forbidden", response.Error)
+
+	mockTokenSvc.AssertExpectations(t)
+	mockTokenUC.AssertExpectations(t)
+}
+
+// TestAuthenticationMiddleware_Error_DatabaseError tests authentication with database error.
+func TestAuthenticationMiddleware_Error_DatabaseError(t *testing.T) {
+	mockTokenUC := &mockTokenUseCase{}
+	mockTokenSvc := &mockTokenService{}
+	logger := createTestLogger()
+
+	plainToken := "valid-token"
+	tokenHash := "valid-hash"
+
+	// Setup expectations - database error
+	mockTokenSvc.On("HashToken", plainToken).Return(tokenHash).Once()
+	mockTokenUC.On("Authenticate", mock.Anything, tokenHash).
+		Return(nil, assert.AnError).Once()
+
+	// Create test router with middleware
+	router := gin.New()
+	router.Use(AuthenticationMiddleware(mockTokenUC, mockTokenSvc, logger))
+	router.GET("/test", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authentication fails")
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+plainToken)
+	router.ServeHTTP(w, req)
+
+	// Assertions - should return 500 for unexpected errors
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "internal_error", response.Error)
+
+	mockTokenSvc.AssertExpectations(t)
+	mockTokenUC.AssertExpectations(t)
+}
+
+// TestGetClient_WithClient tests GetClient when client is in context.
+func TestGetClient_WithClient(t *testing.T) {
+	ctx := context.Background()
+	clientID := uuid.Must(uuid.NewV7())
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "test-client",
+		IsActive: true,
+	}
+
+	// Store client in context
+	ctx = WithClient(ctx, client)
+
+	// Retrieve client
+	retrievedClient, ok := GetClient(ctx)
+
+	// Assertions
+	assert.True(t, ok, "GetClient should return true")
+	require.NotNil(t, retrievedClient, "client should not be nil")
+	assert.Equal(t, clientID, retrievedClient.ID)
+	assert.Equal(t, "test-client", retrievedClient.Name)
+	assert.True(t, retrievedClient.IsActive)
+}
+
+// TestGetClient_WithoutClient tests GetClient when no client is in context.
+func TestGetClient_WithoutClient(t *testing.T) {
+	ctx := context.Background()
+
+	// Try to retrieve client from empty context
+	retrievedClient, ok := GetClient(ctx)
+
+	// Assertions
+	assert.False(t, ok, "GetClient should return false")
+	assert.Nil(t, retrievedClient, "client should be nil")
+}
+
+// TestWithClient_NilClient tests storing nil client in context.
+func TestWithClient_NilClient(t *testing.T) {
+	ctx := context.Background()
+
+	// Store nil client
+	ctx = WithClient(ctx, nil)
+
+	// Retrieve client
+	retrievedClient, ok := GetClient(ctx)
+
+	// Assertions
+	assert.True(t, ok, "GetClient should return true (value was set)")
+	assert.Nil(t, retrievedClient, "client should be nil")
+}
+
+// TestAuthorizationMiddleware_Success tests successful authorization with exact path match.
+func TestAuthorizationMiddleware_Success(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with read capability on specific path
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "test-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/api/v1/secrets",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+	}
+
+	// Create test router with middleware
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		// Simulate AuthenticationMiddleware by storing client in context
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+	router.GET("/api/v1/secrets", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	router.ServeHTTP(w, req)
+
+	// Assertions
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestAuthorizationMiddleware_Success_WildcardPath tests authorization with wildcard "*" path.
+func TestAuthorizationMiddleware_Success_WildcardPath(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create admin client with wildcard access
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "admin-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "*",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability, authDomain.WriteCapability},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		path       string
+		capability authDomain.Capability
+	}{
+		{"read_any_path", "/api/v1/secrets", authDomain.ReadCapability},
+		{"write_any_path", "/api/v1/secrets/new", authDomain.WriteCapability},
+		{"read_different_path", "/api/v1/keys/123", authDomain.ReadCapability},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create test router
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				ctx := WithClient(c.Request.Context(), client)
+				c.Request = c.Request.WithContext(ctx)
+				c.Next()
+			})
+			router.Use(AuthorizationMiddleware(tc.capability, logger))
+			router.GET(tc.path, func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"message": "success"})
+			})
+
+			// Make request
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			router.ServeHTTP(w, req)
+
+			// Should succeed with wildcard policy
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+// TestAuthorizationMiddleware_Success_PrefixWildcard tests authorization with prefix wildcard "path/*".
+func TestAuthorizationMiddleware_Success_PrefixWildcard(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with prefix wildcard access
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "secrets-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/secret/*",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		path          string
+		shouldSucceed bool
+	}{
+		{"match_prefix_single", "/secret/mykey", true},
+		{"match_prefix_nested", "/secret/team/prod/key", true},
+		{"no_match_different_prefix", "/public/key", false},
+		{"no_match_exact_without_slash", "/secret", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create test router
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				ctx := WithClient(c.Request.Context(), client)
+				c.Request = c.Request.WithContext(ctx)
+				c.Next()
+			})
+			router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+			router.GET("/*path", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"message": "success"})
+			})
+
+			// Make request
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			router.ServeHTTP(w, req)
+
+			if tc.shouldSucceed {
+				assert.Equal(t, http.StatusOK, w.Code)
+			} else {
+				assert.Equal(t, http.StatusForbidden, w.Code)
+			}
+		})
+	}
+}
+
+// TestAuthorizationMiddleware_Success_MultipleCapabilities tests authorization with multiple capabilities.
+func TestAuthorizationMiddleware_Success_MultipleCapabilities(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with multiple capabilities on same path
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "rw-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path: "/api/v1/secrets",
+				Capabilities: []authDomain.Capability{
+					authDomain.ReadCapability,
+					authDomain.WriteCapability,
+					authDomain.DeleteCapability,
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		capability authDomain.Capability
+	}{
+		{"read_capability", authDomain.ReadCapability},
+		{"write_capability", authDomain.WriteCapability},
+		{"delete_capability", authDomain.DeleteCapability},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create test router
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				ctx := WithClient(c.Request.Context(), client)
+				c.Request = c.Request.WithContext(ctx)
+				c.Next()
+			})
+			router.Use(AuthorizationMiddleware(tc.capability, logger))
+			router.GET("/api/v1/secrets", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"message": "success"})
+			})
+
+			// Make request
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+			router.ServeHTTP(w, req)
+
+			// Should succeed for all capabilities
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+// TestAuthorizationMiddleware_Error_NoClientInContext tests missing client in context.
+func TestAuthorizationMiddleware_Error_NoClientInContext(t *testing.T) {
+	logger := createTestLogger()
+
+	// Create test router without AuthenticationMiddleware
+	router := gin.New()
+	router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+	router.GET("/test", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authorization fails")
+	})
+
+	// Make request without client in context
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	router.ServeHTTP(w, req)
+
+	// Assertions - should return 401 when client is missing
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unauthorized", response.Error)
+}
+
+// TestAuthorizationMiddleware_Error_ClientLacksCapability tests client without required capability.
+func TestAuthorizationMiddleware_Error_ClientLacksCapability(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with only read capability
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "readonly-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/api/v1/secrets",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+	}
+
+	// Create test router requiring write capability
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(AuthorizationMiddleware(authDomain.WriteCapability, logger))
+	router.POST("/api/v1/secrets", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authorization fails")
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/secrets", nil)
+	router.ServeHTTP(w, req)
+
+	// Assertions - should return 403 when capability is missing
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "forbidden", response.Error)
+}
+
+// TestAuthorizationMiddleware_Error_PathNotInPolicy tests path not matching any policy.
+func TestAuthorizationMiddleware_Error_PathNotInPolicy(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with access to /api/v1/secrets only
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "limited-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/api/v1/secrets",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+	}
+
+	// Create test router for different path
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+	router.GET("/api/v1/keys", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authorization fails")
+	})
+
+	// Make request to unauthorized path
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/keys", nil)
+	router.ServeHTTP(w, req)
+
+	// Assertions - should return 403 when path doesn't match
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "forbidden", response.Error)
+}
+
+// TestAuthorizationMiddleware_Error_WrongCapabilityForPath tests wrong capability for path.
+func TestAuthorizationMiddleware_Error_WrongCapabilityForPath(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with read on /secrets and write on /keys
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "split-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/api/v1/secrets",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+			{
+				Path:         "/api/v1/keys",
+				Capabilities: []authDomain.Capability{authDomain.WriteCapability},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		path       string
+		capability authDomain.Capability
+	}{
+		{"write_on_readonly_path", "/api/v1/secrets", authDomain.WriteCapability},
+		{"read_on_writeonly_path", "/api/v1/keys", authDomain.ReadCapability},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create test router
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				ctx := WithClient(c.Request.Context(), client)
+				c.Request = c.Request.WithContext(ctx)
+				c.Next()
+			})
+			router.Use(AuthorizationMiddleware(tc.capability, logger))
+			router.GET(tc.path, func(c *gin.Context) {
+				t.Fatal("handler should not be called when authorization fails")
+			})
+
+			// Make request
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			router.ServeHTTP(w, req)
+
+			// Should fail with 403
+			assert.Equal(t, http.StatusForbidden, w.Code)
+
+			var response httputil.ErrorResponse
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, "forbidden", response.Error)
+		})
+	}
+}
+
+// TestAuthorizationMiddleware_Error_EmptyPath tests that Client.IsAllowed handles empty paths correctly.
+// Note: In practice, Gin always normalizes paths to at least "/", but we test the middleware's
+// behavior with the domain logic that empty paths are rejected by Client.IsAllowed.
+func TestAuthorizationMiddleware_Error_EmptyPath(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with wildcard access
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "test-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "*",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+	}
+
+	// Create test router - use "/" as the path (Gin's normalized empty path)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+	router.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// Make request to root path "/"
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	router.ServeHTTP(w, req)
+
+	// Should succeed - "/" is a valid path and wildcard "*" matches everything
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestAuthorizationMiddleware_Error_InactiveClientStillAuthorizes tests that inactive clients
+// stored in context still pass authorization (authentication should have failed first).
+func TestAuthorizationMiddleware_Error_InactiveClientStillAuthorizes(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create inactive client with valid policies
+	// Note: This scenario shouldn't happen in practice because AuthenticationMiddleware
+	// would reject inactive clients, but we test the authorization logic in isolation.
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "inactive-client",
+		IsActive: false, // Inactive
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/api/v1/secrets",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+	}
+
+	// Create test router
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		// Simulate storing inactive client in context (shouldn't happen in practice)
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+	router.GET("/api/v1/secrets", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	router.ServeHTTP(w, req)
+
+	// Authorization middleware only checks policies, not IsActive status.
+	// AuthenticationMiddleware is responsible for checking IsActive.
+	// So this should succeed from an authorization perspective.
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestAuthorizationMiddleware_Error_NoPolicies tests client with no policies.
+func TestAuthorizationMiddleware_Error_NoPolicies(t *testing.T) {
+	logger := createTestLogger()
+	clientID := uuid.Must(uuid.NewV7())
+
+	// Create client with no policies
+	client := &authDomain.Client{
+		ID:       clientID,
+		Name:     "no-policy-client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{}, // Empty policies
+	}
+
+	// Create test router
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := WithClient(c.Request.Context(), client)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(AuthorizationMiddleware(authDomain.ReadCapability, logger))
+	router.GET("/api/v1/secrets", func(c *gin.Context) {
+		t.Fatal("handler should not be called when authorization fails")
+	})
+
+	// Make request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	router.ServeHTTP(w, req)
+
+	// Should fail with 403 when no policies exist
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var response httputil.ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "forbidden", response.Error)
+}


### PR DESCRIPTION
Implement Bearer token authentication and capability-based authorization middleware following Clean Architecture patterns. The middleware integrates with the existing token use case and provides context-based client management for downstream handlers.

**Authentication Middleware:**
- Extracts and validates Bearer tokens from Authorization header (case-insensitive)
- Hashes tokens using TokenService.HashToken() for secure lookup
- Authenticates via TokenUseCase.Authenticate() to validate token and retrieve client
- Stores authenticated client in request context for downstream access
- Returns 401 for missing/malformed tokens or invalid credentials
- Returns 403 for inactive clients

**Authorization Middleware:**
- Enforces capability-based access control using client policies
- Retrieves authenticated client from context (requires AuthenticationMiddleware)
- Checks Client.IsAllowed(path, capability) for policy-based permissions
- Supports exact path matching, wildcard "*", and prefix "path/*" patterns
- Returns 403 when client lacks required capability or path access
- Returns 401 when no authenticated client found in context

**Context Management:**
- WithClient() stores authenticated client in typed context key
- GetClient() retrieves client with existence check (client, bool)
- Type-safe context key prevents collisions

**Testing:**
- Comprehensive test suite with 20+ test cases covering success and error scenarios
- Tests for case-insensitive Bearer prefix, malformed headers, invalid tokens
- Tests for wildcard paths, prefix wildcards, multiple capabilities
- Tests for missing client, insufficient permissions, path mismatches
- Mock implementations for TokenUseCase and TokenService
- Integration-ready tests using Gin test utilities

**Configuration:**
- Updates .mockery.yaml to generate TokenUseCase mock