### PR TITLE
docs: standardize docstrings to enhanced compact format across codebase

### DIFF
--- a/internal/crypto/domain/dek.go
+++ b/internal/crypto/domain/dek.go
@@ -7,7 +7,8 @@ import (
 )
 
 // Dek represents a Data Encryption Key used to encrypt application data.
-// It is encrypted with a KEK and stored alongside the encrypted data.
+// Encrypted with a KEK and stored alongside encrypted data. The plaintext DEK is never
+// persisted and should be zeroed from memory immediately after use.
 type Dek struct {
 	ID           uuid.UUID // Unique identifier (UUIDv7)
 	KekID        uuid.UUID // Reference to the KEK used to encrypt this DEK

--- a/internal/crypto/domain/master_key.go
+++ b/internal/crypto/domain/master_key.go
@@ -9,7 +9,8 @@ import (
 )
 
 // MasterKey represents a cryptographic master key used to encrypt KEKs.
-// Should be 32 bytes (256 bits) and stored securely in KMS or environment variables.
+// Must be 32 bytes (256 bits) and stored securely in KMS or environment variables.
+// The Key field contains sensitive data and should be zeroed after use.
 type MasterKey struct {
 	ID  string // Unique identifier for the master key
 	Key []byte // The raw 32-byte master key material
@@ -44,6 +45,7 @@ func (m *MasterKeyChain) Close() {
 
 // LoadMasterKeyChainFromEnv loads master keys from MASTER_KEYS and ACTIVE_MASTER_KEY_ID environment variables.
 // Keys must be in format "id:base64key" (comma-separated) and exactly 32 bytes when decoded.
+// Returns ErrMasterKeysNotSet, ErrActiveMasterKeyIDNotSet, ErrInvalidKeySize, or ErrActiveMasterKeyNotFound on failure.
 func LoadMasterKeyChainFromEnv() (*MasterKeyChain, error) {
 	raw := os.Getenv("MASTER_KEYS")
 	if raw == "" {

--- a/internal/crypto/repository/postgresql_dek_repository.go
+++ b/internal/crypto/repository/postgresql_dek_repository.go
@@ -1,7 +1,3 @@
-// Package repository implements data persistence for KEKs and DEKs.
-//
-// Provides PostgreSQL and MySQL implementations with transaction support via database.GetTx().
-// PostgreSQL uses native UUID and BYTEA types, MySQL uses BINARY(16) and BLOB types.
 package repository
 
 import (

--- a/internal/crypto/repository/postgresql_kek_repository.go
+++ b/internal/crypto/repository/postgresql_kek_repository.go
@@ -1,7 +1,5 @@
 // Package repository implements data persistence for KEKs and DEKs.
-//
-// Provides PostgreSQL and MySQL implementations with transaction support via database.GetTx().
-// PostgreSQL uses native UUID and BYTEA types, MySQL uses BINARY(16) and BLOB types.
+// Provides PostgreSQL (UUID/BYTEA) and MySQL (BINARY/BLOB) implementations with transaction support.
 package repository
 
 import (
@@ -13,8 +11,7 @@ import (
 	apperrors "github.com/allisson/secrets/internal/errors"
 )
 
-// PostgreSQLKekRepository implements KEK persistence for PostgreSQL.
-// Uses native UUID and BYTEA types with transaction support via database.GetTx().
+// PostgreSQLKekRepository implements KEK persistence for PostgreSQL using native UUID and BYTEA types.
 type PostgreSQLKekRepository struct {
 	db *sql.DB
 }

--- a/internal/crypto/service/aead_manager.go
+++ b/internal/crypto/service/aead_manager.go
@@ -13,6 +13,7 @@ func NewAEADManager() *AEADManagerService {
 }
 
 // CreateCipher creates an AEAD cipher instance for the specified algorithm.
+// Returns ErrInvalidKeySize if key is not 32 bytes or ErrUnsupportedAlgorithm if algorithm is unknown.
 func (am *AEADManagerService) CreateCipher(key []byte, alg cryptoDomain.Algorithm) (AEAD, error) {
 	// Validate key size
 	if len(key) != 32 {

--- a/internal/crypto/service/aes_gcm.go
+++ b/internal/crypto/service/aes_gcm.go
@@ -1,6 +1,3 @@
-// Package service provides cryptographic services for envelope encryption.
-//
-// Implements AEAD ciphers (AES-256-GCM, ChaCha20-Poly1305) and key management.
 package service
 
 import (
@@ -17,6 +14,7 @@ type AESGCMCipher struct {
 }
 
 // NewAESGCM creates a new AES-256-GCM cipher instance.
+// Returns an error if key is not exactly 32 bytes.
 func NewAESGCM(key []byte) (*AESGCMCipher, error) {
 	if len(key) != 32 {
 		return nil, errors.New("key must be exactly 32 bytes")

--- a/internal/crypto/service/chacha20_poly1305.go
+++ b/internal/crypto/service/chacha20_poly1305.go
@@ -14,6 +14,7 @@ type ChaCha20Poly1305Cipher struct {
 }
 
 // NewChaCha20Poly1305 creates a new ChaCha20-Poly1305 cipher instance.
+// Returns an error if key is not exactly 32 bytes.
 func NewChaCha20Poly1305(key []byte) (*ChaCha20Poly1305Cipher, error) {
 	aead, err := chacha20poly1305.New(key)
 	if err != nil {

--- a/internal/crypto/service/interface.go
+++ b/internal/crypto/service/interface.go
@@ -1,7 +1,5 @@
 // Package service provides cryptographic services for envelope encryption.
-//
-// Implements AEAD ciphers (AES-256-GCM, ChaCha20-Poly1305) and manages KEK/DEK lifecycle.
-// Services follow Clean Architecture with dependency injection and stateless design.
+// Implements AEAD ciphers (AES-256-GCM, ChaCha20-Poly1305) for KEK/DEK management.
 package service
 
 import (

--- a/internal/crypto/service/key_manager.go
+++ b/internal/crypto/service/key_manager.go
@@ -22,7 +22,8 @@ func NewKeyManager(aeadManager AEADManager) *KeyManagerService {
 	}
 }
 
-// CreateKek creates a new KEK encrypted with the master key.
+// CreateKek generates a random 32-byte KEK, encrypts it with the master key, and returns the encrypted KEK.
+// The plaintext KEK is included in the returned Kek.Key field and should be zeroed after use.
 func (km *KeyManagerService) CreateKek(
 	masterKey *cryptoDomain.MasterKey,
 	alg cryptoDomain.Algorithm,
@@ -60,6 +61,7 @@ func (km *KeyManagerService) CreateKek(
 }
 
 // DecryptKek decrypts a KEK using the master key.
+// Returns ErrDecryptionFailed if decryption fails due to wrong key or corrupted data.
 func (km *KeyManagerService) DecryptKek(
 	kek *cryptoDomain.Kek,
 	masterKey *cryptoDomain.MasterKey,
@@ -79,7 +81,8 @@ func (km *KeyManagerService) DecryptKek(
 	return kekKey, nil
 }
 
-// CreateDek creates a new DEK encrypted with the KEK.
+// CreateDek generates a random 32-byte DEK and encrypts it with the KEK.
+// The plaintext DEK is NOT included in the returned struct and must be derived separately.
 func (km *KeyManagerService) CreateDek(
 	kek *cryptoDomain.Kek,
 	alg cryptoDomain.Algorithm,
@@ -115,6 +118,7 @@ func (km *KeyManagerService) CreateDek(
 }
 
 // DecryptDek decrypts a DEK using the KEK.
+// Returns ErrDecryptionFailed if decryption fails due to wrong key or corrupted data.
 func (km *KeyManagerService) DecryptDek(
 	dek *cryptoDomain.Dek,
 	kek *cryptoDomain.Kek,

--- a/internal/crypto/usecase/interface.go
+++ b/internal/crypto/usecase/interface.go
@@ -1,4 +1,4 @@
-// Package usecase defines business logic interfaces for cryptographic operations.
+// Package usecase defines business logic interfaces for KEK operations and repository contracts.
 package usecase
 
 import (

--- a/internal/crypto/usecase/kek_usecase.go
+++ b/internal/crypto/usecase/kek_usecase.go
@@ -1,4 +1,5 @@
 // Package usecase implements business logic orchestration for cryptographic operations.
+// Coordinates KEK lifecycle including creation, rotation, and decryption using repositories and services.
 package usecase
 
 import (
@@ -28,6 +29,7 @@ func (k *kekUseCase) getMasterKey(
 }
 
 // Create generates and persists a new KEK using the active master key.
+// Returns ErrMasterKeyNotFound if the active master key is not in the chain.
 func (k *kekUseCase) Create(
 	ctx context.Context,
 	masterKeyChain *cryptoDomain.MasterKeyChain,
@@ -47,7 +49,8 @@ func (k *kekUseCase) Create(
 }
 
 // Rotate performs atomic KEK rotation by creating a new KEK with incremented version.
-// If no KEKs exist, creates the first KEK with version 1.
+// If no KEKs exist, creates the first KEK with version 1. Executes within a transaction.
+// Returns ErrMasterKeyNotFound if the active master key is not in the chain.
 func (k *kekUseCase) Rotate(
 	ctx context.Context,
 	masterKeyChain *cryptoDomain.MasterKeyChain,
@@ -82,6 +85,7 @@ func (k *kekUseCase) Rotate(
 }
 
 // Unwrap decrypts all KEKs from the database and returns them in a KekChain for in-memory use.
+// Returns ErrMasterKeyNotFound if any KEK's master key is not in the chain, or ErrDecryptionFailed on decryption errors.
 func (k *kekUseCase) Unwrap(
 	ctx context.Context,
 	masterKeyChain *cryptoDomain.MasterKeyChain,


### PR DESCRIPTION
Update AGENTS.md to document the new enhanced compact format for docstrings and apply this format consistently across all code files. Replace verbose multi-step documentation with concise 1-2 sentence descriptions that focus on "what" and "why" rather than implementation details.

Changes:
- AGENTS.md: Add comprehensive guidelines for enhanced compact format with examples
- cmd/app/main.go: Simplify runCreateMasterKey, runCreateKek, and runRotateKek documentation
- internal/auth/http/middleware.go: Condense AuthenticationMiddleware and AuthorizationMiddleware docs
- internal/auth/usecase/token_usecase.go: Streamline Issue and Authenticate method documentation
- internal/crypto/domain/*.go: Improve domain model documentation (Kek, Dek, MasterKey)
- internal/crypto/repository/*.go: Update package and type documentation
- internal/crypto/service/*.go: Simplify service interface and implementation docs
- internal/crypto/usecase/*.go: Condense use case method documentation

The new format integrates parameter context, error conditions, and security notes inline without formal "Parameters:" or "Returns:" sections, making documentation more readable while maintaining completeness.