### PR TITLE
refactor(cmd): extract CLI command implementations into separate package

### DIFF
--- a/cmd/app/commands/create_kek.go
+++ b/cmd/app/commands/create_kek.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/allisson/secrets/internal/app"
+	"github.com/allisson/secrets/internal/config"
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+)
+
+// RunCreateKek creates a new Key Encryption Key using the specified algorithm.
+// Should only be run once during initial system setup. The KEK is encrypted using
+// the active master key from MASTER_KEYS environment variable.
+//
+// Requirements: Database must be migrated, MASTER_KEYS and ACTIVE_MASTER_KEY_ID must be set.
+func RunCreateKek(ctx context.Context, algorithmStr string) error {
+	// Load configuration
+	cfg := config.Load()
+
+	// Create DI container
+	container := app.NewContainer(cfg)
+
+	// Get logger from container
+	logger := container.Logger()
+	logger.Info("creating new KEK", slog.String("algorithm", algorithmStr))
+
+	// Ensure cleanup on exit
+	defer closeContainer(container, logger)
+
+	// Parse algorithm
+	algorithm, err := parseAlgorithm(algorithmStr)
+	if err != nil {
+		return err
+	}
+
+	// Get master key chain from container
+	masterKeyChain, err := container.MasterKeyChain()
+	if err != nil {
+		return fmt.Errorf("failed to load master key chain: %w", err)
+	}
+
+	logger.Info("master key chain loaded",
+		slog.String("active_master_key_id", masterKeyChain.ActiveMasterKeyID()),
+	)
+
+	// Get KEK use case from container
+	kekUseCase, err := container.KekUseCase()
+	if err != nil {
+		return fmt.Errorf("failed to initialize KEK use case: %w", err)
+	}
+
+	// Create the KEK
+	if err := kekUseCase.Create(ctx, masterKeyChain, algorithm); err != nil {
+		return fmt.Errorf("failed to create KEK: %w", err)
+	}
+
+	logger.Info("KEK created successfully",
+		slog.String("algorithm", string(algorithm)),
+		slog.String("master_key_id", masterKeyChain.ActiveMasterKeyID()),
+	)
+
+	return nil
+}
+
+// parseAlgorithm converts algorithm string to cryptoDomain.Algorithm type.
+// Returns an error if the algorithm string is invalid.
+func parseAlgorithm(algorithmStr string) (cryptoDomain.Algorithm, error) {
+	switch algorithmStr {
+	case "aes-gcm":
+		return cryptoDomain.AESGCM, nil
+	case "chacha20-poly1305":
+		return cryptoDomain.ChaCha20, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid algorithm: %s (valid options: aes-gcm, chacha20-poly1305)",
+			algorithmStr,
+		)
+	}
+}

--- a/cmd/app/commands/helpers.go
+++ b/cmd/app/commands/helpers.go
@@ -1,0 +1,30 @@
+// Package commands contains CLI command implementations for the application.
+package commands
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/golang-migrate/migrate/v4"
+
+	"github.com/allisson/secrets/internal/app"
+)
+
+// closeContainer closes all resources in the container and logs any errors.
+func closeContainer(container *app.Container, logger *slog.Logger) {
+	if err := container.Shutdown(context.Background()); err != nil {
+		logger.Error("failed to shutdown container", slog.Any("error", err))
+	}
+}
+
+// closeMigrate closes the migration instance and logs any errors.
+func closeMigrate(migrate *migrate.Migrate, logger *slog.Logger) {
+	sourceError, databaseError := migrate.Close()
+	if sourceError != nil || databaseError != nil {
+		logger.Error(
+			"failed to close the migrate",
+			slog.Any("source_error", sourceError),
+			slog.Any("database_error", databaseError),
+		)
+	}
+}

--- a/cmd/app/commands/master_key.go
+++ b/cmd/app/commands/master_key.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+// RunCreateMasterKey generates a cryptographically secure 32-byte master key for envelope encryption.
+// Creates the root key used to encrypt all KEKs. Key material is zeroed from memory after encoding.
+// If keyID is empty, generates a default ID in format "master-key-YYYY-MM-DD".
+//
+// Output format: MASTER_KEYS="<keyID>:<base64-encoded-key>" and ACTIVE_MASTER_KEY_ID="<keyID>"
+//
+// Security: Store output securely (secrets manager/KMS), never commit to version control, rotate
+// every 90 days. For production, consider using a proper KMS instead of environment variables.
+func RunCreateMasterKey(keyID string) error {
+	// Generate default key ID if not provided
+	if keyID == "" {
+		keyID = fmt.Sprintf("master-key-%s", time.Now().Format("2006-01-02"))
+	}
+
+	// Generate a cryptographically secure 32-byte master key
+	masterKey := make([]byte, 32)
+	if _, err := rand.Read(masterKey); err != nil {
+		return fmt.Errorf("failed to generate master key: %w", err)
+	}
+
+	// Encode the master key to base64
+	encodedKey := base64.StdEncoding.EncodeToString(masterKey)
+
+	// Zero out the master key from memory for security
+	for i := range masterKey {
+		masterKey[i] = 0
+	}
+
+	// Print the environment variable configuration
+	fmt.Println("# Master Key Configuration")
+	fmt.Println("# Copy these environment variables to your .env file or secrets manager")
+	fmt.Println()
+	fmt.Printf("MASTER_KEYS=\"%s:%s\"\n", keyID, encodedKey)
+	fmt.Printf("ACTIVE_MASTER_KEY_ID=\"%s\"\n", keyID)
+	fmt.Println()
+	fmt.Println("# For multiple master keys (key rotation), use comma-separated format:")
+	fmt.Printf("# MASTER_KEYS=\"%s:%s,new-key:base64-encoded-new-key\"\n", keyID, encodedKey)
+	fmt.Println("# ACTIVE_MASTER_KEY_ID=\"new-key\"")
+
+	return nil
+}

--- a/cmd/app/commands/migrations.go
+++ b/cmd/app/commands/migrations.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/mysql"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+
+	"github.com/allisson/secrets/internal/app"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// RunMigrations executes database migrations based on the configured driver.
+// Determines migration path from DBDriver (postgresql or mysql) and applies all pending
+// migrations. Returns nil if no migrations to apply. Logs migration progress and success.
+func RunMigrations() error {
+	cfg := config.Load()
+
+	// Create container just for logger
+	container := app.NewContainer(cfg)
+	logger := container.Logger()
+
+	logger.Info("running database migrations",
+		slog.String("driver", cfg.DBDriver),
+	)
+
+	// Determine migration path based on driver
+	migrationsPath := "file://migrations/postgresql"
+	if cfg.DBDriver == "mysql" {
+		migrationsPath = "file://migrations/mysql"
+	}
+
+	m, err := migrate.New(migrationsPath, cfg.DBConnectionString)
+	if err != nil {
+		return fmt.Errorf("failed to create migrate instance: %w", err)
+	}
+	defer closeMigrate(m, logger)
+
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	logger.Info("migrations completed successfully")
+	return nil
+}

--- a/cmd/app/commands/rotate_kek.go
+++ b/cmd/app/commands/rotate_kek.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/allisson/secrets/internal/app"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// RunRotateKek rotates the existing Key Encryption Key using the specified algorithm.
+// Creates a new KEK version and marks the previous active KEK as inactive. The new KEK is
+// encrypted using the active master key. This operation is atomic and maintains backward
+// compatibility - existing DEKs encrypted with the old KEK remain readable.
+//
+// Key rotation recommended every 90 days or when suspecting KEK compromise, changing encryption
+// algorithms, or rotating master keys.
+//
+// Requirements: An active KEK must already exist, MASTER_KEYS and ACTIVE_MASTER_KEY_ID must be set.
+func RunRotateKek(ctx context.Context, algorithmStr string) error {
+	// Load configuration
+	cfg := config.Load()
+
+	// Create DI container
+	container := app.NewContainer(cfg)
+
+	// Get logger from container
+	logger := container.Logger()
+	logger.Info("rotating KEK", slog.String("algorithm", algorithmStr))
+
+	// Ensure cleanup on exit
+	defer closeContainer(container, logger)
+
+	// Parse algorithm
+	algorithm, err := parseAlgorithm(algorithmStr)
+	if err != nil {
+		return err
+	}
+
+	// Get master key chain from container
+	masterKeyChain, err := container.MasterKeyChain()
+	if err != nil {
+		return fmt.Errorf("failed to load master key chain: %w", err)
+	}
+
+	logger.Info("master key chain loaded",
+		slog.String("active_master_key_id", masterKeyChain.ActiveMasterKeyID()),
+	)
+
+	// Get KEK use case from container
+	kekUseCase, err := container.KekUseCase()
+	if err != nil {
+		return fmt.Errorf("failed to initialize KEK use case: %w", err)
+	}
+
+	// Rotate the KEK
+	if err := kekUseCase.Rotate(ctx, masterKeyChain, algorithm); err != nil {
+		return fmt.Errorf("failed to rotate KEK: %w", err)
+	}
+
+	logger.Info("KEK rotated successfully",
+		slog.String("algorithm", string(algorithm)),
+		slog.String("master_key_id", masterKeyChain.ActiveMasterKeyID()),
+	)
+
+	return nil
+}

--- a/cmd/app/commands/server.go
+++ b/cmd/app/commands/server.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/allisson/secrets/internal/app"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// RunServer starts the HTTP server with graceful shutdown support.
+// Loads configuration, initializes the DI container, and starts the Gin HTTP server.
+// Blocks until receiving SIGINT/SIGTERM or encountering a fatal error. On shutdown
+// signal, gracefully stops the server within DBConnMaxLifetime timeout.
+func RunServer(ctx context.Context) error {
+	// Load configuration
+	cfg := config.Load()
+
+	// Set Gin mode based on log level
+	gin.SetMode(cfg.GetGinMode())
+
+	// Create DI container
+	container := app.NewContainer(cfg)
+
+	// Get logger from container
+	logger := container.Logger()
+	logger.Info("starting server", slog.String("version", "1.0.0"))
+
+	// Ensure cleanup on exit
+	defer closeContainer(container, logger)
+
+	// Get HTTP server from container (this initializes all dependencies)
+	server, err := container.HTTPServer()
+	if err != nil {
+		return fmt.Errorf("failed to initialize HTTP server: %w", err)
+	}
+
+	// Setup graceful shutdown
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Start server in goroutine
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := server.Start(ctx); err != nil {
+			serverErr <- err
+		}
+	}()
+
+	// Wait for shutdown signal or server error
+	select {
+	case <-ctx.Done():
+		logger.Info("shutdown signal received")
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), cfg.DBConnMaxLifetime)
+		defer shutdownCancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("server shutdown failed: %w", err)
+		}
+	case err := <-serverErr:
+		return err
+	}
+
+	return nil
+}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -3,46 +3,13 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
-	"errors"
-	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/mysql"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/urfave/cli/v3"
 
-	"github.com/allisson/secrets/internal/app"
-	"github.com/allisson/secrets/internal/config"
-	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	"github.com/allisson/secrets/cmd/app/commands"
 )
-
-// closeContainer closes all resources in the container and logs any errors.
-func closeContainer(container *app.Container, logger *slog.Logger) {
-	if err := container.Shutdown(context.Background()); err != nil {
-		logger.Error("failed to shutdown container", slog.Any("error", err))
-	}
-}
-
-// closeMigrate closes the migration instance and logs any errors.
-func closeMigrate(migrate *migrate.Migrate, logger *slog.Logger) {
-	sourceError, databaseError := migrate.Close()
-	if sourceError != nil || databaseError != nil {
-		logger.Error(
-			"failed to close the migrate",
-			slog.Any("source_error", sourceError),
-			slog.Any("database_error", databaseError),
-		)
-	}
-}
 
 func main() {
 	cmd := &cli.Command{
@@ -54,14 +21,14 @@ func main() {
 				Name:  "server",
 				Usage: "Start the HTTP server",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runServer(ctx)
+					return commands.RunServer(ctx)
 				},
 			},
 			{
 				Name:  "migrate",
 				Usage: "Run database migrations",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runMigrations()
+					return commands.RunMigrations()
 				},
 			},
 			{
@@ -76,7 +43,7 @@ func main() {
 					},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runCreateMasterKey(cmd.String("id"))
+					return commands.RunCreateMasterKey(cmd.String("id"))
 				},
 			},
 			{
@@ -91,7 +58,7 @@ func main() {
 					},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runCreateKek(ctx, cmd.String("algorithm"))
+					return commands.RunCreateKek(ctx, cmd.String("algorithm"))
 				},
 			},
 			{
@@ -106,7 +73,7 @@ func main() {
 					},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runRotateKek(ctx, cmd.String("algorithm"))
+					return commands.RunRotateKek(ctx, cmd.String("algorithm"))
 				},
 			},
 		},
@@ -116,252 +83,4 @@ func main() {
 		slog.Error("application error", slog.Any("error", err))
 		os.Exit(1)
 	}
-}
-
-// runServer starts the HTTP server with graceful shutdown support.
-func runServer(ctx context.Context) error {
-	// Load configuration
-	cfg := config.Load()
-
-	// Set Gin mode based on log level
-	gin.SetMode(cfg.GetGinMode())
-
-	// Create DI container
-	container := app.NewContainer(cfg)
-
-	// Get logger from container
-	logger := container.Logger()
-	logger.Info("starting server", slog.String("version", "1.0.0"))
-
-	// Ensure cleanup on exit
-	defer closeContainer(container, logger)
-
-	// Get HTTP server from container (this initializes all dependencies)
-	server, err := container.HTTPServer()
-	if err != nil {
-		return fmt.Errorf("failed to initialize HTTP server: %w", err)
-	}
-
-	// Setup graceful shutdown
-	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	// Start server in goroutine
-	serverErr := make(chan error, 1)
-	go func() {
-		if err := server.Start(ctx); err != nil {
-			serverErr <- err
-		}
-	}()
-
-	// Wait for shutdown signal or server error
-	select {
-	case <-ctx.Done():
-		logger.Info("shutdown signal received")
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), cfg.DBConnMaxLifetime)
-		defer shutdownCancel()
-		if err := server.Shutdown(shutdownCtx); err != nil {
-			return fmt.Errorf("server shutdown failed: %w", err)
-		}
-	case err := <-serverErr:
-		return err
-	}
-
-	return nil
-}
-
-// runCreateMasterKey generates a cryptographically secure 32-byte master key for envelope encryption.
-// Creates the root key used to encrypt all KEKs. Key material is zeroed from memory after encoding.
-// If keyID is empty, generates a default ID in format "master-key-YYYY-MM-DD".
-//
-// Output format: MASTER_KEYS="<keyID>:<base64-encoded-key>" and ACTIVE_MASTER_KEY_ID="<keyID>"
-//
-// Security: Store output securely (secrets manager/KMS), never commit to version control, rotate
-// every 90 days. For production, consider using a proper KMS instead of environment variables.
-func runCreateMasterKey(keyID string) error {
-	// Generate default key ID if not provided
-	if keyID == "" {
-		keyID = fmt.Sprintf("master-key-%s", time.Now().Format("2006-01-02"))
-	}
-
-	// Generate a cryptographically secure 32-byte master key
-	masterKey := make([]byte, 32)
-	if _, err := rand.Read(masterKey); err != nil {
-		return fmt.Errorf("failed to generate master key: %w", err)
-	}
-
-	// Encode the master key to base64
-	encodedKey := base64.StdEncoding.EncodeToString(masterKey)
-
-	// Zero out the master key from memory for security
-	for i := range masterKey {
-		masterKey[i] = 0
-	}
-
-	// Print the environment variable configuration
-	fmt.Println("# Master Key Configuration")
-	fmt.Println("# Copy these environment variables to your .env file or secrets manager")
-	fmt.Println()
-	fmt.Printf("MASTER_KEYS=\"%s:%s\"\n", keyID, encodedKey)
-	fmt.Printf("ACTIVE_MASTER_KEY_ID=\"%s\"\n", keyID)
-	fmt.Println()
-	fmt.Println("# For multiple master keys (key rotation), use comma-separated format:")
-	fmt.Printf("# MASTER_KEYS=\"%s:%s,new-key:base64-encoded-new-key\"\n", keyID, encodedKey)
-	fmt.Println("# ACTIVE_MASTER_KEY_ID=\"new-key\"")
-
-	return nil
-}
-
-// runMigrations executes database migrations based on the configured driver.
-func runMigrations() error {
-	cfg := config.Load()
-
-	// Create container just for logger
-	container := app.NewContainer(cfg)
-	logger := container.Logger()
-
-	logger.Info("running database migrations",
-		slog.String("driver", cfg.DBDriver),
-	)
-
-	// Determine migration path based on driver
-	migrationsPath := "file://migrations/postgresql"
-	if cfg.DBDriver == "mysql" {
-		migrationsPath = "file://migrations/mysql"
-	}
-
-	m, err := migrate.New(migrationsPath, cfg.DBConnectionString)
-	if err != nil {
-		return fmt.Errorf("failed to create migrate instance: %w", err)
-	}
-	defer closeMigrate(m, logger)
-
-	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		return fmt.Errorf("failed to run migrations: %w", err)
-	}
-
-	logger.Info("migrations completed successfully")
-	return nil
-}
-
-// runCreateKek creates a new Key Encryption Key using the specified algorithm.
-// Should only be run once during initial system setup. The KEK is encrypted using
-// the active master key from MASTER_KEYS environment variable.
-//
-// Requirements: Database must be migrated, MASTER_KEYS and ACTIVE_MASTER_KEY_ID must be set.
-func runCreateKek(ctx context.Context, algorithmStr string) error {
-	// Load configuration
-	cfg := config.Load()
-
-	// Create DI container
-	container := app.NewContainer(cfg)
-
-	// Get logger from container
-	logger := container.Logger()
-	logger.Info("creating new KEK", slog.String("algorithm", algorithmStr))
-
-	// Ensure cleanup on exit
-	defer closeContainer(container, logger)
-
-	// Parse algorithm
-	var algorithm cryptoDomain.Algorithm
-	switch algorithmStr {
-	case "aes-gcm":
-		algorithm = cryptoDomain.AESGCM
-	case "chacha20-poly1305":
-		algorithm = cryptoDomain.ChaCha20
-	default:
-		return fmt.Errorf("invalid algorithm: %s (valid options: aes-gcm, chacha20-poly1305)", algorithmStr)
-	}
-
-	// Get master key chain from container
-	masterKeyChain, err := container.MasterKeyChain()
-	if err != nil {
-		return fmt.Errorf("failed to load master key chain: %w", err)
-	}
-
-	logger.Info("master key chain loaded",
-		slog.String("active_master_key_id", masterKeyChain.ActiveMasterKeyID()),
-	)
-
-	// Get KEK use case from container
-	kekUseCase, err := container.KekUseCase()
-	if err != nil {
-		return fmt.Errorf("failed to initialize KEK use case: %w", err)
-	}
-
-	// Create the KEK
-	if err := kekUseCase.Create(ctx, masterKeyChain, algorithm); err != nil {
-		return fmt.Errorf("failed to create KEK: %w", err)
-	}
-
-	logger.Info("KEK created successfully",
-		slog.String("algorithm", string(algorithm)),
-		slog.String("master_key_id", masterKeyChain.ActiveMasterKeyID()),
-	)
-
-	return nil
-}
-
-// runRotateKek rotates the existing Key Encryption Key using the specified algorithm.
-// Creates a new KEK version and marks the previous active KEK as inactive. The new KEK is
-// encrypted using the active master key. This operation is atomic and maintains backward
-// compatibility - existing DEKs encrypted with the old KEK remain readable.
-//
-// Key rotation recommended every 90 days or when suspecting KEK compromise, changing encryption
-// algorithms, or rotating master keys.
-//
-// Requirements: An active KEK must already exist, MASTER_KEYS and ACTIVE_MASTER_KEY_ID must be set.
-func runRotateKek(ctx context.Context, algorithmStr string) error {
-	// Load configuration
-	cfg := config.Load()
-
-	// Create DI container
-	container := app.NewContainer(cfg)
-
-	// Get logger from container
-	logger := container.Logger()
-	logger.Info("rotating KEK", slog.String("algorithm", algorithmStr))
-
-	// Ensure cleanup on exit
-	defer closeContainer(container, logger)
-
-	// Parse algorithm
-	var algorithm cryptoDomain.Algorithm
-	switch algorithmStr {
-	case "aes-gcm":
-		algorithm = cryptoDomain.AESGCM
-	case "chacha20-poly1305":
-		algorithm = cryptoDomain.ChaCha20
-	default:
-		return fmt.Errorf("invalid algorithm: %s (valid options: aes-gcm, chacha20-poly1305)", algorithmStr)
-	}
-
-	// Get master key chain from container
-	masterKeyChain, err := container.MasterKeyChain()
-	if err != nil {
-		return fmt.Errorf("failed to load master key chain: %w", err)
-	}
-
-	logger.Info("master key chain loaded",
-		slog.String("active_master_key_id", masterKeyChain.ActiveMasterKeyID()),
-	)
-
-	// Get KEK use case from container
-	kekUseCase, err := container.KekUseCase()
-	if err != nil {
-		return fmt.Errorf("failed to initialize KEK use case: %w", err)
-	}
-
-	// Rotate the KEK
-	if err := kekUseCase.Rotate(ctx, masterKeyChain, algorithm); err != nil {
-		return fmt.Errorf("failed to rotate KEK: %w", err)
-	}
-
-	logger.Info("KEK rotated successfully",
-		slog.String("algorithm", string(algorithm)),
-		slog.String("master_key_id", masterKeyChain.ActiveMasterKeyID()),
-	)
-
-	return nil
 }


### PR DESCRIPTION
- Reorganizes CLI command structure by moving all command logic from cmd/app/main.go into a dedicated cmd/app/commands package with one file per command. This improves maintainability, reduces file size (main.go reduced from ~367 to ~87 lines), and follows Single Responsibility Principle.
- Each command is now an exported Run* function (RunServer, RunMigrations, RunCreateMasterKey, RunCreateKek, RunRotateKek) with shared helper functions (closeContainer, closeMigrate, parseAlgorithm) kept package-private.
- Updates AGENTS.md with CLI Commands Structure section documenting the new organization pattern, command testing approach, and available commands.