### PR TITLE
feat(cmd): add create-client and update-client CLI commands

### DIFF
--- a/cmd/app/commands/create_client.go
+++ b/cmd/app/commands/create_client.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/allisson/secrets/internal/app"
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// RunCreateClient creates a new authentication client with policies.
+// Supports both interactive mode (when policiesJSON is empty) and non-interactive
+// mode (when policiesJSON is provided). Outputs client ID and plain secret in
+// either text or JSON format.
+//
+// Requirements: Database must be migrated and accessible.
+func RunCreateClient(
+	ctx context.Context,
+	name string,
+	isActive bool,
+	policiesJSON string,
+	format string,
+) error {
+	// Load configuration
+	cfg := config.Load()
+
+	// Create DI container
+	container := app.NewContainer(cfg)
+
+	// Get logger from container
+	logger := container.Logger()
+	logger.Info("creating new client", slog.String("name", name))
+
+	// Ensure cleanup on exit
+	defer closeContainer(container, logger)
+
+	// Parse or prompt for policies
+	var policies []authDomain.PolicyDocument
+	var err error
+
+	if policiesJSON == "" {
+		// Interactive mode
+		policies, err = promptForPolicies()
+		if err != nil {
+			return fmt.Errorf("failed to get policies: %w", err)
+		}
+	} else {
+		// Non-interactive mode: parse JSON
+		if err := json.Unmarshal([]byte(policiesJSON), &policies); err != nil {
+			return fmt.Errorf("failed to parse policies JSON: %w", err)
+		}
+	}
+
+	// Validate that at least one policy was provided
+	if len(policies) == 0 {
+		return fmt.Errorf("at least one policy is required")
+	}
+
+	// Get client use case from container
+	clientUseCase, err := container.ClientUseCase()
+	if err != nil {
+		return fmt.Errorf("failed to initialize client use case: %w", err)
+	}
+
+	// Create input
+	input := &authDomain.CreateClientInput{
+		Name:     name,
+		IsActive: isActive,
+		Policies: policies,
+	}
+
+	// Create the client
+	output, err := clientUseCase.Create(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	// Output result based on format
+	if format == "json" {
+		outputJSON(output)
+	} else {
+		outputText(output)
+	}
+
+	logger.Info("client created successfully",
+		slog.String("client_id", output.ID.String()),
+		slog.String("name", name),
+		slog.Bool("is_active", isActive),
+	)
+
+	return nil
+}
+
+// promptForPolicies interactively prompts the user to enter policy documents.
+// Shows available capabilities and accepts multiple policies until user declines.
+func promptForPolicies() ([]authDomain.PolicyDocument, error) {
+	reader := bufio.NewReader(os.Stdin)
+	var policies []authDomain.PolicyDocument
+
+	fmt.Println("\nEnter policies for the client")
+	fmt.Println("Available capabilities: read, write, delete, encrypt, decrypt, rotate")
+	fmt.Println()
+
+	policyNum := 1
+	for {
+		fmt.Printf("Policy #%d\n", policyNum)
+
+		// Get path
+		fmt.Print("Enter path pattern (e.g., 'secret/*' or '*'): ")
+		path, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read path: %w", err)
+		}
+		path = strings.TrimSpace(path)
+
+		if path == "" {
+			return nil, fmt.Errorf("path cannot be empty")
+		}
+
+		// Get capabilities
+		fmt.Print("Enter capabilities (comma-separated, e.g., 'read,write'): ")
+		capsInput, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read capabilities: %w", err)
+		}
+		capsInput = strings.TrimSpace(capsInput)
+
+		if capsInput == "" {
+			return nil, fmt.Errorf("capabilities cannot be empty")
+		}
+
+		capabilities, err := parseCapabilities(capsInput)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add policy
+		policies = append(policies, authDomain.PolicyDocument{
+			Path:         path,
+			Capabilities: capabilities,
+		})
+
+		// Ask if user wants to add another
+		fmt.Print("Add another policy? (y/n): ")
+		addAnother, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read input: %w", err)
+		}
+		addAnother = strings.ToLower(strings.TrimSpace(addAnother))
+
+		if addAnother != "y" && addAnother != "yes" {
+			break
+		}
+
+		fmt.Println()
+		policyNum++
+	}
+
+	return policies, nil
+}
+
+// parseCapabilities converts a comma-separated string into a slice of Capability.
+func parseCapabilities(input string) ([]authDomain.Capability, error) {
+	parts := strings.Split(input, ",")
+	capabilities := make([]authDomain.Capability, 0, len(parts))
+
+	for _, part := range parts {
+		cap := authDomain.Capability(strings.TrimSpace(part))
+		if cap != "" {
+			capabilities = append(capabilities, cap)
+		}
+	}
+
+	if len(capabilities) == 0 {
+		return nil, fmt.Errorf("at least one capability is required")
+	}
+
+	return capabilities, nil
+}
+
+// outputText outputs the result in human-readable text format.
+func outputText(output *authDomain.CreateClientOutput) {
+	fmt.Println("\nClient created successfully!")
+	fmt.Printf("Client ID: %s\n", output.ID.String())
+	fmt.Printf("Secret: %s\n", output.PlainSecret)
+	fmt.Println("\nIMPORTANT: The secret is shown only once. Store it securely.")
+}
+
+// outputJSON outputs the result in JSON format for machine consumption.
+func outputJSON(output *authDomain.CreateClientOutput) {
+	result := map[string]string{
+		"client_id": output.ID.String(),
+		"secret":    output.PlainSecret,
+	}
+
+	jsonBytes, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonBytes))
+}

--- a/cmd/app/commands/update_client.go
+++ b/cmd/app/commands/update_client.go
@@ -1,0 +1,215 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/allisson/secrets/internal/app"
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// RunUpdateClient updates an existing authentication client's configuration.
+// Supports both interactive mode (when policiesJSON is empty) and non-interactive
+// mode (when policiesJSON is provided). Only Name, IsActive, and Policies can be
+// updated. The client ID and secret remain unchanged.
+//
+// Requirements: Database must be migrated and the client must exist.
+func RunUpdateClient(
+	ctx context.Context,
+	clientIDStr string,
+	name string,
+	isActive bool,
+	policiesJSON string,
+	format string,
+) error {
+	// Load configuration
+	cfg := config.Load()
+
+	// Create DI container
+	container := app.NewContainer(cfg)
+
+	// Get logger from container
+	logger := container.Logger()
+	logger.Info("updating client", slog.String("client_id", clientIDStr))
+
+	// Ensure cleanup on exit
+	defer closeContainer(container, logger)
+
+	// Parse client ID
+	clientID, err := uuid.Parse(clientIDStr)
+	if err != nil {
+		return fmt.Errorf("invalid client ID format: %w", err)
+	}
+
+	// Get client use case from container
+	clientUseCase, err := container.ClientUseCase()
+	if err != nil {
+		return fmt.Errorf("failed to initialize client use case: %w", err)
+	}
+
+	// Get existing client to display current values if in interactive mode
+	existingClient, err := clientUseCase.Get(ctx, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to get existing client: %w", err)
+	}
+
+	// Parse or prompt for policies
+	var policies []authDomain.PolicyDocument
+
+	if policiesJSON == "" {
+		// Interactive mode - show current policies and prompt for new ones
+		policies, err = promptForPoliciesUpdate(existingClient.Policies)
+		if err != nil {
+			return fmt.Errorf("failed to get policies: %w", err)
+		}
+	} else {
+		// Non-interactive mode: parse JSON
+		if err := json.Unmarshal([]byte(policiesJSON), &policies); err != nil {
+			return fmt.Errorf("failed to parse policies JSON: %w", err)
+		}
+	}
+
+	// Validate that at least one policy was provided
+	if len(policies) == 0 {
+		return fmt.Errorf("at least one policy is required")
+	}
+
+	// Create update input
+	input := &authDomain.UpdateClientInput{
+		Name:     name,
+		IsActive: isActive,
+		Policies: policies,
+	}
+
+	// Update the client
+	if err := clientUseCase.Update(ctx, clientID, input); err != nil {
+		return fmt.Errorf("failed to update client: %w", err)
+	}
+
+	// Output result based on format
+	if format == "json" {
+		outputUpdateJSON(clientID, name, isActive)
+	} else {
+		outputUpdateText(clientID, name, isActive)
+	}
+
+	logger.Info("client updated successfully",
+		slog.String("client_id", clientID.String()),
+		slog.String("name", name),
+		slog.Bool("is_active", isActive),
+	)
+
+	return nil
+}
+
+// promptForPoliciesUpdate interactively prompts the user to enter policy documents.
+// Shows current policies and available capabilities. Accepts multiple policies until user declines.
+func promptForPoliciesUpdate(
+	currentPolicies []authDomain.PolicyDocument,
+) ([]authDomain.PolicyDocument, error) {
+	reader := bufio.NewReader(os.Stdin)
+	var policies []authDomain.PolicyDocument
+
+	fmt.Println("\nCurrent policies:")
+	for i, policy := range currentPolicies {
+		capsStr := make([]string, len(policy.Capabilities))
+		for j, cap := range policy.Capabilities {
+			capsStr[j] = string(cap)
+		}
+		fmt.Printf("  %d. Path: %s, Capabilities: [%s]\n", i+1, policy.Path, strings.Join(capsStr, ", "))
+	}
+
+	fmt.Println("\nEnter new policies for the client")
+	fmt.Println("Available capabilities: read, write, delete, encrypt, decrypt, rotate")
+	fmt.Println()
+
+	policyNum := 1
+	for {
+		fmt.Printf("Policy #%d\n", policyNum)
+
+		// Get path
+		fmt.Print("Enter path pattern (e.g., 'secret/*' or '*'): ")
+		path, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read path: %w", err)
+		}
+		path = strings.TrimSpace(path)
+
+		if path == "" {
+			return nil, fmt.Errorf("path cannot be empty")
+		}
+
+		// Get capabilities
+		fmt.Print("Enter capabilities (comma-separated, e.g., 'read,write'): ")
+		capsInput, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read capabilities: %w", err)
+		}
+		capsInput = strings.TrimSpace(capsInput)
+
+		if capsInput == "" {
+			return nil, fmt.Errorf("capabilities cannot be empty")
+		}
+
+		capabilities, err := parseCapabilities(capsInput)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add policy
+		policies = append(policies, authDomain.PolicyDocument{
+			Path:         path,
+			Capabilities: capabilities,
+		})
+
+		// Ask if user wants to add another
+		fmt.Print("Add another policy? (y/n): ")
+		addAnother, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read input: %w", err)
+		}
+		addAnother = strings.ToLower(strings.TrimSpace(addAnother))
+
+		if addAnother != "y" && addAnother != "yes" {
+			break
+		}
+
+		fmt.Println()
+		policyNum++
+	}
+
+	return policies, nil
+}
+
+// outputUpdateText outputs the result in human-readable text format.
+func outputUpdateText(clientID uuid.UUID, name string, isActive bool) {
+	fmt.Println("\nClient updated successfully!")
+	fmt.Printf("Client ID: %s\n", clientID.String())
+	fmt.Printf("Name: %s\n", name)
+	fmt.Printf("Active: %t\n", isActive)
+}
+
+// outputUpdateJSON outputs the result in JSON format for machine consumption.
+func outputUpdateJSON(clientID uuid.UUID, name string, isActive bool) {
+	result := map[string]interface{}{
+		"client_id": clientID.String(),
+		"name":      name,
+		"is_active": isActive,
+	}
+
+	jsonBytes, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonBytes))
+}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -76,6 +76,89 @@ func main() {
 					return commands.RunRotateKek(ctx, cmd.String("algorithm"))
 				},
 			},
+			{
+				Name:  "create-client",
+				Usage: "Create a new authentication client with policies",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "name",
+						Aliases:  []string{"n"},
+						Required: true,
+						Usage:    "Human-readable client name",
+					},
+					&cli.BoolFlag{
+						Name:    "active",
+						Aliases: []string{"a"},
+						Value:   true,
+						Usage:   "Whether the client can authenticate immediately",
+					},
+					&cli.StringFlag{
+						Name:    "policies",
+						Aliases: []string{"p"},
+						Usage:   "JSON array of policy documents (omit for interactive mode)",
+					},
+					&cli.StringFlag{
+						Name:    "format",
+						Aliases: []string{"f"},
+						Value:   "text",
+						Usage:   "Output format: 'text' or 'json'",
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return commands.RunCreateClient(
+						ctx,
+						cmd.String("name"),
+						cmd.Bool("active"),
+						cmd.String("policies"),
+						cmd.String("format"),
+					)
+				},
+			},
+			{
+				Name:  "update-client",
+				Usage: "Update an existing authentication client's configuration",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "id",
+						Aliases:  []string{"i"},
+						Required: true,
+						Usage:    "Client ID (UUID)",
+					},
+					&cli.StringFlag{
+						Name:     "name",
+						Aliases:  []string{"n"},
+						Required: true,
+						Usage:    "Human-readable client name",
+					},
+					&cli.BoolFlag{
+						Name:    "active",
+						Aliases: []string{"a"},
+						Value:   true,
+						Usage:   "Whether the client can authenticate",
+					},
+					&cli.StringFlag{
+						Name:    "policies",
+						Aliases: []string{"p"},
+						Usage:   "JSON array of policy documents (omit for interactive mode)",
+					},
+					&cli.StringFlag{
+						Name:    "format",
+						Aliases: []string{"f"},
+						Value:   "text",
+						Usage:   "Output format: 'text' or 'json'",
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return commands.RunUpdateClient(
+						ctx,
+						cmd.String("id"),
+						cmd.String("name"),
+						cmd.Bool("active"),
+						cmd.String("policies"),
+						cmd.String("format"),
+					)
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Add new CLI commands for managing authentication clients with capability-based authorization policies. Supports both interactive mode (prompts user for input) and non-interactive mode (accepts JSON policies). Includes DI container integration for ClientUseCase and ClientRepository with PostgreSQL/MySQL support.

Key changes:
- Add cmd/app/commands/create_client.go - Creates clients with policies
- Add cmd/app/commands/update_client.go - Updates existing client configurations
- Extend cmd/app/main.go - Register new commands with urfave/cli v3 flags
- Update internal/app/di.go - Add ClientRepository, ClientUseCase, and SecretService to DI container

Commands:
- app create-client --name <name> [--policies <json>] [--format text|json]
- app update-client --id <uuid> --name <name> [--policies <json>] [--format text|json]