### PR TITLE
feat(auth): store authorized path and capability in context

### DIFF
--- a/internal/auth/http/context.go
+++ b/internal/auth/http/context.go
@@ -10,6 +10,12 @@ import (
 // clientKey is a context key type for storing authenticated clients.
 type clientKey struct{}
 
+// pathKey is a context key type for storing authorized paths.
+type pathKey struct{}
+
+// capabilityKey is a context key type for storing authorized capabilities.
+type capabilityKey struct{}
+
 // WithClient stores an authenticated client in the context.
 // This is typically called by the authentication middleware after successful token validation.
 func WithClient(ctx context.Context, client *authDomain.Client) context.Context {
@@ -22,4 +28,32 @@ func WithClient(ctx context.Context, client *authDomain.Client) context.Context 
 func GetClient(ctx context.Context) (*authDomain.Client, bool) {
 	client, ok := ctx.Value(clientKey{}).(*authDomain.Client)
 	return client, ok
+}
+
+// WithPath stores the authorized path in the context.
+// This is typically called by the authorization middleware after successful authorization check.
+func WithPath(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, pathKey{}, path)
+}
+
+// GetPath retrieves the authorized path from the context.
+// Returns (path, true) if a path is present, or ("", false) if no path was set.
+// This is typically called by handlers that need the authorized path for audit logging.
+func GetPath(ctx context.Context) (string, bool) {
+	path, ok := ctx.Value(pathKey{}).(string)
+	return path, ok
+}
+
+// WithCapability stores the authorized capability in the context.
+// This is typically called by the authorization middleware after successful authorization check.
+func WithCapability(ctx context.Context, capability authDomain.Capability) context.Context {
+	return context.WithValue(ctx, capabilityKey{}, capability)
+}
+
+// GetCapability retrieves the authorized capability from the context.
+// Returns (capability, true) if present, or ("", false) if not set.
+// This is typically called by handlers that need the authorized capability for audit logging.
+func GetCapability(ctx context.Context) (authDomain.Capability, bool) {
+	capability, ok := ctx.Value(capabilityKey{}).(authDomain.Capability)
+	return capability, ok
 }

--- a/internal/auth/http/middleware.go
+++ b/internal/auth/http/middleware.go
@@ -133,6 +133,11 @@ func AuthorizationMiddleware(
 			slog.String("path", path),
 			slog.String("capability", string(capability)))
 
+		// Store path and capability in context for audit logging
+		ctx := WithPath(c.Request.Context(), path)
+		ctx = WithCapability(ctx, capability)
+		c.Request = c.Request.WithContext(ctx)
+
 		// Continue to next handler
 		c.Next()
 	}

--- a/internal/auth/http/middleware_test.go
+++ b/internal/auth/http/middleware_test.go
@@ -417,6 +417,108 @@ func TestWithClient_NilClient(t *testing.T) {
 	assert.Nil(t, retrievedClient, "client should be nil")
 }
 
+// TestGetPath_WithPath tests GetPath when path is in context.
+func TestGetPath_WithPath(t *testing.T) {
+	ctx := context.Background()
+	expectedPath := "/api/v1/secrets"
+
+	// Store path in context
+	ctx = WithPath(ctx, expectedPath)
+
+	// Retrieve path
+	retrievedPath, ok := GetPath(ctx)
+
+	// Assertions
+	assert.True(t, ok, "GetPath should return true")
+	assert.Equal(t, expectedPath, retrievedPath)
+}
+
+// TestGetPath_WithoutPath tests GetPath when no path is in context.
+func TestGetPath_WithoutPath(t *testing.T) {
+	ctx := context.Background()
+
+	// Try to retrieve path from empty context
+	retrievedPath, ok := GetPath(ctx)
+
+	// Assertions
+	assert.False(t, ok, "GetPath should return false")
+	assert.Equal(t, "", retrievedPath, "path should be empty string")
+}
+
+// TestWithPath_EmptyString tests storing empty string path in context.
+func TestWithPath_EmptyString(t *testing.T) {
+	ctx := context.Background()
+
+	// Store empty path
+	ctx = WithPath(ctx, "")
+
+	// Retrieve path
+	retrievedPath, ok := GetPath(ctx)
+
+	// Assertions
+	assert.True(t, ok, "GetPath should return true (value was set)")
+	assert.Equal(t, "", retrievedPath, "path should be empty string")
+}
+
+// TestGetCapability_WithCapability tests GetCapability when capability is in context.
+func TestGetCapability_WithCapability(t *testing.T) {
+	ctx := context.Background()
+	expectedCapability := authDomain.ReadCapability
+
+	// Store capability in context
+	ctx = WithCapability(ctx, expectedCapability)
+
+	// Retrieve capability
+	retrievedCapability, ok := GetCapability(ctx)
+
+	// Assertions
+	assert.True(t, ok, "GetCapability should return true")
+	assert.Equal(t, expectedCapability, retrievedCapability)
+}
+
+// TestGetCapability_WithoutCapability tests GetCapability when no capability is in context.
+func TestGetCapability_WithoutCapability(t *testing.T) {
+	ctx := context.Background()
+
+	// Try to retrieve capability from empty context
+	retrievedCapability, ok := GetCapability(ctx)
+
+	// Assertions
+	assert.False(t, ok, "GetCapability should return false")
+	assert.Equal(t, authDomain.Capability(""), retrievedCapability, "capability should be empty")
+}
+
+// TestWithCapability_AllTypes tests storing different capability types in context.
+func TestWithCapability_AllTypes(t *testing.T) {
+	testCases := []struct {
+		name       string
+		capability authDomain.Capability
+	}{
+		{"ReadCapability", authDomain.ReadCapability},
+		{"WriteCapability", authDomain.WriteCapability},
+		{"DeleteCapability", authDomain.DeleteCapability},
+		{"EncryptCapability", authDomain.EncryptCapability},
+		{"DecryptCapability", authDomain.DecryptCapability},
+		{"RotateCapability", authDomain.RotateCapability},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Store capability in context
+			ctx = WithCapability(ctx, tc.capability)
+
+			// Retrieve capability
+			retrievedCapability, ok := GetCapability(ctx)
+
+			// Assertions
+			assert.True(t, ok, "GetCapability should return true")
+			assert.Equal(t, tc.capability, retrievedCapability)
+		})
+	}
+}
+
 // TestAuthorizationMiddleware_Success tests successful authorization with exact path match.
 func TestAuthorizationMiddleware_Success(t *testing.T) {
 	logger := createTestLogger()


### PR DESCRIPTION
Add context helpers to store and retrieve the authorized path and capability in the authorization middleware. This enables handlers to access authorization metadata for audit logging and security monitoring without re-checking permissions.

- Add WithPath/GetPath context helpers for storing authorized paths
- Add WithCapability/GetCapability context helpers for storing capabilities
- Update AuthorizationMiddleware to store path and capability after successful authorization
- Add comprehensive test coverage for all new context helper functions