### PR TITLE
feat(http): add client management REST API with CRUD handlers

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -33,5 +33,7 @@ packages:
     interfaces:
       ClientRepository:
       TokenRepository:
+      AuditLogRepository:
       ClientUseCase:
       TokenUseCase:
+      AuditLogUseCase:

--- a/internal/auth/http/handler.go
+++ b/internal/auth/http/handler.go
@@ -1,0 +1,269 @@
+// Package http provides HTTP handlers for authentication and client management operations.
+package http
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	validation "github.com/jellydator/validation"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
+	"github.com/allisson/secrets/internal/httputil"
+	customValidation "github.com/allisson/secrets/internal/validation"
+)
+
+// ClientHandler handles HTTP requests for client management operations.
+// It coordinates authentication, authorization, and audit logging with the ClientUseCase.
+type ClientHandler struct {
+	clientUseCase   authUseCase.ClientUseCase
+	auditLogUseCase authUseCase.AuditLogUseCase
+	logger          *slog.Logger
+}
+
+// NewClientHandler creates a new client handler with required dependencies.
+func NewClientHandler(
+	clientUseCase authUseCase.ClientUseCase,
+	auditLogUseCase authUseCase.AuditLogUseCase,
+	logger *slog.Logger,
+) *ClientHandler {
+	return &ClientHandler{
+		clientUseCase:   clientUseCase,
+		auditLogUseCase: auditLogUseCase,
+		logger:          logger,
+	}
+}
+
+// CreateClientRequest contains the parameters for creating a new authentication client.
+type CreateClientRequest struct {
+	Name     string                      `json:"name"`
+	IsActive bool                        `json:"is_active"`
+	Policies []authDomain.PolicyDocument `json:"policies"`
+}
+
+// Validate checks if the create client request is valid.
+func (r *CreateClientRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Name,
+			validation.Required,
+			customValidation.NotBlank,
+			validation.Length(1, 255),
+		),
+		validation.Field(&r.Policies,
+			validation.Required,
+			validation.Each(validation.By(validatePolicyDocument)),
+		),
+	)
+}
+
+// UpdateClientRequest contains the parameters for updating an existing client.
+type UpdateClientRequest struct {
+	Name     string                      `json:"name"`
+	IsActive bool                        `json:"is_active"`
+	Policies []authDomain.PolicyDocument `json:"policies"`
+}
+
+// Validate checks if the update client request is valid.
+func (r *UpdateClientRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Name,
+			validation.Required,
+			customValidation.NotBlank,
+			validation.Length(1, 255),
+		),
+		validation.Field(&r.Policies,
+			validation.Required,
+			validation.Each(validation.By(validatePolicyDocument)),
+		),
+	)
+}
+
+// validatePolicyDocument validates a single policy document.
+func validatePolicyDocument(value interface{}) error {
+	policy, ok := value.(authDomain.PolicyDocument)
+	if !ok {
+		return validation.NewError("validation_policy_type", "must be a policy document")
+	}
+
+	return validation.ValidateStruct(&policy,
+		validation.Field(&policy.Path,
+			validation.Required,
+			customValidation.NotBlank,
+			validation.Length(1, 500),
+		),
+		validation.Field(&policy.Capabilities,
+			validation.Required,
+			validation.Length(1, 0), // At least one capability
+		),
+	)
+}
+
+// CreateClientResponse contains the result of creating a new client.
+// SECURITY: The secret is only returned once and must be saved securely.
+type CreateClientResponse struct {
+	ID     string `json:"id"`
+	Secret string `json:"secret"`
+}
+
+// ClientResponse represents a client in API responses (excludes secret).
+type ClientResponse struct {
+	ID        string                      `json:"id"`
+	Name      string                      `json:"name"`
+	IsActive  bool                        `json:"is_active"`
+	Policies  []authDomain.PolicyDocument `json:"policies"`
+	CreatedAt time.Time                   `json:"created_at"`
+}
+
+// mapClientToResponse converts a domain client to an API response.
+func mapClientToResponse(client *authDomain.Client) ClientResponse {
+	return ClientResponse{
+		ID:        client.ID.String(),
+		Name:      client.Name,
+		IsActive:  client.IsActive,
+		Policies:  client.Policies,
+		CreatedAt: client.CreatedAt,
+	}
+}
+
+// CreateHandler creates a new authentication client with policies.
+// POST /v1/clients - Requires WriteCapability on path /v1/clients.
+// Returns 201 Created with ID and plain text secret.
+func (h *ClientHandler) CreateHandler(c *gin.Context) {
+	var req CreateClientRequest
+
+	// Parse and bind JSON
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		httputil.HandleValidationErrorGin(c, customValidation.WrapValidationError(err), h.logger)
+		return
+	}
+
+	// Create input for use case
+	input := &authDomain.CreateClientInput{
+		Name:     req.Name,
+		IsActive: req.IsActive,
+		Policies: req.Policies,
+	}
+
+	// Call use case
+	output, err := h.clientUseCase.Create(c.Request.Context(), input)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return response with plain secret
+	response := CreateClientResponse{
+		ID:     output.ID.String(),
+		Secret: output.PlainSecret,
+	}
+
+	c.JSON(http.StatusCreated, response)
+}
+
+// GetHandler retrieves a client by ID.
+// GET /v1/clients/:id - Requires ReadCapability on path /v1/clients/:id.
+// Returns 200 OK with client data (no secret).
+func (h *ClientHandler) GetHandler(c *gin.Context) {
+	// Parse and validate UUID
+	clientID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.HandleValidationErrorGin(c,
+			fmt.Errorf("invalid client ID format: must be a valid UUID"),
+			h.logger)
+		return
+	}
+
+	// Call use case
+	client, err := h.clientUseCase.Get(c.Request.Context(), clientID)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return response
+	c.JSON(http.StatusOK, mapClientToResponse(client))
+}
+
+// UpdateHandler updates an existing client's configuration.
+// PUT /v1/clients/:id - Requires WriteCapability on path /v1/clients/:id.
+// Returns 200 OK with updated client data (no secret).
+func (h *ClientHandler) UpdateHandler(c *gin.Context) {
+	// Parse and validate UUID
+	clientID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.HandleValidationErrorGin(c,
+			fmt.Errorf("invalid client ID format: must be a valid UUID"),
+			h.logger)
+		return
+	}
+
+	var req UpdateClientRequest
+
+	// Parse and bind JSON
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		httputil.HandleValidationErrorGin(c, customValidation.WrapValidationError(err), h.logger)
+		return
+	}
+
+	// Create input for use case
+	input := &authDomain.UpdateClientInput{
+		Name:     req.Name,
+		IsActive: req.IsActive,
+		Policies: req.Policies,
+	}
+
+	// Call use case
+	if err := h.clientUseCase.Update(c.Request.Context(), clientID, input); err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Get updated client to return
+	client, err := h.clientUseCase.Get(c.Request.Context(), clientID)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return response
+	c.JSON(http.StatusOK, mapClientToResponse(client))
+}
+
+// DeleteHandler soft deletes a client by setting IsActive to false.
+// DELETE /v1/clients/:id - Requires DeleteCapability on path /v1/clients/:id.
+// Returns 204 No Content.
+func (h *ClientHandler) DeleteHandler(c *gin.Context) {
+	// Parse and validate UUID
+	clientID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.HandleValidationErrorGin(c,
+			fmt.Errorf("invalid client ID format: must be a valid UUID"),
+			h.logger)
+		return
+	}
+
+	// Call use case
+	if err := h.clientUseCase.Delete(c.Request.Context(), clientID); err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return 204 No Content with empty body
+	c.Data(http.StatusNoContent, "application/json", nil)
+}

--- a/internal/auth/http/handler_test.go
+++ b/internal/auth/http/handler_test.go
@@ -1,0 +1,565 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/auth/usecase/mocks"
+)
+
+// setupTestHandler creates a test handler with mocked dependencies.
+func setupTestHandler(t *testing.T) (*ClientHandler, *mocks.MockClientUseCase) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	mockClientUseCase := mocks.NewMockClientUseCase(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	handler := NewClientHandler(mockClientUseCase, nil, logger)
+
+	return handler, mockClientUseCase
+}
+
+// createTestContext creates a test Gin context with the given request.
+func createTestContext(method, path string, body interface{}) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, _ := json.Marshal(body)
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	req := httptest.NewRequest(method, path, bodyReader)
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	return c, w
+}
+
+func TestClientHandler_CreateHandler(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+		plainSecret := "sec_1234567890abcdef"
+
+		request := CreateClientRequest{
+			Name:     "Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path: "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{
+						authDomain.ReadCapability,
+						authDomain.WriteCapability,
+					},
+				},
+			},
+		}
+
+		expectedInput := &authDomain.CreateClientInput{
+			Name:     request.Name,
+			IsActive: request.IsActive,
+			Policies: request.Policies,
+		}
+
+		expectedOutput := &authDomain.CreateClientOutput{
+			ID:          clientID,
+			PlainSecret: plainSecret,
+		}
+
+		mockUseCase.EXPECT().
+			Create(mock.Anything, expectedInput).
+			Return(expectedOutput, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/clients", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var response CreateClientResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, clientID.String(), response.ID)
+		assert.Equal(t, plainSecret, response.Secret)
+	})
+
+	t.Run("Error_InvalidJSON", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		c, w := createTestContext(http.MethodPost, "/v1/clients", nil)
+		c.Request.Body = io.NopCloser(bytes.NewReader([]byte("invalid json")))
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ValidationFailed_MissingName", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		request := CreateClientRequest{
+			Name:     "",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/clients", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ValidationFailed_EmptyPolicies", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		request := CreateClientRequest{
+			Name:     "Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{},
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/clients", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_UseCaseError", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		request := CreateClientRequest{
+			Name:     "Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+		}
+
+		mockUseCase.EXPECT().
+			Create(mock.Anything, mock.Anything).
+			Return(nil, authDomain.ErrClientNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/clients", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "not_found", response["error"])
+	})
+}
+
+func TestClientHandler_GetHandler(t *testing.T) {
+	t.Run("Success_ValidUUID", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+		expectedClient := &authDomain.Client{
+			ID:       clientID,
+			Name:     "Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+			CreatedAt: time.Now().UTC(),
+		}
+
+		mockUseCase.EXPECT().
+			Get(mock.Anything, clientID).
+			Return(expectedClient, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodGet, "/v1/clients/"+clientID.String(), nil)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.GetHandler(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response ClientResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, clientID.String(), response.ID)
+		assert.Equal(t, "Test Client", response.Name)
+		assert.True(t, response.IsActive)
+		assert.Len(t, response.Policies, 1)
+	})
+
+	t.Run("Error_InvalidUUID", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		c, w := createTestContext(http.MethodGet, "/v1/clients/invalid-uuid", nil)
+		c.Params = gin.Params{{Key: "id", Value: "invalid-uuid"}}
+
+		handler.GetHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ClientNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+
+		mockUseCase.EXPECT().
+			Get(mock.Anything, clientID).
+			Return(nil, authDomain.ErrClientNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodGet, "/v1/clients/"+clientID.String(), nil)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.GetHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "not_found", response["error"])
+	})
+}
+
+func TestClientHandler_UpdateHandler(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+		request := UpdateClientRequest{
+			Name:     "Updated Client",
+			IsActive: false,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/prod/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+		}
+
+		expectedInput := &authDomain.UpdateClientInput{
+			Name:     request.Name,
+			IsActive: request.IsActive,
+			Policies: request.Policies,
+		}
+
+		updatedClient := &authDomain.Client{
+			ID:        clientID,
+			Name:      request.Name,
+			IsActive:  request.IsActive,
+			Policies:  request.Policies,
+			CreatedAt: time.Now().UTC(),
+		}
+
+		mockUseCase.EXPECT().
+			Update(mock.Anything, clientID, expectedInput).
+			Return(nil).
+			Once()
+
+		mockUseCase.EXPECT().
+			Get(mock.Anything, clientID).
+			Return(updatedClient, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPut, "/v1/clients/"+clientID.String(), request)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.UpdateHandler(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response ClientResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, clientID.String(), response.ID)
+		assert.Equal(t, "Updated Client", response.Name)
+		assert.False(t, response.IsActive)
+	})
+
+	t.Run("Error_InvalidUUID", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		request := UpdateClientRequest{
+			Name:     "Updated Client",
+			IsActive: false,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+		}
+
+		c, w := createTestContext(http.MethodPut, "/v1/clients/invalid-uuid", request)
+		c.Params = gin.Params{{Key: "id", Value: "invalid-uuid"}}
+
+		handler.UpdateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_InvalidJSON", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+
+		c, w := createTestContext(http.MethodPut, "/v1/clients/"+clientID.String(), nil)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+		c.Request.Body = io.NopCloser(bytes.NewReader([]byte("invalid json")))
+
+		handler.UpdateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ValidationFailed", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+		request := UpdateClientRequest{
+			Name:     "",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+		}
+
+		c, w := createTestContext(http.MethodPut, "/v1/clients/"+clientID.String(), request)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.UpdateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ClientNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+		request := UpdateClientRequest{
+			Name:     "Updated Client",
+			IsActive: false,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path:         "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+				},
+			},
+		}
+
+		mockUseCase.EXPECT().
+			Update(mock.Anything, clientID, mock.Anything).
+			Return(authDomain.ErrClientNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodPut, "/v1/clients/"+clientID.String(), request)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.UpdateHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "not_found", response["error"])
+	})
+}
+
+func TestClientHandler_DeleteHandler(t *testing.T) {
+	t.Run("Success_ValidUUID", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+
+		mockUseCase.EXPECT().
+			Delete(mock.Anything, clientID).
+			Return(nil).
+			Once()
+
+		c, w := createTestContext(http.MethodDelete, "/v1/clients/"+clientID.String(), nil)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.DeleteHandler(c)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, w.Body.String())
+	})
+
+	t.Run("Error_InvalidUUID", func(t *testing.T) {
+		handler, _ := setupTestHandler(t)
+
+		c, w := createTestContext(http.MethodDelete, "/v1/clients/invalid-uuid", nil)
+		c.Params = gin.Params{{Key: "id", Value: "invalid-uuid"}}
+
+		handler.DeleteHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ClientNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestHandler(t)
+
+		clientID := uuid.Must(uuid.NewV7())
+
+		mockUseCase.EXPECT().
+			Delete(mock.Anything, clientID).
+			Return(authDomain.ErrClientNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodDelete, "/v1/clients/"+clientID.String(), nil)
+		c.Params = gin.Params{{Key: "id", Value: clientID.String()}}
+
+		handler.DeleteHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "not_found", response["error"])
+	})
+}
+
+func TestValidatePolicyDocument(t *testing.T) {
+	t.Run("Success_ValidPolicy", func(t *testing.T) {
+		policy := authDomain.PolicyDocument{
+			Path:         "/v1/secrets/*",
+			Capabilities: []authDomain.Capability{authDomain.ReadCapability, authDomain.WriteCapability},
+		}
+
+		err := validatePolicyDocument(policy)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Error_EmptyPath", func(t *testing.T) {
+		policy := authDomain.PolicyDocument{
+			Path:         "",
+			Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+		}
+
+		err := validatePolicyDocument(policy)
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_EmptyCapabilities", func(t *testing.T) {
+		policy := authDomain.PolicyDocument{
+			Path:         "/v1/secrets/*",
+			Capabilities: []authDomain.Capability{},
+		}
+
+		err := validatePolicyDocument(policy)
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_InvalidType", func(t *testing.T) {
+		err := validatePolicyDocument("not a policy")
+		assert.Error(t, err)
+	})
+}
+
+func TestMapClientToResponse(t *testing.T) {
+	clientID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	client := &authDomain.Client{
+		ID:       clientID,
+		Secret:   "hashed_secret",
+		Name:     "Test Client",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "/v1/secrets/*",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability},
+			},
+		},
+		CreatedAt: now,
+	}
+
+	response := mapClientToResponse(client)
+
+	assert.Equal(t, clientID.String(), response.ID)
+	assert.Equal(t, "Test Client", response.Name)
+	assert.True(t, response.IsActive)
+	assert.Len(t, response.Policies, 1)
+	assert.Equal(t, "/v1/secrets/*", response.Policies[0].Path)
+	assert.Equal(t, now, response.CreatedAt)
+}


### PR DESCRIPTION
Implements HTTP handlers for complete client management lifecycle under /v1/clients route with authentication and authorization middleware integration.

- Add ClientHandler with Create/Get/Update/Delete operations
- Implement request/response DTOs with jellydator/validation
- Add comprehensive unit tests covering success and error scenarios
- Wire ClientHandler dependencies through DI container
- Register /v1/clients routes with capability-based authorization
- Update AGENTS.md with client management HTTP patterns and examples
- Update README.md with complete API documentation and planned features section
- Add TokenService, TokenRepository, AuditLogRepository, and related use cases to DI container
- Configure mockery for AuditLogRepository and AuditLogUseCase interfaces

Breaking changes:
- Moves API routes from /api/* to /v1/* prefix for versioning