### PR TITLE
feat(auth): add token issuance HTTP endpoint for client credential

### DIFF
--- a/internal/auth/domain/token.go
+++ b/internal/auth/domain/token.go
@@ -24,4 +24,5 @@ type IssueTokenInput struct {
 
 type IssueTokenOutput struct {
 	PlainToken string
+	ExpiresAt  time.Time
 }

--- a/internal/auth/usecase/token_usecase.go
+++ b/internal/auth/usecase/token_usecase.go
@@ -59,11 +59,12 @@ func (t *tokenUseCase) Issue(
 	}
 
 	// Create the token entity with expiration from config
+	expiresAt := time.Now().UTC().Add(t.config.AuthTokenExpiration)
 	token := &authDomain.Token{
 		ID:        uuid.Must(uuid.NewV7()),
 		TokenHash: tokenHash,
 		ClientID:  client.ID,
-		ExpiresAt: time.Now().UTC().Add(t.config.AuthTokenExpiration),
+		ExpiresAt: expiresAt,
 		RevokedAt: nil,
 		CreatedAt: time.Now().UTC(),
 	}
@@ -73,9 +74,10 @@ func (t *tokenUseCase) Issue(
 		return nil, err
 	}
 
-	// Return the plain token
+	// Return the plain token with expiration time
 	return &authDomain.IssueTokenOutput{
 		PlainToken: plainToken,
+		ExpiresAt:  expiresAt,
 	}, nil
 }
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -53,6 +53,7 @@ func NewServer(
 // This method is called during server initialization with all required dependencies.
 func (s *Server) SetupRouter(
 	clientHandler *authHTTP.ClientHandler,
+	tokenHandler *authHTTP.TokenHandler,
 	tokenUseCase authUseCase.TokenUseCase,
 	tokenService authService.TokenService,
 	auditLogUseCase authUseCase.AuditLogUseCase,
@@ -81,6 +82,9 @@ func (s *Server) SetupRouter(
 	// API v1 routes
 	v1 := router.Group("/v1")
 	{
+		// Token issuance endpoint (no authentication required)
+		v1.POST("/token", tokenHandler.IssueTokenHandler)
+
 		// Client management endpoints
 		clients := v1.Group("/clients")
 		clients.Use(authMiddleware) // All client routes require authentication


### PR DESCRIPTION
Implements POST /v1/token endpoint to allow clients to authenticate using client_id and client_secret credentials and receive a time-limited authentication token. This completes the authentication flow by providing the mechanism to obtain Bearer tokens used by other API endpoints.

Changes:
- Add TokenHandler with IssueTokenHandler method to handle POST /v1/token requests
- Add IssueTokenRequest/IssueTokenResponse DTOs with validation for client credentials
- Update IssueTokenOutput domain type to include ExpiresAt timestamp
- Modify TokenUseCase.Issue() to return token expiration time in output
- Register TokenHandler in DI container with all dependencies
- Add /v1/token route to HTTP server (no authentication required)
- Update README with token issuance documentation, examples, and bootstrap workflow
- Add comprehensive test coverage for token issuance handler (9 test cases)

API Details:
- Endpoint: POST /v1/token
- Request: {"client_id": "uuid", "client_secret": "string"}
- Response: {"token": "tok_...", "expires_at": "2026-02-13T20:13:45Z"}
- Status codes: 201 Created, 401 Unauthorized, 403 Forbidden, 422 Unprocessable Entity
- Token lifetime configurable via AUTH_TOKEN_EXPIRATION_SECONDS (default: 86400s / 24 hours)

Security:
- Validates client exists and is active before issuing token
- Returns generic 401 error for invalid credentials (prevents enumeration attacks)
- Token returned only once on creation (cannot be retrieved later)
- Expiration time included in response for client-side token renewal logic

Documentation:
- Add complete token issuance section to README with curl examples
- Update quick start guide with bootstrap client creation and token exchange steps
- Document error responses and token lifecycle (expiration, renewal, storage)
- Add CLI command reference for create-client/update-client commands