### PR TITLE
feat(transit/http): add transit encryption REST API

### DIFF
--- a/internal/transit/http/crypto_handler.go
+++ b/internal/transit/http/crypto_handler.go
@@ -1,0 +1,137 @@
+// Package http provides HTTP handlers for transit key management and cryptographic operations.
+package http
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	"github.com/allisson/secrets/internal/httputil"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+	"github.com/allisson/secrets/internal/transit/http/dto"
+	transitUseCase "github.com/allisson/secrets/internal/transit/usecase"
+	customValidation "github.com/allisson/secrets/internal/validation"
+)
+
+// CryptoHandler handles HTTP requests for transit encryption and decryption operations.
+// It coordinates authentication, authorization, and audit logging with the TransitKeyUseCase.
+type CryptoHandler struct {
+	transitKeyUseCase transitUseCase.TransitKeyUseCase
+	auditLogUseCase   authUseCase.AuditLogUseCase
+	logger            *slog.Logger
+}
+
+// NewCryptoHandler creates a new crypto handler with required dependencies.
+func NewCryptoHandler(
+	transitKeyUseCase transitUseCase.TransitKeyUseCase,
+	auditLogUseCase authUseCase.AuditLogUseCase,
+	logger *slog.Logger,
+) *CryptoHandler {
+	return &CryptoHandler{
+		transitKeyUseCase: transitKeyUseCase,
+		auditLogUseCase:   auditLogUseCase,
+		logger:            logger,
+	}
+}
+
+// EncryptHandler encrypts plaintext data using the specified transit key.
+// POST /v1/transit/keys/:name/encrypt - Requires EncryptCapability.
+// Returns 200 OK with ciphertext in format "version:base64-ciphertext".
+func (h *CryptoHandler) EncryptHandler(c *gin.Context) {
+	// Extract and validate name from URL parameter
+	name := c.Param("name")
+	if name == "" {
+		httputil.HandleValidationErrorGin(
+			c,
+			fmt.Errorf("transit key name cannot be empty"),
+			h.logger,
+		)
+		return
+	}
+
+	var req dto.EncryptRequest
+
+	// Parse and bind JSON
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		httputil.HandleValidationErrorGin(c, customValidation.WrapValidationError(err), h.logger)
+		return
+	}
+
+	// Call use case
+	encryptedBlob, err := h.transitKeyUseCase.Encrypt(c.Request.Context(), name, req.Plaintext)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return response with ciphertext string
+	response := dto.EncryptResponse{
+		Ciphertext: encryptedBlob.String(), // Format: "version:base64-ciphertext"
+		Version:    encryptedBlob.Version,
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+// DecryptHandler decrypts ciphertext using the version specified in the encrypted blob.
+// POST /v1/transit/keys/:name/decrypt - Requires DecryptCapability.
+// Returns 200 OK with plaintext bytes. SECURITY: Plaintext is zeroed after response.
+func (h *CryptoHandler) DecryptHandler(c *gin.Context) {
+	// Extract and validate name from URL parameter
+	name := c.Param("name")
+	if name == "" {
+		httputil.HandleValidationErrorGin(
+			c,
+			fmt.Errorf("transit key name cannot be empty"),
+			h.logger,
+		)
+		return
+	}
+
+	var req dto.DecryptRequest
+
+	// Parse and bind JSON
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		httputil.HandleValidationErrorGin(c, customValidation.WrapValidationError(err), h.logger)
+		return
+	}
+
+	// Parse ciphertext format "version:base64-ciphertext"
+	encryptedBlob, err := transitDomain.NewEncryptedBlob(req.Ciphertext)
+	if err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Call use case with parsed ciphertext
+	decryptedBlob, err := h.transitKeyUseCase.Decrypt(c.Request.Context(), name, encryptedBlob.Ciphertext)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// SECURITY: Zero plaintext after mapping to response
+	defer cryptoDomain.Zero(decryptedBlob.Plaintext)
+
+	// Return response with plaintext
+	response := dto.DecryptResponse{
+		Plaintext: decryptedBlob.Plaintext,
+		Version:   decryptedBlob.Version,
+	}
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/transit/http/crypto_handler_test.go
+++ b/internal/transit/http/crypto_handler_test.go
@@ -1,0 +1,300 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	apperrors "github.com/allisson/secrets/internal/errors"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+	"github.com/allisson/secrets/internal/transit/http/dto"
+	"github.com/allisson/secrets/internal/transit/usecase/mocks"
+)
+
+// setupTestCryptoHandler creates a test crypto handler with mocked dependencies.
+func setupTestCryptoHandler(t *testing.T) (*CryptoHandler, *mocks.MockTransitKeyUseCase) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	mockTransitKeyUseCase := mocks.NewMockTransitKeyUseCase(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	handler := NewCryptoHandler(mockTransitKeyUseCase, nil, logger)
+
+	return handler, mockTransitKeyUseCase
+}
+
+func TestCryptoHandler_EncryptHandler(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		handler, mockUseCase := setupTestCryptoHandler(t)
+
+		plaintext := []byte("my secret data")
+
+		request := dto.EncryptRequest{
+			Plaintext: plaintext,
+		}
+
+		encryptedBlob := &transitDomain.EncryptedBlob{
+			Version:    1,
+			Ciphertext: []byte("encrypted-data"),
+		}
+
+		mockUseCase.EXPECT().
+			Encrypt(mock.Anything, "test-key", plaintext).
+			Return(encryptedBlob, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/encrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.EncryptHandler(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response dto.EncryptResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, encryptedBlob.String(), response.Ciphertext)
+		assert.Equal(t, uint(1), response.Version)
+	})
+
+	t.Run("Error_EmptyName", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		request := dto.EncryptRequest{
+			Plaintext: []byte("my secret data"),
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys//encrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: ""}}
+
+		handler.EncryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_InvalidJSON", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/encrypt", nil)
+		c.Request.Body = io.NopCloser(bytes.NewReader([]byte("invalid json")))
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.EncryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_ValidationFailed_EmptyPlaintext", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		request := dto.EncryptRequest{
+			Plaintext: []byte{},
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/encrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.EncryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_TransitKeyNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestCryptoHandler(t)
+
+		plaintext := []byte("my secret data")
+
+		request := dto.EncryptRequest{
+			Plaintext: plaintext,
+		}
+
+		mockUseCase.EXPECT().
+			Encrypt(mock.Anything, "nonexistent-key", plaintext).
+			Return(nil, transitDomain.ErrTransitKeyNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/nonexistent-key/encrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "nonexistent-key"}}
+
+		handler.EncryptHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestCryptoHandler_DecryptHandler(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		handler, mockUseCase := setupTestCryptoHandler(t)
+
+		plaintext := []byte("my secret data")
+		expectedPlaintext := make([]byte, len(plaintext))
+		copy(expectedPlaintext, plaintext) // Save expected value before handler zeros it
+		ciphertext := []byte("encrypted-data")
+		ciphertextString := "1:ZW5jcnlwdGVkLWRhdGE=" // version:base64(ciphertext)
+
+		request := dto.DecryptRequest{
+			Ciphertext: ciphertextString,
+		}
+
+		decryptedBlob := &transitDomain.EncryptedBlob{
+			Version:    1,
+			Ciphertext: ciphertext,
+			Plaintext:  plaintext,
+		}
+
+		mockUseCase.EXPECT().
+			Decrypt(mock.Anything, "test-key", ciphertext).
+			Return(decryptedBlob, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response dto.DecryptResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedPlaintext, response.Plaintext)
+		assert.Equal(t, uint(1), response.Version)
+	})
+
+	t.Run("Error_EmptyName", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		request := dto.DecryptRequest{
+			Ciphertext: "1:ZW5jcnlwdGVkLWRhdGE=",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys//decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: ""}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_InvalidJSON", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/decrypt", nil)
+		c.Request.Body = io.NopCloser(bytes.NewReader([]byte("invalid json")))
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_ValidationFailed_EmptyCiphertext", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		request := dto.DecryptRequest{
+			Ciphertext: "",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_InvalidBlobFormat", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		request := dto.DecryptRequest{
+			Ciphertext: "invalid-format",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_InvalidBase64", func(t *testing.T) {
+		handler, _ := setupTestCryptoHandler(t)
+
+		request := dto.DecryptRequest{
+			Ciphertext: "1:invalid-base64!!!",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_TransitKeyNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestCryptoHandler(t)
+
+		ciphertext := []byte("encrypted-data")
+		ciphertextString := "1:ZW5jcnlwdGVkLWRhdGE="
+
+		request := dto.DecryptRequest{
+			Ciphertext: ciphertextString,
+		}
+
+		mockUseCase.EXPECT().
+			Decrypt(mock.Anything, "nonexistent-key", ciphertext).
+			Return(nil, transitDomain.ErrTransitKeyNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/nonexistent-key/decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "nonexistent-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("Error_UseCaseError", func(t *testing.T) {
+		handler, mockUseCase := setupTestCryptoHandler(t)
+
+		ciphertext := []byte("encrypted-data")
+		ciphertextString := "1:ZW5jcnlwdGVkLWRhdGE="
+
+		request := dto.DecryptRequest{
+			Ciphertext: ciphertextString,
+		}
+
+		mockUseCase.EXPECT().
+			Decrypt(mock.Anything, "test-key", ciphertext).
+			Return(nil, apperrors.ErrInvalidInput).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/decrypt", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.DecryptHandler(c)
+
+		assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	})
+}

--- a/internal/transit/http/dto/request.go
+++ b/internal/transit/http/dto/request.go
@@ -1,0 +1,103 @@
+// Package dto provides data transfer objects for HTTP request and response handling.
+package dto
+
+import (
+	"fmt"
+
+	validation "github.com/jellydator/validation"
+
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	customValidation "github.com/allisson/secrets/internal/validation"
+)
+
+// CreateTransitKeyRequest contains the parameters for creating a new transit key.
+type CreateTransitKeyRequest struct {
+	Name      string `json:"name"`
+	Algorithm string `json:"algorithm"` // "aes-gcm" or "chacha20-poly1305"
+}
+
+// Validate checks if the create transit key request is valid.
+func (r *CreateTransitKeyRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Name,
+			validation.Required,
+			customValidation.NotBlank,
+			validation.Length(1, 255),
+		),
+		validation.Field(&r.Algorithm,
+			validation.Required,
+			customValidation.NotBlank,
+			validation.By(validateAlgorithm),
+		),
+	)
+}
+
+// RotateTransitKeyRequest contains the parameters for rotating a transit key.
+type RotateTransitKeyRequest struct {
+	Algorithm string `json:"algorithm"` // "aes-gcm" or "chacha20-poly1305"
+}
+
+// Validate checks if the rotate transit key request is valid.
+func (r *RotateTransitKeyRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Algorithm,
+			validation.Required,
+			customValidation.NotBlank,
+			validation.By(validateAlgorithm),
+		),
+	)
+}
+
+// EncryptRequest contains the parameters for encrypting data.
+type EncryptRequest struct {
+	Plaintext []byte `json:"plaintext"`
+}
+
+// Validate checks if the encrypt request is valid.
+func (r *EncryptRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Plaintext,
+			validation.Required,
+			validation.Length(1, 0), // At least 1 byte
+		),
+	)
+}
+
+// DecryptRequest contains the parameters for decrypting data.
+type DecryptRequest struct {
+	Ciphertext string `json:"ciphertext"` // Format: "version:base64-ciphertext"
+}
+
+// Validate checks if the decrypt request is valid.
+func (r *DecryptRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Ciphertext,
+			validation.Required,
+			customValidation.NotBlank,
+		),
+	)
+}
+
+// validateAlgorithm validates that the algorithm is supported.
+func validateAlgorithm(value interface{}) error {
+	alg, ok := value.(string)
+	if !ok {
+		return validation.NewError("validation_algorithm_type", "must be a string")
+	}
+
+	_, err := ParseAlgorithm(alg)
+	return err
+}
+
+// ParseAlgorithm converts a string to a cryptoDomain.Algorithm.
+// Returns an error if the algorithm is not supported.
+func ParseAlgorithm(alg string) (cryptoDomain.Algorithm, error) {
+	switch alg {
+	case "aes-gcm":
+		return cryptoDomain.AESGCM, nil
+	case "chacha20-poly1305":
+		return cryptoDomain.ChaCha20, nil
+	default:
+		return "", fmt.Errorf("invalid algorithm: must be 'aes-gcm' or 'chacha20-poly1305'")
+	}
+}

--- a/internal/transit/http/dto/request_test.go
+++ b/internal/transit/http/dto/request_test.go
@@ -1,0 +1,199 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+)
+
+func TestCreateTransitKeyRequest_Validate(t *testing.T) {
+	t.Run("Success_ValidRequest_AESGCM", func(t *testing.T) {
+		req := CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "aes-gcm",
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Success_ValidRequest_ChaCha20", func(t *testing.T) {
+		req := CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "chacha20-poly1305",
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Error_MissingName", func(t *testing.T) {
+		req := CreateTransitKeyRequest{
+			Name:      "",
+			Algorithm: "aes-gcm",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_MissingAlgorithm", func(t *testing.T) {
+		req := CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_InvalidAlgorithm", func(t *testing.T) {
+		req := CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "invalid-algorithm",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_NameTooLong", func(t *testing.T) {
+		longName := make([]byte, 256)
+		for i := range longName {
+			longName[i] = 'a'
+		}
+
+		req := CreateTransitKeyRequest{
+			Name:      string(longName),
+			Algorithm: "aes-gcm",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+}
+
+func TestRotateTransitKeyRequest_Validate(t *testing.T) {
+	t.Run("Success_ValidRequest_AESGCM", func(t *testing.T) {
+		req := RotateTransitKeyRequest{
+			Algorithm: "aes-gcm",
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Success_ValidRequest_ChaCha20", func(t *testing.T) {
+		req := RotateTransitKeyRequest{
+			Algorithm: "chacha20-poly1305",
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Error_MissingAlgorithm", func(t *testing.T) {
+		req := RotateTransitKeyRequest{
+			Algorithm: "",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_InvalidAlgorithm", func(t *testing.T) {
+		req := RotateTransitKeyRequest{
+			Algorithm: "invalid-algorithm",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+}
+
+func TestEncryptRequest_Validate(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		req := EncryptRequest{
+			Plaintext: []byte("my secret data"),
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Error_EmptyPlaintext", func(t *testing.T) {
+		req := EncryptRequest{
+			Plaintext: []byte{},
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_NilPlaintext", func(t *testing.T) {
+		req := EncryptRequest{
+			Plaintext: nil,
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+}
+
+func TestDecryptRequest_Validate(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		req := DecryptRequest{
+			Ciphertext: "1:ZW5jcnlwdGVkLWRhdGE=",
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Error_EmptyCiphertext", func(t *testing.T) {
+		req := DecryptRequest{
+			Ciphertext: "",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_BlankCiphertext", func(t *testing.T) {
+		req := DecryptRequest{
+			Ciphertext: "   ",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+}
+
+func TestParseAlgorithm(t *testing.T) {
+	t.Run("Success_AESGCM", func(t *testing.T) {
+		alg, err := ParseAlgorithm("aes-gcm")
+		assert.NoError(t, err)
+		assert.Equal(t, cryptoDomain.AESGCM, alg)
+	})
+
+	t.Run("Success_ChaCha20", func(t *testing.T) {
+		alg, err := ParseAlgorithm("chacha20-poly1305")
+		assert.NoError(t, err)
+		assert.Equal(t, cryptoDomain.ChaCha20, alg)
+	})
+
+	t.Run("Error_InvalidAlgorithm", func(t *testing.T) {
+		alg, err := ParseAlgorithm("invalid")
+		assert.Error(t, err)
+		assert.Empty(t, alg)
+		assert.Contains(t, err.Error(), "invalid algorithm")
+	})
+
+	t.Run("Error_EmptyString", func(t *testing.T) {
+		alg, err := ParseAlgorithm("")
+		assert.Error(t, err)
+		assert.Empty(t, alg)
+	})
+}

--- a/internal/transit/http/dto/response.go
+++ b/internal/transit/http/dto/response.go
@@ -1,0 +1,41 @@
+// Package dto provides data transfer objects for HTTP request and response handling.
+package dto
+
+import (
+	"time"
+
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+// TransitKeyResponse represents a transit key in API responses.
+type TransitKeyResponse struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Version   uint      `json:"version"`
+	DekID     string    `json:"dek_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// MapTransitKeyToResponse converts a domain transit key to an API response.
+func MapTransitKeyToResponse(transitKey *transitDomain.TransitKey) TransitKeyResponse {
+	return TransitKeyResponse{
+		ID:        transitKey.ID.String(),
+		Name:      transitKey.Name,
+		Version:   transitKey.Version,
+		DekID:     transitKey.DekID.String(),
+		CreatedAt: transitKey.CreatedAt,
+	}
+}
+
+// EncryptResponse contains the result of an encryption operation.
+type EncryptResponse struct {
+	Ciphertext string `json:"ciphertext"` // Format: "version:base64-ciphertext"
+	Version    uint   `json:"version"`
+}
+
+// DecryptResponse contains the result of a decryption operation.
+// SECURITY: The Plaintext field contains sensitive data and should be transmitted over HTTPS.
+type DecryptResponse struct {
+	Plaintext []byte `json:"plaintext"`
+	Version   uint   `json:"version"`
+}

--- a/internal/transit/http/dto/response_test.go
+++ b/internal/transit/http/dto/response_test.go
@@ -1,0 +1,79 @@
+package dto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+func TestMapTransitKeyToResponse(t *testing.T) {
+	t.Run("Success_ValidMapping", func(t *testing.T) {
+		transitKeyID := uuid.Must(uuid.NewV7())
+		dekID := uuid.Must(uuid.NewV7())
+		now := time.Now().UTC()
+
+		transitKey := &transitDomain.TransitKey{
+			ID:        transitKeyID,
+			Name:      "test-key",
+			Version:   1,
+			DekID:     dekID,
+			CreatedAt: now,
+		}
+
+		response := MapTransitKeyToResponse(transitKey)
+
+		assert.Equal(t, transitKeyID.String(), response.ID)
+		assert.Equal(t, "test-key", response.Name)
+		assert.Equal(t, uint(1), response.Version)
+		assert.Equal(t, dekID.String(), response.DekID)
+		assert.Equal(t, now, response.CreatedAt)
+	})
+
+	t.Run("Success_VersionTwo", func(t *testing.T) {
+		transitKeyID := uuid.Must(uuid.NewV7())
+		dekID := uuid.Must(uuid.NewV7())
+		now := time.Now().UTC()
+
+		transitKey := &transitDomain.TransitKey{
+			ID:        transitKeyID,
+			Name:      "test-key",
+			Version:   2,
+			DekID:     dekID,
+			CreatedAt: now,
+		}
+
+		response := MapTransitKeyToResponse(transitKey)
+
+		assert.Equal(t, uint(2), response.Version)
+	})
+}
+
+func TestEncryptResponse(t *testing.T) {
+	t.Run("Success_CreateResponse", func(t *testing.T) {
+		response := EncryptResponse{
+			Ciphertext: "1:ZW5jcnlwdGVkLWRhdGE=",
+			Version:    1,
+		}
+
+		assert.Equal(t, "1:ZW5jcnlwdGVkLWRhdGE=", response.Ciphertext)
+		assert.Equal(t, uint(1), response.Version)
+	})
+}
+
+func TestDecryptResponse(t *testing.T) {
+	t.Run("Success_CreateResponse", func(t *testing.T) {
+		plaintext := []byte("my secret data")
+
+		response := DecryptResponse{
+			Plaintext: plaintext,
+			Version:   1,
+		}
+
+		assert.Equal(t, plaintext, response.Plaintext)
+		assert.Equal(t, uint(1), response.Version)
+	})
+}

--- a/internal/transit/http/test_helpers.go
+++ b/internal/transit/http/test_helpers.go
@@ -1,0 +1,29 @@
+// Package http provides HTTP handlers for transit key management and cryptographic operations.
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+)
+
+// createTestContext creates a test Gin context with the given request.
+func createTestContext(method, path string, body interface{}) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, _ := json.Marshal(body)
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	req := httptest.NewRequest(method, path, bodyReader)
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	return c, w
+}

--- a/internal/transit/http/transit_key_handler.go
+++ b/internal/transit/http/transit_key_handler.go
@@ -1,0 +1,146 @@
+// Package http provides HTTP handlers for transit key management and cryptographic operations.
+package http
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
+	"github.com/allisson/secrets/internal/httputil"
+	"github.com/allisson/secrets/internal/transit/http/dto"
+	transitUseCase "github.com/allisson/secrets/internal/transit/usecase"
+	customValidation "github.com/allisson/secrets/internal/validation"
+)
+
+// TransitKeyHandler handles HTTP requests for transit key management operations.
+// It coordinates authentication, authorization, and audit logging with the TransitKeyUseCase.
+type TransitKeyHandler struct {
+	transitKeyUseCase transitUseCase.TransitKeyUseCase
+	auditLogUseCase   authUseCase.AuditLogUseCase
+	logger            *slog.Logger
+}
+
+// NewTransitKeyHandler creates a new transit key handler with required dependencies.
+func NewTransitKeyHandler(
+	transitKeyUseCase transitUseCase.TransitKeyUseCase,
+	auditLogUseCase authUseCase.AuditLogUseCase,
+	logger *slog.Logger,
+) *TransitKeyHandler {
+	return &TransitKeyHandler{
+		transitKeyUseCase: transitKeyUseCase,
+		auditLogUseCase:   auditLogUseCase,
+		logger:            logger,
+	}
+}
+
+// CreateHandler creates a new transit key with version 1.
+// POST /v1/transit/keys - Requires WriteCapability on path /v1/transit/keys.
+// Returns 201 Created with transit key metadata.
+func (h *TransitKeyHandler) CreateHandler(c *gin.Context) {
+	var req dto.CreateTransitKeyRequest
+
+	// Parse and bind JSON
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		httputil.HandleValidationErrorGin(c, customValidation.WrapValidationError(err), h.logger)
+		return
+	}
+
+	// Parse algorithm
+	alg, err := dto.ParseAlgorithm(req.Algorithm)
+	if err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Call use case
+	transitKey, err := h.transitKeyUseCase.Create(c.Request.Context(), req.Name, alg)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return response
+	response := dto.MapTransitKeyToResponse(transitKey)
+	c.JSON(http.StatusCreated, response)
+}
+
+// RotateHandler creates a new version of an existing transit key.
+// POST /v1/transit/keys/:name/rotate - Requires RotateCapability.
+// Returns 200 OK with new version metadata.
+func (h *TransitKeyHandler) RotateHandler(c *gin.Context) {
+	// Extract and validate name from URL parameter
+	name := c.Param("name")
+	if name == "" {
+		httputil.HandleValidationErrorGin(
+			c,
+			fmt.Errorf("transit key name cannot be empty"),
+			h.logger,
+		)
+		return
+	}
+
+	var req dto.RotateTransitKeyRequest
+
+	// Parse and bind JSON
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		httputil.HandleValidationErrorGin(c, customValidation.WrapValidationError(err), h.logger)
+		return
+	}
+
+	// Parse algorithm
+	alg, err := dto.ParseAlgorithm(req.Algorithm)
+	if err != nil {
+		httputil.HandleValidationErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Call use case
+	transitKey, err := h.transitKeyUseCase.Rotate(c.Request.Context(), name, alg)
+	if err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return response
+	response := dto.MapTransitKeyToResponse(transitKey)
+	c.JSON(http.StatusOK, response)
+}
+
+// DeleteHandler soft deletes a transit key by ID.
+// DELETE /v1/transit/keys/:id - Requires DeleteCapability on path /v1/transit/keys/:id.
+// Returns 204 No Content.
+func (h *TransitKeyHandler) DeleteHandler(c *gin.Context) {
+	// Parse and validate UUID
+	transitKeyID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.HandleValidationErrorGin(c,
+			fmt.Errorf("invalid transit key ID format: must be a valid UUID"),
+			h.logger)
+		return
+	}
+
+	// Call use case
+	if err := h.transitKeyUseCase.Delete(c.Request.Context(), transitKeyID); err != nil {
+		httputil.HandleErrorGin(c, err, h.logger)
+		return
+	}
+
+	// Return 204 No Content with empty body
+	c.Data(http.StatusNoContent, "application/json", nil)
+}

--- a/internal/transit/http/transit_key_handler_test.go
+++ b/internal/transit/http/transit_key_handler_test.go
@@ -1,0 +1,346 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	apperrors "github.com/allisson/secrets/internal/errors"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+	"github.com/allisson/secrets/internal/transit/http/dto"
+	"github.com/allisson/secrets/internal/transit/usecase/mocks"
+)
+
+// setupTestTransitKeyHandler creates a test handler with mocked dependencies.
+func setupTestTransitKeyHandler(t *testing.T) (*TransitKeyHandler, *mocks.MockTransitKeyUseCase) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	mockTransitKeyUseCase := mocks.NewMockTransitKeyUseCase(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	handler := NewTransitKeyHandler(mockTransitKeyUseCase, nil, logger)
+
+	return handler, mockTransitKeyUseCase
+}
+
+func TestTransitKeyHandler_CreateHandler(t *testing.T) {
+	t.Run("Success_ValidRequest_AESGCM", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		transitKeyID := uuid.Must(uuid.NewV7())
+		dekID := uuid.Must(uuid.NewV7())
+		now := time.Now().UTC()
+
+		request := dto.CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "aes-gcm",
+		}
+
+		expectedTransitKey := &transitDomain.TransitKey{
+			ID:        transitKeyID,
+			Name:      "test-key",
+			Version:   1,
+			DekID:     dekID,
+			CreatedAt: now,
+		}
+
+		mockUseCase.EXPECT().
+			Create(mock.Anything, "test-key", cryptoDomain.AESGCM).
+			Return(expectedTransitKey, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var response dto.TransitKeyResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, transitKeyID.String(), response.ID)
+		assert.Equal(t, "test-key", response.Name)
+		assert.Equal(t, uint(1), response.Version)
+		assert.Equal(t, dekID.String(), response.DekID)
+	})
+
+	t.Run("Success_ValidRequest_ChaCha20", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		transitKeyID := uuid.Must(uuid.NewV7())
+		dekID := uuid.Must(uuid.NewV7())
+		now := time.Now().UTC()
+
+		request := dto.CreateTransitKeyRequest{
+			Name:      "test-key-chacha",
+			Algorithm: "chacha20-poly1305",
+		}
+
+		expectedTransitKey := &transitDomain.TransitKey{
+			ID:        transitKeyID,
+			Name:      "test-key-chacha",
+			Version:   1,
+			DekID:     dekID,
+			CreatedAt: now,
+		}
+
+		mockUseCase.EXPECT().
+			Create(mock.Anything, "test-key-chacha", cryptoDomain.ChaCha20).
+			Return(expectedTransitKey, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var response dto.TransitKeyResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, transitKeyID.String(), response.ID)
+		assert.Equal(t, "test-key-chacha", response.Name)
+	})
+
+	t.Run("Error_InvalidJSON", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys", nil)
+		c.Request.Body = io.NopCloser(bytes.NewReader([]byte("invalid json")))
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ValidationFailed_MissingName", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		request := dto.CreateTransitKeyRequest{
+			Name:      "",
+			Algorithm: "aes-gcm",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_ValidationFailed_InvalidAlgorithm", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		request := dto.CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "invalid-algorithm",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "validation_error", response["error"])
+	})
+
+	t.Run("Error_UseCaseError", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		request := dto.CreateTransitKeyRequest{
+			Name:      "test-key",
+			Algorithm: "aes-gcm",
+		}
+
+		mockUseCase.EXPECT().
+			Create(mock.Anything, "test-key", cryptoDomain.AESGCM).
+			Return(nil, apperrors.ErrConflict).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys", request)
+
+		handler.CreateHandler(c)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+	})
+}
+
+func TestTransitKeyHandler_RotateHandler(t *testing.T) {
+	t.Run("Success_ValidRequest", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		transitKeyID := uuid.Must(uuid.NewV7())
+		dekID := uuid.Must(uuid.NewV7())
+		now := time.Now().UTC()
+
+		request := dto.RotateTransitKeyRequest{
+			Algorithm: "aes-gcm",
+		}
+
+		expectedTransitKey := &transitDomain.TransitKey{
+			ID:        transitKeyID,
+			Name:      "test-key",
+			Version:   2,
+			DekID:     dekID,
+			CreatedAt: now,
+		}
+
+		mockUseCase.EXPECT().
+			Rotate(mock.Anything, "test-key", cryptoDomain.AESGCM).
+			Return(expectedTransitKey, nil).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/rotate", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.RotateHandler(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response dto.TransitKeyResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, transitKeyID.String(), response.ID)
+		assert.Equal(t, "test-key", response.Name)
+		assert.Equal(t, uint(2), response.Version)
+	})
+
+	t.Run("Error_EmptyName", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		request := dto.RotateTransitKeyRequest{
+			Algorithm: "aes-gcm",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys//rotate", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: ""}}
+
+		handler.RotateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_InvalidJSON", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/rotate", nil)
+		c.Request.Body = io.NopCloser(bytes.NewReader([]byte("invalid json")))
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.RotateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_ValidationFailed_InvalidAlgorithm", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		request := dto.RotateTransitKeyRequest{
+			Algorithm: "invalid",
+		}
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/test-key/rotate", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "test-key"}}
+
+		handler.RotateHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_TransitKeyNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		request := dto.RotateTransitKeyRequest{
+			Algorithm: "aes-gcm",
+		}
+
+		mockUseCase.EXPECT().
+			Rotate(mock.Anything, "nonexistent-key", cryptoDomain.AESGCM).
+			Return(nil, transitDomain.ErrTransitKeyNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodPost, "/v1/transit/keys/nonexistent-key/rotate", request)
+		c.Params = gin.Params{gin.Param{Key: "name", Value: "nonexistent-key"}}
+
+		handler.RotateHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestTransitKeyHandler_DeleteHandler(t *testing.T) {
+	t.Run("Success_ValidUUID", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		transitKeyID := uuid.Must(uuid.NewV7())
+
+		mockUseCase.EXPECT().
+			Delete(mock.Anything, transitKeyID).
+			Return(nil).
+			Once()
+
+		c, w := createTestContext(http.MethodDelete, fmt.Sprintf("/v1/transit/keys/%s", transitKeyID), nil)
+		c.Params = gin.Params{gin.Param{Key: "id", Value: transitKeyID.String()}}
+
+		handler.DeleteHandler(c)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, w.Body.String())
+	})
+
+	t.Run("Error_InvalidUUID", func(t *testing.T) {
+		handler, _ := setupTestTransitKeyHandler(t)
+
+		c, w := createTestContext(http.MethodDelete, "/v1/transit/keys/invalid-uuid", nil)
+		c.Params = gin.Params{gin.Param{Key: "id", Value: "invalid-uuid"}}
+
+		handler.DeleteHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Error_TransitKeyNotFound", func(t *testing.T) {
+		handler, mockUseCase := setupTestTransitKeyHandler(t)
+
+		transitKeyID := uuid.Must(uuid.NewV7())
+
+		mockUseCase.EXPECT().
+			Delete(mock.Anything, transitKeyID).
+			Return(transitDomain.ErrTransitKeyNotFound).
+			Once()
+
+		c, w := createTestContext(http.MethodDelete, fmt.Sprintf("/v1/transit/keys/%s", transitKeyID), nil)
+		c.Params = gin.Params{gin.Param{Key: "id", Value: transitKeyID.String()}}
+
+		handler.DeleteHandler(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}


### PR DESCRIPTION
Implements encryption-as-a-service HTTP endpoints for transit key management and cryptographic operations.

Adds TransitKeyHandler for CRUD operations
(create/rotate/delete) and CryptoHandler for encrypt/decrypt endpoints.

Integrates with existing authentication/authorization middleware using capability-based access control.

Updates README with comprehensive transit
encryption documentation including API examples, policy configurations, and client library implementations for Python, JavaScript, and Go.

---

Summary of changes:
- Transit HTTP Layer (10 new files):
  - transit_key_handler.go + tests - Create/rotate/delete transit keys
  - crypto_handler.go + tests - Encrypt/decrypt operations
  - dto/ package - Request/response DTOs with validation
  - test_helpers.go - Shared test utilities

- Integration:
  - internal/app/di.go - Added 7 new DI methods for transit layer dependencies
  - internal/http/server.go - Registered /v1/transit/keys routes with auth middleware

- Documentation:
  - README.md - Added 800+ lines covering transit encryption architecture, API reference, security warnings, policy examples, and client libraries