### PR TITLE
refactor(api): require base64 encoding for all plaintext data

### DIFF
--- a/internal/secrets/http/dto/request.go
+++ b/internal/secrets/http/dto/request.go
@@ -3,12 +3,14 @@ package dto
 
 import (
 	validation "github.com/jellydator/validation"
+
+	customValidation "github.com/allisson/secrets/internal/validation"
 )
 
 // CreateOrUpdateSecretRequest contains the parameters for creating or updating a secret.
 // The path is extracted from the URL parameter, not the request body.
 type CreateOrUpdateSecretRequest struct {
-	Value []byte `json:"value" binding:"required"`
+	Value string `json:"value" binding:"required"` // base64-encoded plaintext
 }
 
 // Validate checks if the create or update secret request is valid.
@@ -16,7 +18,8 @@ func (r *CreateOrUpdateSecretRequest) Validate() error {
 	return validation.ValidateStruct(r,
 		validation.Field(&r.Value,
 			validation.Required,
-			validation.Length(1, 0), // At least 1 byte
+			customValidation.NotBlank,
+			customValidation.Base64,
 		),
 	)
 }

--- a/internal/secrets/http/dto/request_test.go
+++ b/internal/secrets/http/dto/request_test.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,7 @@ import (
 func TestCreateOrUpdateSecretRequest_Validate(t *testing.T) {
 	t.Run("Success_ValidRequest", func(t *testing.T) {
 		req := CreateOrUpdateSecretRequest{
-			Value: []byte("my-secret-value"),
+			Value: base64.StdEncoding.EncodeToString([]byte("my-secret-value")),
 		}
 
 		err := req.Validate()
@@ -18,7 +19,17 @@ func TestCreateOrUpdateSecretRequest_Validate(t *testing.T) {
 
 	t.Run("Success_LargeValue", func(t *testing.T) {
 		req := CreateOrUpdateSecretRequest{
-			Value: make([]byte, 10000), // 10KB value
+			Value: base64.StdEncoding.EncodeToString(make([]byte, 10000)), // 10KB value
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Success_BinaryData", func(t *testing.T) {
+		binaryData := []byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD}
+		req := CreateOrUpdateSecretRequest{
+			Value: base64.StdEncoding.EncodeToString(binaryData),
 		}
 
 		err := req.Validate()
@@ -27,7 +38,7 @@ func TestCreateOrUpdateSecretRequest_Validate(t *testing.T) {
 
 	t.Run("Error_EmptyValue", func(t *testing.T) {
 		req := CreateOrUpdateSecretRequest{
-			Value: []byte{},
+			Value: "",
 		}
 
 		err := req.Validate()
@@ -35,10 +46,18 @@ func TestCreateOrUpdateSecretRequest_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "value")
 	})
 
-	t.Run("Error_NilValue", func(t *testing.T) {
+	t.Run("Error_InvalidBase64", func(t *testing.T) {
 		req := CreateOrUpdateSecretRequest{
-			Value: nil,
+			Value: "not-valid-base64!@#$%",
 		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "base64")
+	})
+
+	t.Run("Error_EmptyString", func(t *testing.T) {
+		req := CreateOrUpdateSecretRequest{}
 
 		err := req.Validate()
 		assert.Error(t, err)

--- a/internal/secrets/http/dto/response.go
+++ b/internal/secrets/http/dto/response.go
@@ -2,19 +2,20 @@
 package dto
 
 import (
+	"encoding/base64"
 	"time"
 
 	secretsDomain "github.com/allisson/secrets/internal/secrets/domain"
 )
 
 // SecretResponse represents a secret in API responses.
-// SECURITY: The Value field contains plaintext and is only included in GET responses.
+// SECURITY: The Value field contains base64-encoded plaintext and is only included in GET responses.
 // Must be transmitted over HTTPS in production.
 type SecretResponse struct {
 	ID        string    `json:"id"`
 	Path      string    `json:"path"`
 	Version   uint      `json:"version"`
-	Value     []byte    `json:"value,omitempty"` // Only included in GET responses
+	Value     string    `json:"value,omitempty"` // base64-encoded plaintext, only included in GET responses
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -30,14 +31,14 @@ func MapSecretToCreateResponse(secret *secretsDomain.Secret) SecretResponse {
 }
 
 // MapSecretToGetResponse converts a domain secret to an API response for GET operations.
-// The plaintext value is included in the response. SECURITY: Caller must zero plaintext
+// The plaintext value is base64-encoded before inclusion. SECURITY: Caller must zero plaintext
 // from the domain object after mapping using cryptoDomain.Zero(secret.Plaintext).
 func MapSecretToGetResponse(secret *secretsDomain.Secret) SecretResponse {
 	return SecretResponse{
 		ID:        secret.ID.String(),
 		Path:      secret.Path,
 		Version:   secret.Version,
-		Value:     secret.Plaintext, // Include decrypted value
+		Value:     base64.StdEncoding.EncodeToString(secret.Plaintext),
 		CreatedAt: secret.CreatedAt,
 	}
 }

--- a/internal/secrets/http/secret_handler.go
+++ b/internal/secrets/http/secret_handler.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -70,8 +71,19 @@ func (h *SecretHandler) CreateOrUpdateHandler(c *gin.Context) {
 		return
 	}
 
-	// Call use case
-	secret, err := h.secretUseCase.CreateOrUpdate(c.Request.Context(), path, req.Value)
+	// Decode base64 value
+	value, err := base64.StdEncoding.DecodeString(req.Value)
+	if err != nil {
+		httputil.HandleValidationErrorGin(
+			c,
+			fmt.Errorf("invalid base64 value: %w", err),
+			h.logger,
+		)
+		return
+	}
+
+	// Call use case with decoded bytes
+	secret, err := h.secretUseCase.CreateOrUpdate(c.Request.Context(), path, value)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return

--- a/internal/transit/http/dto/request.go
+++ b/internal/transit/http/dto/request.go
@@ -50,7 +50,7 @@ func (r *RotateTransitKeyRequest) Validate() error {
 
 // EncryptRequest contains the parameters for encrypting data.
 type EncryptRequest struct {
-	Plaintext []byte `json:"plaintext"`
+	Plaintext string `json:"plaintext"` // Base64-encoded plaintext
 }
 
 // Validate checks if the encrypt request is valid.
@@ -58,7 +58,8 @@ func (r *EncryptRequest) Validate() error {
 	return validation.ValidateStruct(r,
 		validation.Field(&r.Plaintext,
 			validation.Required,
-			validation.Length(1, 0), // At least 1 byte
+			customValidation.NotBlank,
+			customValidation.Base64,
 		),
 	)
 }

--- a/internal/transit/http/dto/request_test.go
+++ b/internal/transit/http/dto/request_test.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,7 +117,17 @@ func TestRotateTransitKeyRequest_Validate(t *testing.T) {
 func TestEncryptRequest_Validate(t *testing.T) {
 	t.Run("Success_ValidRequest", func(t *testing.T) {
 		req := EncryptRequest{
-			Plaintext: []byte("my secret data"),
+			Plaintext: base64.StdEncoding.EncodeToString([]byte("my secret data")),
+		}
+
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Success_BinaryData", func(t *testing.T) {
+		binaryData := []byte{0x00, 0xFF, 0xAB, 0xCD, 0xEF}
+		req := EncryptRequest{
+			Plaintext: base64.StdEncoding.EncodeToString(binaryData),
 		}
 
 		err := req.Validate()
@@ -125,16 +136,25 @@ func TestEncryptRequest_Validate(t *testing.T) {
 
 	t.Run("Error_EmptyPlaintext", func(t *testing.T) {
 		req := EncryptRequest{
-			Plaintext: []byte{},
+			Plaintext: "",
 		}
 
 		err := req.Validate()
 		assert.Error(t, err)
 	})
 
-	t.Run("Error_NilPlaintext", func(t *testing.T) {
+	t.Run("Error_InvalidBase64", func(t *testing.T) {
 		req := EncryptRequest{
-			Plaintext: nil,
+			Plaintext: "not-valid-base64!@#$",
+		}
+
+		err := req.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Error_BlankString", func(t *testing.T) {
+		req := EncryptRequest{
+			Plaintext: "   ",
 		}
 
 		err := req.Validate()

--- a/internal/transit/http/dto/response.go
+++ b/internal/transit/http/dto/response.go
@@ -2,6 +2,7 @@
 package dto
 
 import (
+	"encoding/base64"
 	"time"
 
 	transitDomain "github.com/allisson/secrets/internal/transit/domain"
@@ -36,6 +37,14 @@ type EncryptResponse struct {
 // DecryptResponse contains the result of a decryption operation.
 // SECURITY: The Plaintext field contains sensitive data and should be transmitted over HTTPS.
 type DecryptResponse struct {
-	Plaintext []byte `json:"plaintext"`
+	Plaintext string `json:"plaintext"` // Base64-encoded plaintext
 	Version   uint   `json:"version"`
+}
+
+// MapDecryptResponse converts plaintext bytes and version to an API response.
+func MapDecryptResponse(plaintext []byte, version uint) DecryptResponse {
+	return DecryptResponse{
+		Plaintext: base64.StdEncoding.EncodeToString(plaintext),
+		Version:   version,
+	}
 }

--- a/internal/transit/http/dto/response_test.go
+++ b/internal/transit/http/dto/response_test.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -65,15 +66,33 @@ func TestEncryptResponse(t *testing.T) {
 }
 
 func TestDecryptResponse(t *testing.T) {
-	t.Run("Success_CreateResponse", func(t *testing.T) {
+	t.Run("Success_MapPlaintextToBase64", func(t *testing.T) {
 		plaintext := []byte("my secret data")
+		version := uint(1)
 
-		response := DecryptResponse{
-			Plaintext: plaintext,
-			Version:   1,
-		}
+		response := MapDecryptResponse(plaintext, version)
 
-		assert.Equal(t, plaintext, response.Plaintext)
-		assert.Equal(t, uint(1), response.Version)
+		assert.Equal(t, base64.StdEncoding.EncodeToString(plaintext), response.Plaintext)
+		assert.Equal(t, version, response.Version)
+	})
+
+	t.Run("Success_EmptyPlaintext", func(t *testing.T) {
+		plaintext := []byte{}
+		version := uint(2)
+
+		response := MapDecryptResponse(plaintext, version)
+
+		assert.Equal(t, base64.StdEncoding.EncodeToString(plaintext), response.Plaintext)
+		assert.Equal(t, version, response.Version)
+	})
+
+	t.Run("Success_BinaryData", func(t *testing.T) {
+		plaintext := []byte{0x00, 0xFF, 0xAB, 0xCD, 0xEF}
+		version := uint(3)
+
+		response := MapDecryptResponse(plaintext, version)
+
+		assert.Equal(t, base64.StdEncoding.EncodeToString(plaintext), response.Plaintext)
+		assert.Equal(t, version, response.Version)
 	})
 }

--- a/internal/validation/base64.go
+++ b/internal/validation/base64.go
@@ -1,0 +1,24 @@
+// Package validation provides custom validation rules for the application.
+package validation
+
+import (
+	"encoding/base64"
+
+	validation "github.com/jellydator/validation"
+)
+
+// Base64 validates that a string is valid base64-encoded data.
+var Base64 = validation.By(func(value interface{}) error {
+	s, ok := value.(string)
+	if !ok {
+		return validation.NewError("validation_base64_type", "must be a string")
+	}
+	if s == "" {
+		return nil // Let Required handle empty strings
+	}
+	_, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return validation.NewError("validation_base64", "must be valid base64-encoded data")
+	}
+	return nil
+})


### PR DESCRIPTION
Changes all Secrets Management and Transit Encryption API endpoints to require base64-encoded plaintext in requests and return base64-encoded plaintext in responses. Previously, the API accepted raw binary data in []byte fields and relied on Go's automatic JSON base64 encoding, which caused confusion about encoding requirements at API boundaries.

Changes:
- Request DTOs now use string fields validated with custom Base64 rule instead of []byte
- Response DTOs return base64-encoded strings instead of raw bytes
- Handlers decode base64 strings before passing to use cases and encode bytes in responses
- Added internal/validation/base64.go with custom Base64 and NotBlank validation rules
- Updated README with breaking change notice and migration examples for all affected endpoints
- Updated all tests to use base64-encoded data in requests/responses

Affected Endpoints:
- POST /v1/secrets/*path - requires base64-encoded value field
- GET /v1/secrets/*path - returns base64-encoded value field
- POST /v1/transit/keys/:name/encrypt - requires base64-encoded plaintext field
- POST /v1/transit/keys/:name/decrypt - returns base64-encoded plaintext field

This improves API clarity by making encoding requirements explicit and consistent across all endpoints that handle sensitive binary data.