### PR TITLE
feat(auth/http): add client listing endpoint with pagination support

### DIFF
--- a/internal/auth/http/dto/response.go
+++ b/internal/auth/http/dto/response.go
@@ -34,6 +34,22 @@ func MapClientToResponse(client *authDomain.Client) ClientResponse {
 	}
 }
 
+// ListClientsResponse represents a paginated list of clients in API responses.
+type ListClientsResponse struct {
+	Clients []ClientResponse `json:"clients"`
+}
+
+// MapClientsToListResponse converts a slice of domain clients to a list API response.
+func MapClientsToListResponse(clients []*authDomain.Client) ListClientsResponse {
+	clientResponses := make([]ClientResponse, 0, len(clients))
+	for _, client := range clients {
+		clientResponses = append(clientResponses, MapClientToResponse(client))
+	}
+	return ListClientsResponse{
+		Clients: clientResponses,
+	}
+}
+
 // IssueTokenResponse contains the result of issuing a token.
 // SECURITY: The token is only returned once and must be saved securely.
 type IssueTokenResponse struct {

--- a/internal/auth/repository/mysql_client_repository.go
+++ b/internal/auth/repository/mysql_client_repository.go
@@ -138,6 +138,65 @@ func (m *MySQLClientRepository) Get(ctx context.Context, clientID uuid.UUID) (*a
 	return &client, nil
 }
 
+// List retrieves clients ordered by ID descending with pagination support using BINARY(16)
+// for UUIDs. Uses transaction support via database.GetTx(). Returns empty slice if no clients
+// found, or an error if UUID/policy unmarshaling or database query fails.
+func (m *MySQLClientRepository) List(
+	ctx context.Context,
+	offset, limit int,
+) ([]*authDomain.Client, error) {
+	querier := database.GetTx(ctx, m.db)
+
+	query := `SELECT id, secret, name, is_active, policies, created_at 
+			  FROM clients 
+			  ORDER BY id DESC 
+			  LIMIT ? OFFSET ?`
+
+	rows, err := querier.QueryContext(ctx, query, limit, offset)
+	if err != nil {
+		return nil, apperrors.Wrap(err, "failed to list clients")
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	// Initialize empty slice to avoid returning nil for empty results
+	clients := make([]*authDomain.Client, 0)
+	for rows.Next() {
+		var client authDomain.Client
+		var idBytes []byte
+		var policiesJSON []byte
+
+		err := rows.Scan(
+			&idBytes,
+			&client.Secret,
+			&client.Name,
+			&client.IsActive,
+			&policiesJSON,
+			&client.CreatedAt,
+		)
+		if err != nil {
+			return nil, apperrors.Wrap(err, "failed to scan client row")
+		}
+
+		if err := client.ID.UnmarshalBinary(idBytes); err != nil {
+			return nil, apperrors.Wrap(err, "failed to unmarshal client id")
+		}
+
+		if err := json.Unmarshal(policiesJSON, &client.Policies); err != nil {
+			return nil, apperrors.Wrap(err, "failed to unmarshal client policies")
+		}
+
+		clients = append(clients, &client)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, apperrors.Wrap(err, "error iterating client rows")
+	}
+
+	return clients, nil
+}
+
 // NewMySQLClientRepository creates a new MySQL Client repository.
 func NewMySQLClientRepository(db *sql.DB) *MySQLClientRepository {
 	return &MySQLClientRepository{db: db}

--- a/internal/auth/repository/mysql_client_repository_test.go
+++ b/internal/auth/repository/mysql_client_repository_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,8 +33,8 @@ func TestMySQLClientRepository_Create(t *testing.T) {
 
 	client := &authDomain.Client{
 		ID:        uuid.Must(uuid.NewV7()),
-		Secret:    "test-secret-hash",
-		Name:      "test-client",
+		Secret:    "secret",
+		Name:      "client",
 		IsActive:  true,
 		CreatedAt: time.Now().UTC(),
 	}
@@ -396,4 +397,192 @@ func TestMySQLClientRepository_Get_WithTransaction(t *testing.T) {
 	retrievedClient2, err := repo.Get(ctx, client2.ID)
 	require.NoError(t, err)
 	assert.Equal(t, client2.ID, retrievedClient2.ID)
+}
+
+func TestMySQLClientRepository_List_Success(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create multiple clients with slight delays to ensure different UUIDv7 timestamps
+	clients := make([]*authDomain.Client, 5)
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			time.Sleep(time.Millisecond)
+		}
+		clients[i] = &authDomain.Client{
+			ID:        uuid.Must(uuid.NewV7()),
+			Secret:    "secret-" + string(rune('0'+i)),
+			Name:      "client-" + string(rune('0'+i)),
+			IsActive:  true,
+			CreatedAt: time.Now().UTC(),
+		}
+		err := repo.Create(ctx, clients[i])
+		require.NoError(t, err)
+	}
+
+	// Test default pagination (first 3 clients)
+	retrieved, err := repo.List(ctx, 0, 3)
+	require.NoError(t, err)
+	assert.Len(t, retrieved, 3)
+
+	// Verify descending order (newest first)
+	assert.Equal(t, clients[4].ID, retrieved[0].ID)
+	assert.Equal(t, clients[3].ID, retrieved[1].ID)
+	assert.Equal(t, clients[2].ID, retrieved[2].ID)
+}
+
+func TestMySQLClientRepository_List_WithOffset(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create 5 clients
+	clients := make([]*authDomain.Client, 5)
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			time.Sleep(time.Millisecond)
+		}
+		clients[i] = &authDomain.Client{
+			ID:        uuid.Must(uuid.NewV7()),
+			Secret:    "secret-" + string(rune('0'+i)),
+			Name:      "client-" + string(rune('0'+i)),
+			IsActive:  true,
+			CreatedAt: time.Now().UTC(),
+		}
+		err := repo.Create(ctx, clients[i])
+		require.NoError(t, err)
+	}
+
+	// Test with offset
+	retrieved, err := repo.List(ctx, 2, 2)
+	require.NoError(t, err)
+	assert.Len(t, retrieved, 2)
+
+	// Verify correct clients (skipping first 2, getting next 2)
+	assert.Equal(t, clients[2].ID, retrieved[0].ID)
+	assert.Equal(t, clients[1].ID, retrieved[1].ID)
+}
+
+func TestMySQLClientRepository_List_EmptyResult(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// List with no clients in database
+	retrieved, err := repo.List(ctx, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, retrieved)
+	assert.NotNil(t, retrieved)
+}
+
+func TestMySQLClientRepository_List_LimitExceedsTotal(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create 2 clients
+	for i := 0; i < 2; i++ {
+		if i > 0 {
+			time.Sleep(time.Millisecond)
+		}
+		client := &authDomain.Client{
+			ID:        uuid.Must(uuid.NewV7()),
+			Secret:    "secret",
+			Name:      fmt.Sprintf("client-%d", i),
+			IsActive:  true,
+			CreatedAt: time.Now().UTC(),
+		}
+		err := repo.Create(ctx, client)
+		require.NoError(t, err)
+	}
+
+	// Request more than available
+	retrieved, err := repo.List(ctx, 0, 100)
+	require.NoError(t, err)
+	assert.Len(t, retrieved, 2)
+}
+
+func TestMySQLClientRepository_List_OffsetExceedsTotal(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create 2 clients
+	for i := 0; i < 2; i++ {
+		if i > 0 {
+			time.Sleep(time.Millisecond)
+		}
+		client := &authDomain.Client{
+			ID:        uuid.Must(uuid.NewV7()),
+			Secret:    "secret",
+			Name:      fmt.Sprintf("client-%d", i),
+			IsActive:  true,
+			CreatedAt: time.Now().UTC(),
+		}
+		err := repo.Create(ctx, client)
+		require.NoError(t, err)
+	}
+
+	// Offset beyond available clients
+	retrieved, err := repo.List(ctx, 10, 10)
+	require.NoError(t, err)
+	assert.Empty(t, retrieved)
+}
+
+func TestMySQLClientRepository_List_WithPolicies(t *testing.T) {
+	db := testutil.SetupMySQLDB(t)
+	defer testutil.TeardownDB(t, db)
+	defer testutil.CleanupMySQLDB(t, db)
+
+	repo := NewMySQLClientRepository(db)
+	ctx := context.Background()
+
+	// Create client with policies
+	client := &authDomain.Client{
+		ID:       uuid.Must(uuid.NewV7()),
+		Secret:   "secret",
+		Name:     "client-with-policies",
+		IsActive: true,
+		Policies: []authDomain.PolicyDocument{
+			{
+				Path:         "secrets/*",
+				Capabilities: []authDomain.Capability{authDomain.ReadCapability, authDomain.WriteCapability},
+			},
+			{
+				Path:         "keys/*",
+				Capabilities: []authDomain.Capability{authDomain.EncryptCapability},
+			},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err := repo.Create(ctx, client)
+	require.NoError(t, err)
+
+	// List and verify policies are preserved
+	retrieved, err := repo.List(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, retrieved, 1)
+
+	assert.Equal(t, client.ID, retrieved[0].ID)
+	assert.Len(t, retrieved[0].Policies, 2)
+	assert.Equal(t, "secrets/*", retrieved[0].Policies[0].Path)
+	assert.Contains(t, retrieved[0].Policies[0].Capabilities, authDomain.ReadCapability)
+	assert.Contains(t, retrieved[0].Policies[0].Capabilities, authDomain.WriteCapability)
 }

--- a/internal/auth/usecase/client_usecase.go
+++ b/internal/auth/usecase/client_usecase.go
@@ -98,6 +98,12 @@ func (c *clientUseCase) Delete(ctx context.Context, clientID uuid.UUID) error {
 	return c.clientRepo.Update(ctx, client)
 }
 
+// List retrieves clients ordered by ID descending with pagination support.
+// Returns empty slice if no clients found.
+func (c *clientUseCase) List(ctx context.Context, offset, limit int) ([]*authDomain.Client, error) {
+	return c.clientRepo.List(ctx, offset, limit)
+}
+
 // NewClientUseCase creates a new ClientUseCase with the provided dependencies.
 func NewClientUseCase(
 	txManager database.TxManager,

--- a/internal/auth/usecase/interface.go
+++ b/internal/auth/usecase/interface.go
@@ -20,6 +20,10 @@ type ClientRepository interface {
 
 	// Get retrieves a client by ID. Returns ErrClientNotFound if not found.
 	Get(ctx context.Context, clientID uuid.UUID) (*authDomain.Client, error)
+
+	// List retrieves clients ordered by ID descending (newest first) with pagination.
+	// Uses offset and limit for pagination control. Returns empty slice if no clients found.
+	List(ctx context.Context, offset, limit int) ([]*authDomain.Client, error)
 }
 
 // TokenRepository defines persistence operations for authentication tokens.
@@ -74,6 +78,10 @@ type ClientUseCase interface {
 	//
 	// Returns ErrClientNotFound if the specified client doesn't exist.
 	Get(ctx context.Context, clientID uuid.UUID) (*authDomain.Client, error)
+
+	// List retrieves clients ordered by ID descending (newest first) with pagination.
+	// Uses offset and limit for pagination control. Returns empty slice if no clients found.
+	List(ctx context.Context, offset, limit int) ([]*authDomain.Client, error)
 
 	// Delete performs a soft delete by setting IsActive to false, preventing authentication
 	// while preserving the client record for audit purposes. The client's data remains in

--- a/internal/auth/usecase/mocks/client_repository.go
+++ b/internal/auth/usecase/mocks/client_repository.go
@@ -130,6 +130,66 @@ func (_c *MockClientRepository_Get_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// List provides a mock function with given fields: ctx, offset, limit
+func (_m *MockClientRepository) List(ctx context.Context, offset int, limit int) ([]*domain.Client, error) {
+	ret := _m.Called(ctx, offset, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
+	var r0 []*domain.Client
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) ([]*domain.Client, error)); ok {
+		return rf(ctx, offset, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) []*domain.Client); ok {
+		r0 = rf(ctx, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*domain.Client)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = rf(ctx, offset, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientRepository_List_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'List'
+type MockClientRepository_List_Call struct {
+	*mock.Call
+}
+
+// List is a helper method to define mock.On call
+//   - ctx context.Context
+//   - offset int
+//   - limit int
+func (_e *MockClientRepository_Expecter) List(ctx interface{}, offset interface{}, limit interface{}) *MockClientRepository_List_Call {
+	return &MockClientRepository_List_Call{Call: _e.mock.On("List", ctx, offset, limit)}
+}
+
+func (_c *MockClientRepository_List_Call) Run(run func(ctx context.Context, offset int, limit int)) *MockClientRepository_List_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *MockClientRepository_List_Call) Return(_a0 []*domain.Client, _a1 error) *MockClientRepository_List_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientRepository_List_Call) RunAndReturn(run func(context.Context, int, int) ([]*domain.Client, error)) *MockClientRepository_List_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function with given fields: ctx, client
 func (_m *MockClientRepository) Update(ctx context.Context, client *domain.Client) error {
 	ret := _m.Called(ctx, client)

--- a/internal/auth/usecase/mocks/client_use_case.go
+++ b/internal/auth/usecase/mocks/client_use_case.go
@@ -189,6 +189,66 @@ func (_c *MockClientUseCase_Get_Call) RunAndReturn(run func(context.Context, uui
 	return _c
 }
 
+// List provides a mock function with given fields: ctx, offset, limit
+func (_m *MockClientUseCase) List(ctx context.Context, offset int, limit int) ([]*domain.Client, error) {
+	ret := _m.Called(ctx, offset, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
+	var r0 []*domain.Client
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) ([]*domain.Client, error)); ok {
+		return rf(ctx, offset, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) []*domain.Client); ok {
+		r0 = rf(ctx, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*domain.Client)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = rf(ctx, offset, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientUseCase_List_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'List'
+type MockClientUseCase_List_Call struct {
+	*mock.Call
+}
+
+// List is a helper method to define mock.On call
+//   - ctx context.Context
+//   - offset int
+//   - limit int
+func (_e *MockClientUseCase_Expecter) List(ctx interface{}, offset interface{}, limit interface{}) *MockClientUseCase_List_Call {
+	return &MockClientUseCase_List_Call{Call: _e.mock.On("List", ctx, offset, limit)}
+}
+
+func (_c *MockClientUseCase_List_Call) Run(run func(ctx context.Context, offset int, limit int)) *MockClientUseCase_List_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *MockClientUseCase_List_Call) Return(_a0 []*domain.Client, _a1 error) *MockClientUseCase_List_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientUseCase_List_Call) RunAndReturn(run func(context.Context, int, int) ([]*domain.Client, error)) *MockClientUseCase_List_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function with given fields: ctx, clientID, updateClientInput
 func (_m *MockClientUseCase) Update(ctx context.Context, clientID uuid.UUID, updateClientInput *domain.UpdateClientInput) error {
 	ret := _m.Called(ctx, clientID, updateClientInput)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -98,6 +98,10 @@ func (s *Server) SetupRouter(
 				authHTTP.AuthorizationMiddleware(authDomain.WriteCapability, auditLogUseCase, s.logger),
 				clientHandler.CreateHandler,
 			)
+			clients.GET("",
+				authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+				clientHandler.ListHandler,
+			)
 			clients.GET("/:id",
 				authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
 				clientHandler.GetHandler,


### PR DESCRIPTION
Implement GET /v1/clients endpoint to list API clients with offset/limit pagination (default: 50, max: 100).

Returns clients ordered by ID DESC (newest first) using UUIDv7 time-based properties. Requires ReadCapability authorization.

- Add List() method to ClientRepository interface and implementations:
  - PostgreSQL: SELECT with native UUID support
  - MySQL: BINARY(16) UUID marshaling with proper ordering
  - Both support transaction-aware querying via GetTx()
- Add ClientUseCase.List() to orchestrate repository calls
- Add ClientHandler.ListHandler() with query param validation:
  - offset: non-negative integer (default 0)
  - limit: 1-100 (default 50)
  - Returns 422 for invalid parameters
- Add ListClientsResponse DTO with MapClientsToListResponse() mapper
- Register GET /v1/clients route with ReadCapability authorization
- Add comprehensive test coverage:
  - Handler tests: pagination, validation, empty results, use case errors
  - Repository tests (PostgreSQL/MySQL): ordering, offset/limit, policies preservation
  - Use case tests: delegation to repository
  - DTO tests: mapping multiple/empty/single clients
- Update README with endpoint documentation and usage examples