### PR TITLE
docs: add cross-linking docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1053,3 +1053,10 @@ func (s *Server) SetupRouter(
 - `DELETE /v1/clients/:id` → `DeleteCapability` (remove client)
 
 **Reference:** `/internal/http/server.go` (SetupRouter method)
+
+## See also
+
+- [Repository README](README.md)
+- [Documentation index](docs/README.md)
+- [Testing guide](docs/development/testing.md)
+- [Contributing guide](docs/contributing.md)

--- a/README.md
+++ b/README.md
@@ -16,47 +16,47 @@ The default way to run Secrets is the published Docker image:
 docker pull allisson/secrets:latest
 ```
 
-Then follow the Docker setup guide in `docs/getting-started/docker.md`.
+Then follow the Docker setup guide in [docs/getting-started/docker.md](docs/getting-started/docker.md).
 
 ⚠️ After rotating a master key or KEK, restart API server instances so they load the updated key material.
 
 ## 🧭 Choose Your Path
 
-1. 🐳 **Run with Docker image (recommended)**: `docs/getting-started/docker.md`
-2. 💻 **Run locally for development**: `docs/getting-started/local-development.md`
+1. 🐳 **Run with Docker image (recommended)**: [docs/getting-started/docker.md](docs/getting-started/docker.md)
+2. 💻 **Run locally for development**: [docs/getting-started/local-development.md](docs/getting-started/local-development.md)
 
 ## 📚 Docs Map
 
 - **Start Here**
-- 🏁 **Docs index**: `docs/README.md`
-- 🚀 **Getting started (Docker)**: `docs/getting-started/docker.md`
-- 💻 **Getting started (local)**: `docs/getting-started/local-development.md`
-- 🧰 **Troubleshooting**: `docs/getting-started/troubleshooting.md`
-- ✅ **Smoke test script**: `docs/getting-started/smoke-test.md`
+- 🏁 **Docs index**: [docs/README.md](docs/README.md)
+- 🚀 **Getting started (Docker)**: [docs/getting-started/docker.md](docs/getting-started/docker.md)
+- 💻 **Getting started (local)**: [docs/getting-started/local-development.md](docs/getting-started/local-development.md)
+- 🧰 **Troubleshooting**: [docs/getting-started/troubleshooting.md](docs/getting-started/troubleshooting.md)
+- ✅ **Smoke test script**: [docs/getting-started/smoke-test.md](docs/getting-started/smoke-test.md)
 
 - **By Topic**
-- ⚙️ **Environment variables**: `docs/configuration/environment-variables.md`
-- 🏗️ **Architecture concepts**: `docs/concepts/architecture.md`
-- 🔒 **Security model**: `docs/concepts/security-model.md`
-- 🔑 **Key management operations**: `docs/operations/key-management.md`
-- 🏭 **Production deployment**: `docs/operations/production.md`
-- 🛠️ **Development and testing**: `docs/development/testing.md`
-- 🤝 **Docs contributing**: `docs/contributing.md`
-- 🗒️ **Docs changelog**: `docs/CHANGELOG.md`
+- ⚙️ **Environment variables**: [docs/configuration/environment-variables.md](docs/configuration/environment-variables.md)
+- 🏗️ **Architecture concepts**: [docs/concepts/architecture.md](docs/concepts/architecture.md)
+- 🔒 **Security model**: [docs/concepts/security-model.md](docs/concepts/security-model.md)
+- 🔑 **Key management operations**: [docs/operations/key-management.md](docs/operations/key-management.md)
+- 🏭 **Production deployment**: [docs/operations/production.md](docs/operations/production.md)
+- 🛠️ **Development and testing**: [docs/development/testing.md](docs/development/testing.md)
+- 🤝 **Docs contributing**: [docs/contributing.md](docs/contributing.md)
+- 🗒️ **Docs changelog**: [docs/CHANGELOG.md](docs/CHANGELOG.md)
 
 - **API Reference**
-- 🔐 **Auth API**: `docs/api/authentication.md`
-- 👤 **Clients API**: `docs/api/clients.md`
-- 📘 **Policy cookbook**: `docs/api/policies.md`
-- 📦 **Secrets API**: `docs/api/secrets.md`
-- 🚄 **Transit API**: `docs/api/transit.md`
-- 📜 **Audit logs API**: `docs/api/audit-logs.md`
+- 🔐 **Auth API**: [docs/api/authentication.md](docs/api/authentication.md)
+- 👤 **Clients API**: [docs/api/clients.md](docs/api/clients.md)
+- 📘 **Policy cookbook**: [docs/api/policies.md](docs/api/policies.md)
+- 📦 **Secrets API**: [docs/api/secrets.md](docs/api/secrets.md)
+- 🚄 **Transit API**: [docs/api/transit.md](docs/api/transit.md)
+- 📜 **Audit logs API**: [docs/api/audit-logs.md](docs/api/audit-logs.md)
 
 - **Examples**
-- 🧪 **Curl examples**: `docs/examples/curl.md`
-- 🐍 **Python examples**: `docs/examples/python.md`
-- 🟨 **JavaScript examples**: `docs/examples/javascript.md`
-- 🐹 **Go examples**: `docs/examples/go.md`
+- 🧪 **Curl examples**: [docs/examples/curl.md](docs/examples/curl.md)
+- 🐍 **Python examples**: [docs/examples/python.md](docs/examples/python.md)
+- 🟨 **JavaScript examples**: [docs/examples/javascript.md](docs/examples/javascript.md)
+- 🐹 **Go examples**: [docs/examples/go.md](docs/examples/go.md)
 
 All detailed guides include practical use cases and copy/paste-ready examples.
 
@@ -81,3 +81,10 @@ All detailed guides include practical use cases and copy/paste-ready examples.
 ## 📄 License
 
 MIT. See `LICENSE`.
+
+## See also
+
+- [Documentation index](docs/README.md)
+- [Docker getting started](docs/getting-started/docker.md)
+- [API authentication](docs/api/authentication.md)
+- [Production operations](docs/operations/production.md)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,3 +22,11 @@
 - Added CI docs-only PR guard requiring `docs/CHANGELOG.md` updates
 - Added pull request template with documentation quality gate checklist
 - Added baseline OpenAPI spec (`docs/openapi.yaml`) and linked it from API docs
+- Added cross-linking across all docs pages via `See also` sections for faster navigation
+- Converted docs path references in `README.md` and `docs/README.md` into clickable Markdown links
+
+## See also
+
+- [Documentation index](README.md)
+- [Contributing guide](contributing.md)
+- [Testing guide](development/testing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,38 +6,38 @@ Welcome to the full documentation for Secrets. Pick a path and dive in 🚀
 
 ## 🧭 Start Here
 
-- 🐳 `getting-started/docker.md` (recommended)
-- 💻 `getting-started/local-development.md`
-- 🧰 `getting-started/troubleshooting.md`
-- ✅ `getting-started/smoke-test.md`
+- 🐳 [getting-started/docker.md](getting-started/docker.md) (recommended)
+- 💻 [getting-started/local-development.md](getting-started/local-development.md)
+- 🧰 [getting-started/troubleshooting.md](getting-started/troubleshooting.md)
+- ✅ [getting-started/smoke-test.md](getting-started/smoke-test.md)
 
 ## 🛣️ First-Time Operator Path
 
-1. Start with Docker guide: `getting-started/docker.md`
-2. Validate end-to-end setup: `getting-started/smoke-test.md`
-3. Apply production hardening checklist: `operations/production.md`
+1. Start with Docker guide: [getting-started/docker.md](getting-started/docker.md)
+2. Validate end-to-end setup: [getting-started/smoke-test.md](getting-started/smoke-test.md)
+3. Apply production hardening checklist: [operations/production.md](operations/production.md)
 
 ## 📖 Documentation by Topic
 
-- ⚙️ `configuration/environment-variables.md`
-- 🏗️ `concepts/architecture.md`
-- 🔒 `concepts/security-model.md`
-- 🔑 `operations/key-management.md`
-- 🏭 `operations/production.md`
-- 🛠️ `development/testing.md`
-- 🤝 `contributing.md`
-- 🗒️ `CHANGELOG.md`
+- ⚙️ [configuration/environment-variables.md](configuration/environment-variables.md)
+- 🏗️ [concepts/architecture.md](concepts/architecture.md)
+- 🔒 [concepts/security-model.md](concepts/security-model.md)
+- 🔑 [operations/key-management.md](operations/key-management.md)
+- 🏭 [operations/production.md](operations/production.md)
+- 🛠️ [development/testing.md](development/testing.md)
+- 🤝 [contributing.md](contributing.md)
+- 🗒️ [CHANGELOG.md](CHANGELOG.md)
 
 ## 🌐 API Reference
 
-- 🔐 `api/authentication.md`
-- 👤 `api/clients.md`
-- 📘 `api/policies.md`
-- 📦 `api/secrets.md`
-- 🚄 `api/transit.md`
-- 📜 `api/audit-logs.md`
-- 🧱 `api/response-shapes.md`
-- 📄 `openapi.yaml`
+- 🔐 [api/authentication.md](api/authentication.md)
+- 👤 [api/clients.md](api/clients.md)
+- 📘 [api/policies.md](api/policies.md)
+- 📦 [api/secrets.md](api/secrets.md)
+- 🚄 [api/transit.md](api/transit.md)
+- 📜 [api/audit-logs.md](api/audit-logs.md)
+- 🧱 [api/response-shapes.md](api/response-shapes.md)
+- 📄 [openapi.yaml](openapi.yaml)
 
 ## 🖥️ Supported Platforms
 
@@ -48,11 +48,18 @@ Welcome to the full documentation for Secrets. Pick a path and dive in 🚀
 
 ## 💡 Practical Examples
 
-- 🧪 `examples/curl.md`
-- 🐍 `examples/python.md`
-- 🟨 `examples/javascript.md`
-- 🐹 `examples/go.md`
+- 🧪 [examples/curl.md](examples/curl.md)
+- 🐍 [examples/python.md](examples/python.md)
+- 🟨 [examples/javascript.md](examples/javascript.md)
+- 🐹 [examples/go.md](examples/go.md)
 
 ## 🧩 Positioning
 
 Secrets is inspired by HashiCorp Vault, but it is much simpler and intentionally focused on core use cases. It is not designed to compete with Vault.
+
+## See also
+
+- [Docker getting started](getting-started/docker.md)
+- [Architecture](concepts/architecture.md)
+- [Authentication API](api/authentication.md)
+- [Production operations](operations/production.md)

--- a/docs/api/audit-logs.md
+++ b/docs/api/audit-logs.md
@@ -146,3 +146,10 @@ curl -s "http://localhost:8080/v1/audit-logs?limit=100" \
 - `docs/examples/javascript.md`
 - `docs/examples/go.md`
 - `docs/api/response-shapes.md`
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Clients API](clients.md)
+- [Policies cookbook](policies.md)
+- [Response shapes](response-shapes.md)

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -111,3 +111,10 @@ Representative error payloads (exact messages may vary):
 
 - `Bearer` prefix is case-insensitive (`bearer`, `Bearer`, `BEARER`)
 - Tokens are time-limited and should be renewed before expiration
+
+## See also
+
+- [Clients API](clients.md)
+- [Policies cookbook](policies.md)
+- [Audit logs API](audit-logs.md)
+- [Response shapes](response-shapes.md)

--- a/docs/api/clients.md
+++ b/docs/api/clients.md
@@ -131,3 +131,10 @@ Expected result: create returns `201 Created` with one-time `secret`; list retur
 - 🧩 Create one client per service
 - 🔒 Grant only required capabilities per path
 - 🔄 Rotate credentials by creating new clients and deactivating old ones
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Policies cookbook](policies.md)
+- [Audit logs API](audit-logs.md)
+- [Response shapes](response-shapes.md)

--- a/docs/api/policies.md
+++ b/docs/api/policies.md
@@ -195,3 +195,10 @@ Also verify path matching, for example `/v1/secrets/app/prod/*` if you want tigh
 2. Use separate clients per service/workload
 3. Avoid wildcard `*` except emergency administration
 4. Review policies on every deploy and rotation cycle
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Clients API](clients.md)
+- [Secrets API](secrets.md)
+- [Transit API](transit.md)

--- a/docs/api/response-shapes.md
+++ b/docs/api/response-shapes.md
@@ -105,3 +105,10 @@ Common error categories:
 - `validation_error`
 - `not_found`
 - `conflict`
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Clients API](clients.md)
+- [Secrets API](secrets.md)
+- [Transit API](transit.md)

--- a/docs/api/secrets.md
+++ b/docs/api/secrets.md
@@ -144,3 +144,10 @@ Expected result: write returns `201 Created`; read returns `200 OK` with base64 
 - `docs/examples/javascript.md`
 - `docs/examples/go.md`
 - `docs/api/response-shapes.md`
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Policies cookbook](policies.md)
+- [Response shapes](response-shapes.md)
+- [Curl examples](../examples/curl.md)

--- a/docs/api/transit.md
+++ b/docs/api/transit.md
@@ -168,3 +168,10 @@ Expected result: key creation returns `201 Created`; encrypt returns `200 OK` wi
 - `docs/examples/javascript.md`
 - `docs/examples/go.md`
 - `docs/api/response-shapes.md`
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Policies cookbook](policies.md)
+- [Response shapes](response-shapes.md)
+- [Curl examples](../examples/curl.md)

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -48,3 +48,10 @@ flowchart TD
 - 🔒 Isolate versions cryptographically using independent DEKs
 - 🧪 Keep use cases testable with mockable interfaces
 - 🌐 Expose consistent HTTP contracts while preserving domain purity
+
+## See also
+
+- [Security model](security-model.md)
+- [Key management operations](../operations/key-management.md)
+- [Environment variables](../configuration/environment-variables.md)
+- [Secrets API](../api/secrets.md)

--- a/docs/concepts/security-model.md
+++ b/docs/concepts/security-model.md
@@ -45,3 +45,10 @@ Secrets is designed for practical defense-in-depth around secret storage and cry
 2. Rotate KEK (and master key if needed)
 3. Re-issue clients/tokens and validate policy scope
 4. Review audit logs for lateral movement indicators
+
+## See also
+
+- [Architecture](architecture.md)
+- [Authentication API](../api/authentication.md)
+- [Policies cookbook](../api/policies.md)
+- [Key management operations](../operations/key-management.md)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -42,3 +42,10 @@ Or with Docker image:
 ```bash
 docker run --rm allisson/secrets:latest create-master-key --id default
 ```
+
+## See also
+
+- [Docker getting started](../getting-started/docker.md)
+- [Local development](../getting-started/local-development.md)
+- [Production operations](../operations/production.md)
+- [Testing guide](../development/testing.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,3 +69,10 @@ This target runs markdown linting and offline markdown link validation.
 2. Add or update relevant examples if behavior/commands changed
 3. Append a concise entry in `docs/CHANGELOG.md` for significant docs changes
 4. Run `make docs-lint` before opening or merging PRs
+
+## See also
+
+- [Documentation index](README.md)
+- [Testing guide](development/testing.md)
+- [Changelog](CHANGELOG.md)
+- [Local development](getting-started/local-development.md)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -35,3 +35,10 @@ make test-db-down
 2. Run `make lint`
 3. Run targeted tests
 4. Run full `make test`
+
+## See also
+
+- [Local development](../getting-started/local-development.md)
+- [Smoke test](../getting-started/smoke-test.md)
+- [Troubleshooting](../getting-started/troubleshooting.md)
+- [Contributing guide](../contributing.md)

--- a/docs/examples/curl.md
+++ b/docs/examples/curl.md
@@ -55,3 +55,10 @@ curl -X POST http://localhost:8080/v1/transit/keys/pii/decrypt \
 curl "http://localhost:8080/v1/audit-logs?limit=50&offset=0" \
   -H "Authorization: Bearer $TOKEN"
 ```
+
+## See also
+
+- [Authentication API](../api/authentication.md)
+- [Secrets API](../api/secrets.md)
+- [Transit API](../api/transit.md)
+- [Clients API](../api/clients.md)

--- a/docs/examples/go.md
+++ b/docs/examples/go.md
@@ -152,3 +152,10 @@ func createTransitKey(token, keyName string) error {
     return nil
 }
 ```
+
+## See also
+
+- [Authentication API](../api/authentication.md)
+- [Secrets API](../api/secrets.md)
+- [Transit API](../api/transit.md)
+- [Response shapes](../api/response-shapes.md)

--- a/docs/examples/javascript.md
+++ b/docs/examples/javascript.md
@@ -78,3 +78,10 @@ main().catch((error) => {
   process.exit(1);
 });
 ```
+
+## See also
+
+- [Authentication API](../api/authentication.md)
+- [Secrets API](../api/secrets.md)
+- [Transit API](../api/transit.md)
+- [Response shapes](../api/response-shapes.md)

--- a/docs/examples/python.md
+++ b/docs/examples/python.md
@@ -72,3 +72,10 @@ if __name__ == "__main__":
     create_secret(token)
     transit_encrypt_decrypt(token)
 ```
+
+## See also
+
+- [Authentication API](../api/authentication.md)
+- [Secrets API](../api/secrets.md)
+- [Transit API](../api/transit.md)
+- [Response shapes](../api/response-shapes.md)

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -122,3 +122,10 @@ curl -X POST http://localhost:8080/v1/secrets/app/prod/db-password \
 ⚠️ Security Warning: base64 is encoding, not encryption. Always use HTTPS/TLS.
 
 For a full end-to-end check, run `docs/getting-started/smoke-test.sh` (usage in `docs/getting-started/smoke-test.md`).
+
+## See also
+
+- [Local development](local-development.md)
+- [Smoke test](smoke-test.md)
+- [Troubleshooting](troubleshooting.md)
+- [Environment variables](../configuration/environment-variables.md)

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -63,3 +63,10 @@ DB_CONNECTION_STRING=postgres://user:password@localhost:5432/mydb?sslmode=disabl
 ```bash
 curl http://localhost:8080/health
 ```
+
+## See also
+
+- [Docker getting started](docker.md)
+- [Smoke test](smoke-test.md)
+- [Troubleshooting](troubleshooting.md)
+- [Testing guide](../development/testing.md)

--- a/docs/getting-started/smoke-test.md
+++ b/docs/getting-started/smoke-test.md
@@ -42,3 +42,10 @@ Optional variables:
 - `TRANSIT_KEY_NAME` (default: `smoke-test-key`)
 
 ⚠️ Security Warning: base64 is encoding, not encryption. Always use HTTPS/TLS.
+
+## See also
+
+- [Docker getting started](docker.md)
+- [Local development](local-development.md)
+- [Troubleshooting](troubleshooting.md)
+- [Curl examples](../examples/curl.md)

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -115,3 +115,10 @@ Use this quick route before diving into detailed sections:
 4. Initial KEK exists
 5. Token issuance works
 6. Caller policy matches endpoint capability and path
+
+## See also
+
+- [Smoke test](smoke-test.md)
+- [Docker getting started](docker.md)
+- [Local development](local-development.md)
+- [Production operations](../operations/production.md)

--- a/docs/operations/key-management.md
+++ b/docs/operations/key-management.md
@@ -82,3 +82,10 @@ Operational step:
 ## Related
 
 - 🏭 Production deployment: `docs/operations/production.md`
+
+## See also
+
+- [Production operations](production.md)
+- [Security model](../concepts/security-model.md)
+- [Transit API](../api/transit.md)
+- [Environment variables](../configuration/environment-variables.md)

--- a/docs/operations/production.md
+++ b/docs/operations/production.md
@@ -115,3 +115,10 @@ SLO examples (starting point):
 - [ ] Least-privilege policies applied for all clients
 - [ ] Monitoring alerts configured
 - [ ] Incident response owner and process documented
+
+## See also
+
+- [Key management operations](key-management.md)
+- [Environment variables](../configuration/environment-variables.md)
+- [Security model](../concepts/security-model.md)
+- [Troubleshooting](../getting-started/troubleshooting.md)

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -344,3 +344,10 @@ Potential improvements for the container:
 3. **Metrics**: Add metrics for component initialization time
 4. **Configuration validation**: Validate configuration before initializing components
 5. **Graceful degradation**: Support optional dependencies that can fail gracefully
+
+## See also
+
+- [Documentation index](../../docs/README.md)
+- [Architecture concepts](../../docs/concepts/architecture.md)
+- [Local development](../../docs/getting-started/local-development.md)
+- [Testing guide](../../docs/development/testing.md)


### PR DESCRIPTION
Improve documentation navigation by adding 'See also' sections to all doc pages and converting file path references to proper markdown links throughout README and docs index files. This enables faster discovery of related content and one-click navigation between documentation pages in web-based viewers.