### PR TITLE
fix(transit): enforce versioned ciphertext format

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All detailed guides include practical use cases and copy/paste-ready examples.
 ## ✨ What You Get
 
 - 🔐 Envelope encryption (`Master Key -> KEK -> DEK -> Secret Data`)
-- 🚄 Transit encryption (`/v1/transit/keys/*`) for encrypt/decrypt as a service
+- 🚄 Transit encryption (`/v1/transit/keys/*`) for encrypt/decrypt as a service (decrypt input uses `<version>:<base64-ciphertext>`; see [Transit API docs](docs/api/transit.md))
 - 👤 Token-based authentication and policy-based authorization
 - 📦 Versioned secrets by path (`/v1/secrets/*path`)
 - 📜 Audit logs with request correlation (`request_id`) and filtering

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,11 @@
 - Added baseline OpenAPI spec (`docs/openapi.yaml`) and linked it from API docs
 - Added cross-linking across all docs pages via `See also` sections for faster navigation
 - Converted docs path references in `README.md` and `docs/README.md` into clickable Markdown links
+- Clarified transit decrypt contract: callers must pass versioned ciphertext (`<version>:<base64-ciphertext>`) exactly as returned by encrypt
+- Documented transit decrypt validation behavior: malformed ciphertext now returns `422 Unprocessable Entity`
+- Added transit decrypt input contract examples (valid/invalid) and representative `422` payloads
+- Added OpenAPI decrypt request examples and explicit `401`/`403`/`404` responses
+- Added 422 troubleshooting matrix and transit round-trip verification/decode notes in examples
 
 ## See also
 

--- a/docs/api/policies.md
+++ b/docs/api/policies.md
@@ -72,6 +72,8 @@ Risk note: should not include `decrypt` unless CI must read values.
 
 Use for services that should encrypt sensitive values but never decrypt.
 
+See [Transit API](transit.md) for encrypt/decrypt request and response contracts.
+
 ```json
 [
   {
@@ -86,6 +88,9 @@ Risk note: encrypt-only separation limits plaintext exposure.
 ## 4) Transit decrypt-only service
 
 Use for tightly scoped decryption workers.
+
+See [Decrypt input contract](transit.md#decrypt-input-contract) for required
+`ciphertext` format.
 
 ```json
 [

--- a/docs/api/response-shapes.md
+++ b/docs/api/response-shapes.md
@@ -65,6 +65,9 @@ Transit decrypt:
 }
 ```
 
+Input contract note: transit decrypt expects `ciphertext` in format
+`<version>:<base64-ciphertext>`. See [Transit API](transit.md#decrypt-input-contract).
+
 Audit log list:
 
 ```json

--- a/docs/api/transit.md
+++ b/docs/api/transit.md
@@ -90,6 +90,21 @@ curl -X POST http://localhost:8080/v1/transit/keys/payment-data/decrypt \
   -d '{"ciphertext":"1:ZW5jcnlwdGVkLi4u"}'
 ```
 
+For transit decrypt, pass `ciphertext` exactly as returned by encrypt (`<version>:<base64-ciphertext>`).
+
+### Decrypt Input Contract
+
+Valid `ciphertext` examples:
+
+- `1:ZW5jcnlwdGVkLWJ5dGVzLi4u`
+- `42:AAEC`
+
+Invalid `ciphertext` examples:
+
+- `ZW5jcnlwdGVkLWJ5dGVzLi4u` (missing version prefix and `:` separator)
+- `1:not-base64!!!` (ciphertext segment is not valid base64)
+- `abc:ZW5jcnlwdGVk` (version is not numeric)
+
 Example decrypt response (`200 OK`):
 
 ```json
@@ -104,7 +119,7 @@ Example decrypt response (`200 OK`):
 - `403 Forbidden`: missing capability (`write`, `rotate`, `encrypt`, `decrypt`, `delete`)
 - `404 Not Found`: key missing or soft deleted
 - `409 Conflict`: key already exists on create
-- `422 Unprocessable Entity`: malformed request payload
+- `422 Unprocessable Entity`: malformed request payload, invalid blob format, or invalid ciphertext base64
 
 ## Error Payload Examples
 
@@ -134,6 +149,32 @@ Representative error payloads (exact messages may vary):
 {
   "error": "validation_error",
   "message": "plaintext must be base64-encoded"
+}
+```
+
+Decrypt validation errors also return `422` when ciphertext is not in
+`<version>:<base64-ciphertext>` format or when ciphertext payload is not valid base64.
+
+Transit decrypt `422` examples (representative messages):
+
+```json
+{
+  "error": "validation_error",
+  "message": "ciphertext must be in format version:base64-ciphertext"
+}
+```
+
+```json
+{
+  "error": "validation_error",
+  "message": "ciphertext version must be numeric"
+}
+```
+
+```json
+{
+  "error": "validation_error",
+  "message": "ciphertext payload must be valid base64"
 }
 ```
 

--- a/docs/examples/curl.md
+++ b/docs/examples/curl.md
@@ -32,6 +32,8 @@ curl http://localhost:8080/v1/secrets/app/prod/api-key \
 
 ## 4) Transit encrypt + decrypt
 
+For transit decrypt, pass `ciphertext` exactly as returned by encrypt (`<version>:<base64-ciphertext>`).
+
 ```bash
 curl -X POST http://localhost:8080/v1/transit/keys \
   -H "Authorization: Bearer $TOKEN" \
@@ -43,10 +45,14 @@ CIPHERTEXT=$(curl -s -X POST http://localhost:8080/v1/transit/keys/pii/encrypt \
   -H "Content-Type: application/json" \
   -d '{"plaintext":"am9obkBleGFtcGxlLmNvbQ=="}' | jq -r .ciphertext)
 
-curl -X POST http://localhost:8080/v1/transit/keys/pii/decrypt \
+PLAINTEXT_B64=$(curl -s -X POST http://localhost:8080/v1/transit/keys/pii/decrypt \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d "{\"ciphertext\":\"$CIPHERTEXT\"}"
+  -d "{\"ciphertext\":\"$CIPHERTEXT\"}" | jq -r .plaintext)
+
+test "$PLAINTEXT_B64" = "am9obkBleGFtcGxlLmNvbQ==" && echo "Transit round-trip verified"
+
+# Note: `plaintext` is base64. Decode it in your app/runtime before use.
 ```
 
 ## 5) Audit logs query

--- a/docs/examples/go.md
+++ b/docs/examples/go.md
@@ -38,7 +38,17 @@ func main() {
         panic(err)
     }
 
-    fmt.Println("decrypted plaintext (base64):", plaintextB64)
+    if plaintextB64 != base64.StdEncoding.EncodeToString([]byte("john@example.com")) {
+        panic("round-trip verification failed")
+    }
+
+    decoded, err := base64.StdEncoding.DecodeString(plaintextB64)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println("decrypted value:", string(decoded))
+
+    fmt.Println("Transit round-trip verified")
 }
 
 func issueToken(clientID, clientSecret string) (string, error) {
@@ -108,6 +118,7 @@ func transitEncrypt(token, keyName, plaintext string) (string, error) {
     if err := json.Unmarshal(raw, &out); err != nil {
         return "", err
     }
+    // For transit decrypt, pass ciphertext exactly as returned by encrypt: "<version>:<base64-ciphertext>".
     return out.Ciphertext, nil
 }
 

--- a/docs/examples/python.md
+++ b/docs/examples/python.md
@@ -55,6 +55,7 @@ def transit_encrypt_decrypt(token: str) -> None:
         timeout=10,
     )
     encrypted.raise_for_status()
+    # For transit decrypt, pass ciphertext exactly as returned by encrypt: "<version>:<base64-ciphertext>".
     ciphertext = encrypted.json()["ciphertext"]
 
     decrypted = requests.post(
@@ -64,7 +65,12 @@ def transit_encrypt_decrypt(token: str) -> None:
         timeout=10,
     )
     decrypted.raise_for_status()
-    print("decrypted payload:", decrypted.json())
+    plaintext_b64 = decrypted.json()["plaintext"]
+    if plaintext_b64 != b64("john@example.com"):
+        raise RuntimeError("round-trip verification failed")
+    plaintext = base64.b64decode(plaintext_b64).decode("utf-8")
+    print("decrypted value:", plaintext)
+    print("Transit round-trip verified")
 
 
 if __name__ == "__main__":

--- a/docs/getting-started/smoke-test.md
+++ b/docs/getting-started/smoke-test.md
@@ -15,6 +15,8 @@ Script path: `docs/getting-started/smoke-test.sh`
 5. `POST /v1/transit/keys`
 6. `POST /v1/transit/keys/:name/encrypt` and `/decrypt`
 
+For transit decrypt, pass `ciphertext` exactly as returned by encrypt (`<version>:<base64-ciphertext>`).
+
 ## Prerequisites
 
 - Running Secrets server
@@ -40,6 +42,9 @@ Optional variables:
 
 - `SECRET_PATH` (default: `/app/prod/smoke-test`)
 - `TRANSIT_KEY_NAME` (default: `smoke-test-key`)
+
+Expected output includes `Smoke test completed successfully`.
+If transit decrypt fails with `422`, see [Troubleshooting](troubleshooting.md#422-unprocessable-entity).
 
 ⚠️ Security Warning: base64 is encoding, not encryption. Always use HTTPS/TLS.
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -50,9 +50,20 @@ Use this quick route before diving into detailed sections:
 
 - Symptom: request rejected with `422`
 - Likely cause: malformed JSON, invalid query params, missing required fields
+
+Common 422 cases:
+
+| Endpoint | Common cause | Fix |
+| --- | --- | --- |
+| `POST /v1/secrets/*path` | `value` is missing or not base64 | Send `value` as base64-encoded bytes |
+| `POST /v1/transit/keys/:name/encrypt` | `plaintext` is missing or not base64 | Send `plaintext` as base64-encoded bytes |
+| `POST /v1/transit/keys/:name/decrypt` | `ciphertext` not in `<version>:<base64-ciphertext>` format | Pass `ciphertext` exactly as returned by encrypt |
+| `GET /v1/audit-logs` | invalid `offset`/`limit`/timestamp format | Use numeric `offset`/`limit` and RFC3339 timestamps |
+
 - Fix:
   - validate JSON body and required fields
   - for secrets/transit endpoints, send base64 values where required
+  - for transit decrypt, pass `ciphertext` exactly as returned by encrypt (`<version>:<base64-ciphertext>`)
   - validate `offset`, `limit`, and RFC3339 timestamps on audit endpoints
 
 ## Database connection failure

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -218,7 +218,17 @@ paths:
               properties:
                 ciphertext:
                   type: string
+                  description: Versioned ciphertext in format "<version>:<base64-ciphertext>"
               required: [ciphertext]
+            examples:
+              validCiphertext:
+                summary: Versioned ciphertext from encrypt response
+                value:
+                  ciphertext: "1:ZW5jcnlwdGVkLWJ5dGVzLi4u"
+              invalidCiphertext:
+                summary: Invalid ciphertext format
+                value:
+                  ciphertext: "not-base64!!!"
       responses:
         "200":
           description: Decrypted
@@ -229,6 +239,18 @@ paths:
                 properties:
                   plaintext:
                     type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Transit key not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          $ref: "#/components/responses/ValidationError"
   /v1/audit-logs:
     get:
       tags: [audit]

--- a/internal/transit/domain/encrypted_blob.go
+++ b/internal/transit/domain/encrypted_blob.go
@@ -19,6 +19,7 @@ type EncryptedBlob struct {
 func NewEncryptedBlob(content string) (EncryptedBlob, error) {
 	// Split by ":" - expect exactly 2 parts: version:ciphertext
 	parts := strings.Split(content, ":")
+
 	if len(parts) != 2 {
 		return EncryptedBlob{}, fmt.Errorf(
 			"%w: expected format 'version:ciphertext', got %d parts",

--- a/internal/transit/http/crypto_handler.go
+++ b/internal/transit/http/crypto_handler.go
@@ -12,7 +12,6 @@ import (
 	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
 	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
 	"github.com/allisson/secrets/internal/httputil"
-	transitDomain "github.com/allisson/secrets/internal/transit/domain"
 	"github.com/allisson/secrets/internal/transit/http/dto"
 	transitUseCase "github.com/allisson/secrets/internal/transit/usecase"
 	customValidation "github.com/allisson/secrets/internal/validation"
@@ -119,15 +118,8 @@ func (h *CryptoHandler) DecryptHandler(c *gin.Context) {
 		return
 	}
 
-	// Parse ciphertext format "version:base64-ciphertext"
-	encryptedBlob, err := transitDomain.NewEncryptedBlob(req.Ciphertext)
-	if err != nil {
-		httputil.HandleValidationErrorGin(c, err, h.logger)
-		return
-	}
-
-	// Call use case with parsed ciphertext
-	decryptedBlob, err := h.transitKeyUseCase.Decrypt(c.Request.Context(), name, encryptedBlob.Ciphertext)
+	// Call use case with ciphertext string (format: "version:base64-ciphertext")
+	decryptedBlob, err := h.transitKeyUseCase.Decrypt(c.Request.Context(), name, req.Ciphertext)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return

--- a/internal/transit/usecase/interface.go
+++ b/internal/transit/usecase/interface.go
@@ -30,8 +30,9 @@ type TransitKeyUseCase interface {
 	Delete(ctx context.Context, transitKeyID uuid.UUID) error
 	Encrypt(ctx context.Context, name string, plaintext []byte) (*transitDomain.EncryptedBlob, error)
 	// Decrypt decrypts ciphertext using the version specified in the encrypted blob.
+	// The ciphertext parameter should be in format "version:base64-ciphertext".
 	//
 	// Security Note: The returned EncryptedBlob contains plaintext data in the Plaintext field.
 	// Callers MUST zero this data after use by calling cryptoDomain.Zero(blob.Plaintext).
-	Decrypt(ctx context.Context, name string, ciphertext []byte) (*transitDomain.EncryptedBlob, error)
+	Decrypt(ctx context.Context, name string, ciphertext string) (*transitDomain.EncryptedBlob, error)
 }

--- a/internal/transit/usecase/mocks/mocks.go
+++ b/internal/transit/usecase/mocks/mocks.go
@@ -550,7 +550,7 @@ func (_c *MockTransitKeyUseCase_Create_Call) RunAndReturn(run func(ctx context.C
 }
 
 // Decrypt provides a mock function for the type MockTransitKeyUseCase
-func (_mock *MockTransitKeyUseCase) Decrypt(ctx context.Context, name string, ciphertext []byte) (*domain0.EncryptedBlob, error) {
+func (_mock *MockTransitKeyUseCase) Decrypt(ctx context.Context, name string, ciphertext string) (*domain0.EncryptedBlob, error) {
 	ret := _mock.Called(ctx, name, ciphertext)
 
 	if len(ret) == 0 {
@@ -559,17 +559,17 @@ func (_mock *MockTransitKeyUseCase) Decrypt(ctx context.Context, name string, ci
 
 	var r0 *domain0.EncryptedBlob
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) (*domain0.EncryptedBlob, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*domain0.EncryptedBlob, error)); ok {
 		return returnFunc(ctx, name, ciphertext)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) *domain0.EncryptedBlob); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *domain0.EncryptedBlob); ok {
 		r0 = returnFunc(ctx, name, ciphertext)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain0.EncryptedBlob)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []byte) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
 		r1 = returnFunc(ctx, name, ciphertext)
 	} else {
 		r1 = ret.Error(1)
@@ -585,12 +585,12 @@ type MockTransitKeyUseCase_Decrypt_Call struct {
 // Decrypt is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-//   - ciphertext []byte
+//   - ciphertext string
 func (_e *MockTransitKeyUseCase_Expecter) Decrypt(ctx interface{}, name interface{}, ciphertext interface{}) *MockTransitKeyUseCase_Decrypt_Call {
 	return &MockTransitKeyUseCase_Decrypt_Call{Call: _e.mock.On("Decrypt", ctx, name, ciphertext)}
 }
 
-func (_c *MockTransitKeyUseCase_Decrypt_Call) Run(run func(ctx context.Context, name string, ciphertext []byte)) *MockTransitKeyUseCase_Decrypt_Call {
+func (_c *MockTransitKeyUseCase_Decrypt_Call) Run(run func(ctx context.Context, name string, ciphertext string)) *MockTransitKeyUseCase_Decrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -600,9 +600,9 @@ func (_c *MockTransitKeyUseCase_Decrypt_Call) Run(run func(ctx context.Context, 
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []byte
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].([]byte)
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
@@ -618,7 +618,7 @@ func (_c *MockTransitKeyUseCase_Decrypt_Call) Return(encryptedBlob *domain0.Encr
 	return _c
 }
 
-func (_c *MockTransitKeyUseCase_Decrypt_Call) RunAndReturn(run func(ctx context.Context, name string, ciphertext []byte) (*domain0.EncryptedBlob, error)) *MockTransitKeyUseCase_Decrypt_Call {
+func (_c *MockTransitKeyUseCase_Decrypt_Call) RunAndReturn(run func(ctx context.Context, name string, ciphertext string) (*domain0.EncryptedBlob, error)) *MockTransitKeyUseCase_Decrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/transit/usecase/transit_key_usecase.go
+++ b/internal/transit/usecase/transit_key_usecase.go
@@ -197,10 +197,10 @@ func (t *transitKeyUseCase) Encrypt(
 func (t *transitKeyUseCase) Decrypt(
 	ctx context.Context,
 	name string,
-	ciphertext []byte,
+	ciphertext string,
 ) (*transitDomain.EncryptedBlob, error) {
-	// Parse encrypted blob from ciphertext
-	blob, err := transitDomain.NewEncryptedBlob(string(ciphertext))
+	// Parse encrypted blob from ciphertext string format "version:base64..."
+	blob, err := transitDomain.NewEncryptedBlob(ciphertext)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transit/usecase/transit_key_usecase_test.go
+++ b/internal/transit/usecase/transit_key_usecase_test.go
@@ -922,7 +922,7 @@ func TestTransitKeyUseCase_Decrypt(t *testing.T) {
 		uc := NewTransitKeyUseCase(
 			mockTxManager, mockTransitRepo, mockDekRepo, mockKeyManager, mockAeadManager, kekChain,
 		)
-		resultBlob, err := uc.Decrypt(ctx, "test-key", []byte(ciphertextStr))
+		resultBlob, err := uc.Decrypt(ctx, "test-key", ciphertextStr)
 
 		// Assert
 		assert.NoError(t, err)
@@ -992,7 +992,7 @@ func TestTransitKeyUseCase_Decrypt(t *testing.T) {
 		uc := NewTransitKeyUseCase(
 			mockTxManager, mockTransitRepo, mockDekRepo, mockKeyManager, mockAeadManager, kekChain,
 		)
-		resultBlob, err := uc.Decrypt(ctx, "test-key", []byte(ciphertextStr))
+		resultBlob, err := uc.Decrypt(ctx, "test-key", ciphertextStr)
 
 		// Assert
 		assert.NoError(t, err)
@@ -1014,7 +1014,7 @@ func TestTransitKeyUseCase_Decrypt(t *testing.T) {
 		kekChain := createTestKekChain(kek.ID, kek)
 		defer kekChain.Close()
 
-		invalidCiphertext := []byte("invalid-blob-format")
+		invalidCiphertext := "invalid-blob-format"
 
 		// Execute
 		uc := NewTransitKeyUseCase(
@@ -1058,7 +1058,7 @@ func TestTransitKeyUseCase_Decrypt(t *testing.T) {
 		uc := NewTransitKeyUseCase(
 			mockTxManager, mockTransitRepo, mockDekRepo, mockKeyManager, mockAeadManager, kekChain,
 		)
-		resultBlob, err := uc.Decrypt(ctx, "test-key", []byte(ciphertextStr))
+		resultBlob, err := uc.Decrypt(ctx, "test-key", ciphertextStr)
 
 		// Assert
 		assert.Error(t, err)
@@ -1116,7 +1116,7 @@ func TestTransitKeyUseCase_Decrypt(t *testing.T) {
 		uc := NewTransitKeyUseCase(
 			mockTxManager, mockTransitRepo, mockDekRepo, mockKeyManager, mockAeadManager, kekChain,
 		)
-		resultBlob, err := uc.Decrypt(ctx, "test-key", []byte(ciphertextStr))
+		resultBlob, err := uc.Decrypt(ctx, "test-key", ciphertextStr)
 
 		// Assert
 		assert.Error(t, err)
@@ -1183,7 +1183,7 @@ func TestTransitKeyUseCase_Decrypt(t *testing.T) {
 		uc := NewTransitKeyUseCase(
 			mockTxManager, mockTransitRepo, mockDekRepo, mockKeyManager, mockAeadManager, kekChain,
 		)
-		resultBlob, err := uc.Decrypt(ctx, "test-key", []byte(ciphertextStr))
+		resultBlob, err := uc.Decrypt(ctx, "test-key", ciphertextStr)
 
 		// Assert
 		assert.Error(t, err)


### PR DESCRIPTION
Move ciphertext format validation from HTTP handler to use case layer to ensure consistent error handling and proper 422 responses for malformed input. Update decrypt interface to accept string parameter for explicit format validation.

Changes:
- Move EncryptedBlob parsing from crypto_handler.go to transit_key_usecase.go
- Change Decrypt interface signature from []byte to string parameter
- Update all decrypt test cases to use string format
- Document decrypt input contract requirements in API docs and examples
- Add 422 troubleshooting matrix for transit endpoints
- Add round-trip verification examples in curl/Go/JavaScript/Python
- Clarify OpenAPI decrypt request format with valid/invalid examples
- Add representative 422 error payloads for ciphertext validation failures

This ensures callers receive 422 Unprocessable Entity for malformed ciphertext format (missing version prefix, invalid base64, non-numeric version) instead of internal validation errors, and explicitly documents the requirement to pass ciphertext exactly as returned by encrypt ("version:base64-ciphertext").