### PR TITLE
docs: add transit create vs rotate guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             docs/**/*.md
             .github/pull_request_template.md
 
+      - name: Example shape checks
+        run: python3 docs/tools/check_example_shapes.py
+
       - name: Markdown link check (offline)
         uses: lycheeverse/lychee-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build run test lint clean migrate-up migrate-down docker-build docker-run mocks docs-lint
+.PHONY: help build run test lint clean migrate-up migrate-down docker-build docker-run mocks docs-lint docs-check-examples
 
 APP_NAME := app
 BINARY_DIR := bin
@@ -70,9 +70,14 @@ mocks: ## Regenerate mock implementations
 	@mockery
 	@echo "Mocks regenerated"
 
+docs-check-examples: ## Validate JSON shapes used by docs examples
+	@echo "Running docs example shape checks..."
+	@python3 docs/tools/check_example_shapes.py
+
 docs-lint: ## Run markdown lint and offline link checks
 	@echo "Running markdownlint-cli2..."
 	@docker run --rm -v "$(PWD):/workdir" -w /workdir davidanson/markdownlint-cli2:v0.18.1 README.md "docs/**/*.md" ".github/pull_request_template.md"
+	@$(MAKE) docs-check-examples
 	@echo "Running lychee offline link checks..."
 	@docker run --rm -v "$(PWD):/input" lycheeverse/lychee:latest --offline --include-fragments --no-progress "/input/README.md" "/input/docs/**/*.md" "/input/.github/pull_request_template.md"
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Then follow the Docker setup guide in [docs/getting-started/docker.md](docs/gett
 - ⚙️ **Environment variables**: [docs/configuration/environment-variables.md](docs/configuration/environment-variables.md)
 - 🏗️ **Architecture concepts**: [docs/concepts/architecture.md](docs/concepts/architecture.md)
 - 🔒 **Security model**: [docs/concepts/security-model.md](docs/concepts/security-model.md)
+- 📘 **Glossary**: [docs/concepts/glossary.md](docs/concepts/glossary.md)
 - 🔑 **Key management operations**: [docs/operations/key-management.md](docs/operations/key-management.md)
+- 🚑 **Failure playbooks**: [docs/operations/failure-playbooks.md](docs/operations/failure-playbooks.md)
 - 🏭 **Production deployment**: [docs/operations/production.md](docs/operations/production.md)
 - 🛠️ **Development and testing**: [docs/development/testing.md](docs/development/testing.md)
 - 🤝 **Docs contributing**: [docs/contributing.md](docs/contributing.md)
@@ -51,6 +53,7 @@ Then follow the Docker setup guide in [docs/getting-started/docker.md](docs/gett
 - 📦 **Secrets API**: [docs/api/secrets.md](docs/api/secrets.md)
 - 🚄 **Transit API**: [docs/api/transit.md](docs/api/transit.md)
 - 📜 **Audit logs API**: [docs/api/audit-logs.md](docs/api/audit-logs.md)
+- 🧩 **API versioning policy**: [docs/api/versioning-policy.md](docs/api/versioning-policy.md)
 
 - **Examples**
 - 🧪 **Curl examples**: [docs/examples/curl.md](docs/examples/curl.md)
@@ -63,7 +66,7 @@ All detailed guides include practical use cases and copy/paste-ready examples.
 ## ✨ What You Get
 
 - 🔐 Envelope encryption (`Master Key -> KEK -> DEK -> Secret Data`)
-- 🚄 Transit encryption (`/v1/transit/keys/*`) for encrypt/decrypt as a service (decrypt input uses `<version>:<base64-ciphertext>`; see [Transit API docs](docs/api/transit.md))
+- 🚄 Transit encryption (`/v1/transit/keys/*`) for encrypt/decrypt as a service (decrypt input uses `<version>:<base64-ciphertext>`; see [Transit API docs](docs/api/transit.md), [create vs rotate](docs/api/transit.md#create-vs-rotate), and [error matrix](docs/api/transit.md#endpoint-error-matrix))
 - 👤 Token-based authentication and policy-based authorization
 - 📦 Versioned secrets by path (`/v1/secrets/*path`)
 - 📜 Audit logs with request correlation (`request_id`) and filtering
@@ -75,7 +78,7 @@ All detailed guides include practical use cases and copy/paste-ready examples.
 - Token issuance: `POST /v1/token`
 - Clients: `GET/POST /v1/clients`, `GET/PUT/DELETE /v1/clients/:id`
 - Secrets: `POST/GET/DELETE /v1/secrets/*path`
-- Transit: `POST /v1/transit/keys`, `POST /v1/transit/keys/:name/rotate`, `POST /v1/transit/keys/:name/encrypt`, `POST /v1/transit/keys/:name/decrypt`, `DELETE /v1/transit/keys/:id`
+- Transit: `POST /v1/transit/keys`, `POST /v1/transit/keys/:name/rotate`, `POST /v1/transit/keys/:name/encrypt`, `POST /v1/transit/keys/:name/decrypt`, `DELETE /v1/transit/keys/:id` ([create vs rotate](docs/api/transit.md#create-vs-rotate), [error matrix](docs/api/transit.md#endpoint-error-matrix))
 - Audit logs: `GET /v1/audit-logs`
 
 ## 📄 License

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,19 @@
 - Added transit decrypt input contract examples (valid/invalid) and representative `422` payloads
 - Added OpenAPI decrypt request examples and explicit `401`/`403`/`404` responses
 - Added 422 troubleshooting matrix and transit round-trip verification/decode notes in examples
+- Clarified transit key create behavior: duplicate key names now documented as `409 Conflict` and rotate is required for new versions
+- Added transit create-vs-rotate guidance, idempotency notes, endpoint error matrix, and representative `409` conflict payload examples
+- Added transit automation runbook note for handling create `409` by rotating keys
+- Added API status code quick-reference tables to clients, secrets, transit, and audit docs
+- Added glossary page and cross-links from API/reference documentation
+- Added example-page common mistakes sections (curl, python, javascript, go)
+- Added docs contribution policy for breaking vs non-breaking documentation updates
+- Added docs freshness SLA table in docs index
+- Added failure playbooks for 401/403/409 incident triage
+- Added API compatibility/versioning policy page for breaking/non-breaking expectations
+- Added ADRs for envelope encryption model and transit versioned ciphertext contract
+- Added executable example shape checks (`make docs-check-examples`) and CI integration
+- Added environment bootstrap sections to all examples pages
 
 ## See also
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,11 +22,23 @@ Welcome to the full documentation for Secrets. Pick a path and dive in 🚀
 - ⚙️ [configuration/environment-variables.md](configuration/environment-variables.md)
 - 🏗️ [concepts/architecture.md](concepts/architecture.md)
 - 🔒 [concepts/security-model.md](concepts/security-model.md)
+- 📘 [concepts/glossary.md](concepts/glossary.md)
 - 🔑 [operations/key-management.md](operations/key-management.md)
 - 🏭 [operations/production.md](operations/production.md)
+- 🚑 [operations/failure-playbooks.md](operations/failure-playbooks.md)
 - 🛠️ [development/testing.md](development/testing.md)
 - 🤝 [contributing.md](contributing.md)
 - 🗒️ [CHANGELOG.md](CHANGELOG.md)
+
+## 🧭 Docs Freshness SLA
+
+| Area | Primary owner | Review cadence |
+| --- | --- | --- |
+| Getting started | Maintainers | Monthly |
+| API reference | Maintainers + feature PR author | Every behavior change + monthly |
+| Operations runbooks | Maintainers + on-call | Monthly and after incidents |
+| Examples | Maintainers | Monthly and when API contract changes |
+| Concepts/architecture | Maintainers | Quarterly |
 
 ## 🌐 API Reference
 
@@ -37,7 +49,13 @@ Welcome to the full documentation for Secrets. Pick a path and dive in 🚀
 - 🚄 [api/transit.md](api/transit.md)
 - 📜 [api/audit-logs.md](api/audit-logs.md)
 - 🧱 [api/response-shapes.md](api/response-shapes.md)
+- 🧩 [api/versioning-policy.md](api/versioning-policy.md)
 - 📄 [openapi.yaml](openapi.yaml)
+
+## 🧠 ADRs
+
+- 🧾 [adr/0001-envelope-encryption-model.md](adr/0001-envelope-encryption-model.md)
+- 🧾 [adr/0002-transit-versioned-ciphertext-contract.md](adr/0002-transit-versioned-ciphertext-contract.md)
 
 ## 🖥️ Supported Platforms
 

--- a/docs/adr/0001-envelope-encryption-model.md
+++ b/docs/adr/0001-envelope-encryption-model.md
@@ -1,0 +1,30 @@
+# ADR 0001: Envelope Encryption Model
+
+> Status: accepted
+> Date: 2026-02-14
+
+## Context
+
+The system must protect stored secret payloads while supporting key rotation without re-encrypting all historical data at once.
+
+## Decision
+
+Use envelope encryption hierarchy:
+
+`Master Key -> KEK -> DEK -> Secret Data`
+
+- master keys protect KEKs
+- KEKs protect DEKs
+- DEKs encrypt secret payloads
+
+## Consequences
+
+- key rotation can happen incrementally
+- historical versions remain decryptable with prior key material
+- clear separation between root trust, key-wrapping, and data encryption roles
+
+## See also
+
+- [Architecture](../concepts/architecture.md)
+- [Security model](../concepts/security-model.md)
+- [Key management operations](../operations/key-management.md)

--- a/docs/adr/0002-transit-versioned-ciphertext-contract.md
+++ b/docs/adr/0002-transit-versioned-ciphertext-contract.md
@@ -1,0 +1,30 @@
+# ADR 0002: Transit Versioned Ciphertext Contract
+
+> Status: accepted
+> Date: 2026-02-14
+
+## Context
+
+Transit decryption must reliably select the correct transit key version and reject malformed ciphertext early.
+
+## Decision
+
+Adopt transit ciphertext contract:
+
+`<version>:<base64-ciphertext>`
+
+- decrypt requires version prefix and base64 payload
+- malformed input returns validation errors (`422`)
+- callers must pass ciphertext exactly as returned by encrypt
+
+## Consequences
+
+- deterministic key version selection for decrypt
+- stronger input validation with predictable errors
+- simpler client behavior by treating encrypt output as opaque
+
+## See also
+
+- [Transit API](../api/transit.md)
+- [Response shapes](../api/response-shapes.md)
+- [Troubleshooting](../getting-started/troubleshooting.md)

--- a/docs/api/audit-logs.md
+++ b/docs/api/audit-logs.md
@@ -18,6 +18,12 @@ Authorization: `read` capability for `/v1/audit-logs`.
 
 - `GET /v1/audit-logs`
 
+## Status Code Quick Reference
+
+| Endpoint | Success | Common error statuses |
+| --- | --- | --- |
+| `GET /v1/audit-logs` | `200` | `401`, `403`, `422` |
+
 Query parameters:
 
 - `offset` (default `0`)
@@ -153,3 +159,5 @@ curl -s "http://localhost:8080/v1/audit-logs?limit=100" \
 - [Clients API](clients.md)
 - [Policies cookbook](policies.md)
 - [Response shapes](response-shapes.md)
+- [API compatibility policy](versioning-policy.md)
+- [Glossary](../concepts/glossary.md)

--- a/docs/api/clients.md
+++ b/docs/api/clients.md
@@ -29,6 +29,16 @@ Capability mapping:
 - `PUT /v1/clients/:id` -> `write`
 - `DELETE /v1/clients/:id` -> `delete`
 
+## Status Code Quick Reference
+
+| Endpoint | Success | Common error statuses |
+| --- | --- | --- |
+| `POST /v1/clients` | `201` | `401`, `403`, `409`, `422` |
+| `GET /v1/clients` | `200` | `401`, `403`, `422` |
+| `GET /v1/clients/:id` | `200` | `401`, `403`, `404`, `422` |
+| `PUT /v1/clients/:id` | `200` | `401`, `403`, `404`, `409`, `422` |
+| `DELETE /v1/clients/:id` | `204` | `401`, `403`, `404`, `422` |
+
 ## Create Client
 
 ```bash
@@ -138,3 +148,5 @@ Expected result: create returns `201 Created` with one-time `secret`; list retur
 - [Policies cookbook](policies.md)
 - [Audit logs API](audit-logs.md)
 - [Response shapes](response-shapes.md)
+- [API compatibility policy](versioning-policy.md)
+- [Glossary](../concepts/glossary.md)

--- a/docs/api/response-shapes.md
+++ b/docs/api/response-shapes.md
@@ -109,9 +109,20 @@ Common error categories:
 - `not_found`
 - `conflict`
 
+Representative conflict payload (for example duplicate transit key create):
+
+```json
+{
+  "error": "conflict",
+  "message": "transit key already exists"
+}
+```
+
 ## See also
 
 - [Authentication API](authentication.md)
 - [Clients API](clients.md)
 - [Secrets API](secrets.md)
 - [Transit API](transit.md)
+- [API compatibility policy](versioning-policy.md)
+- [Glossary](../concepts/glossary.md)

--- a/docs/api/secrets.md
+++ b/docs/api/secrets.md
@@ -19,6 +19,14 @@ All endpoints require Bearer authentication.
 - `GET /v1/secrets/*path` (read latest)
 - `DELETE /v1/secrets/*path` (soft delete latest)
 
+## Status Code Quick Reference
+
+| Endpoint | Success | Common error statuses |
+| --- | --- | --- |
+| `POST /v1/secrets/*path` | `201` | `401`, `403`, `422` |
+| `GET /v1/secrets/*path` | `200` | `401`, `403`, `404` |
+| `DELETE /v1/secrets/*path` | `204` | `401`, `403`, `404` |
+
 ## Create or Update Secret
 
 ```bash
@@ -150,4 +158,6 @@ Expected result: write returns `201 Created`; read returns `200 OK` with base64 
 - [Authentication API](authentication.md)
 - [Policies cookbook](policies.md)
 - [Response shapes](response-shapes.md)
+- [API compatibility policy](versioning-policy.md)
 - [Curl examples](../examples/curl.md)
+- [Glossary](../concepts/glossary.md)

--- a/docs/api/versioning-policy.md
+++ b/docs/api/versioning-policy.md
@@ -1,0 +1,50 @@
+# 🧩 API Compatibility and Versioning Policy
+
+> Last updated: 2026-02-14
+> Applies to: API v1
+
+This page defines compatibility expectations for HTTP API changes.
+
+## Compatibility Contract
+
+- Current public baseline is API v1 (`/v1/*`)
+- Existing endpoint paths and JSON field names are treated as stable unless explicitly deprecated
+- OpenAPI source of truth: `docs/openapi.yaml`
+
+## Breaking Changes
+
+Treat these as breaking:
+
+- changing endpoint paths or required path parameters
+- removing response fields or changing field meaning/type
+- changing required request fields or accepted formats
+- changing status code semantics for successful behavior
+
+Required process for breaking changes:
+
+1. Update `docs/openapi.yaml`
+2. Update affected API docs and examples
+3. Add migration notes in `docs/getting-started/troubleshooting.md` or relevant runbook
+4. Add explicit entry in `docs/CHANGELOG.md`
+
+## Non-Breaking Changes
+
+Usually non-breaking:
+
+- adding optional request/response fields
+- adding new endpoints under `/v1/*`
+- clarifying documentation text and examples
+- adding additional error examples without changing behavior
+
+## Deprecation Guidance
+
+- Mark deprecated behavior clearly in endpoint docs
+- Provide replacement behavior and example migration path
+- Keep deprecated behavior available long enough for operational rollout
+
+## See also
+
+- [Authentication API](authentication.md)
+- [Response shapes](response-shapes.md)
+- [Contributing guide](../contributing.md)
+- [Documentation changelog](../CHANGELOG.md)

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -23,6 +23,20 @@ Master Key -> KEK -> DEK -> Transit Key -> Application Data
 
 Transit mode is encryption-as-a-service: Secrets returns ciphertext/plaintext to the caller and does not persist application payloads.
 
+## 🤔 Secrets API vs Transit API
+
+Use this quick rule:
+
+- Use Secrets API when Secrets should store and version ciphertext by path
+- Use Transit API when your application stores payloads and only needs encrypt/decrypt operations
+
+| Need | Choose | Why |
+| --- | --- | --- |
+| Centralized secret storage at `/v1/secrets/*path` | Secrets API | Server persists encrypted data and versions it |
+| Encrypt/decrypt service without storing payloads | Transit API | Server returns crypto result only; payload storage remains in your app |
+| Secret version history by path | Secrets API | Versioning is built into secret writes |
+| Key version rotation for stateless crypto operations | Transit API | Transit keys rotate independently while old versions can still decrypt |
+
 ## 🧩 Data and flow diagram
 
 ```mermaid
@@ -55,3 +69,5 @@ flowchart TD
 - [Key management operations](../operations/key-management.md)
 - [Environment variables](../configuration/environment-variables.md)
 - [Secrets API](../api/secrets.md)
+- [ADR 0001: Envelope Encryption Model](../adr/0001-envelope-encryption-model.md)
+- [ADR 0002: Transit Versioned Ciphertext Contract](../adr/0002-transit-versioned-ciphertext-contract.md)

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -1,0 +1,23 @@
+# 📘 Glossary
+
+> Last updated: 2026-02-14
+
+Quick definitions for terms used across API and operations docs.
+
+## Terms
+
+- `Master Key`: Root key material used to protect KEKs; loaded from environment/KMS
+- `KEK` (Key Encryption Key): Encrypts/decrypts DEKs; rotated over time
+- `DEK` (Data Encryption Key): Encrypts payload data (secret values or transit key material)
+- `Transit Key`: Named, versioned key used by transit encrypt/decrypt endpoints
+- `Versioned ciphertext`: Transit ciphertext format `<version>:<base64-ciphertext>`
+- `Capability`: Authorization permission (`read`, `write`, `delete`, `encrypt`, `decrypt`, `rotate`)
+- `Soft delete`: Record marked deleted without immediate physical removal
+- `Request ID`: Per-request UUID used for traceability and audit correlation
+
+## See also
+
+- [Architecture](architecture.md)
+- [Security model](security-model.md)
+- [Transit API](../api/transit.md)
+- [Secrets API](../api/secrets.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,6 +25,13 @@ Use this guide when adding or editing project documentation.
 - Include `Last updated` metadata in new docs
 - For API docs, include `Applies to: API v1`
 
+## Breaking vs Non-Breaking Docs Changes
+
+- Treat endpoint path changes, request/response contract changes, and status code behavior changes as breaking docs updates
+- Breaking docs updates must include: updated API page, updated examples, and `docs/CHANGELOG.md` entry
+- Treat wording clarifications, formatting, and cross-links as non-breaking docs updates
+- Non-breaking docs updates should still run `make docs-lint` and keep links accurate
+
 ## Security Messaging
 
 - Use this exact warning where base64 appears:
@@ -44,9 +51,12 @@ Run the same style/link checks locally before opening a PR:
 
 ```bash
 make docs-lint
+make docs-check-examples
 ```
 
 This target runs markdown linting and offline markdown link validation.
+
+`make docs-check-examples` validates representative JSON response shapes used in docs.
 
 ## PR Checklist
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -12,6 +12,7 @@ make lint
 make test
 make test-with-db
 make mocks
+make docs-check-examples
 ```
 
 ## Run specific tests

--- a/docs/examples/go.md
+++ b/docs/examples/go.md
@@ -4,6 +4,20 @@
 
 ⚠️ Security Warning: base64 is encoding, not encryption. Always use HTTPS/TLS.
 
+## Bootstrap
+
+Prerequisites:
+
+- Go 1.25+
+
+Recommended environment variables:
+
+```bash
+export BASE_URL="http://localhost:8080"
+export CLIENT_ID="<client-id>"
+export CLIENT_SECRET="<client-secret>"
+```
+
 ```go
 package main
 
@@ -14,12 +28,16 @@ import (
     "fmt"
     "io"
     "net/http"
+    "os"
 )
 
-const baseURL = "http://localhost:8080"
+var baseURL = envOrDefault("BASE_URL", "http://localhost:8080")
 
 func main() {
-    token, err := issueToken("<client-id>", "<client-secret>")
+    token, err := issueToken(
+        envOrDefault("CLIENT_ID", "<client-id>"),
+        envOrDefault("CLIENT_SECRET", "<client-secret>"),
+    )
     if err != nil {
         panic(err)
     }
@@ -49,6 +67,14 @@ func main() {
     fmt.Println("decrypted value:", string(decoded))
 
     fmt.Println("Transit round-trip verified")
+}
+
+func envOrDefault(key, defaultValue string) string {
+    value := os.Getenv(key)
+    if value == "" {
+        return defaultValue
+    }
+    return value
 }
 
 func issueToken(clientID, clientSecret string) (string, error) {
@@ -163,6 +189,13 @@ func createTransitKey(token, keyName string) error {
     return nil
 }
 ```
+
+## Common Mistakes
+
+- Posting raw strings instead of base64-encoded fields for secrets/transit payloads
+- Generating decrypt `ciphertext` from local assumptions instead of encrypt response
+- Missing bearer token header on one request in a multi-step flow
+- Ignoring `409 Conflict` on transit create and not switching to rotate logic
 
 ## See also
 

--- a/docs/examples/javascript.md
+++ b/docs/examples/javascript.md
@@ -4,10 +4,25 @@
 
 ⚠️ Security Warning: base64 is encoding, not encryption. Always use HTTPS/TLS.
 
+## Bootstrap
+
+Prerequisites:
+
+- Node.js 20+
+- runtime with global `fetch` support
+
+Recommended environment variables:
+
+```bash
+export BASE_URL="http://localhost:8080"
+export CLIENT_ID="<client-id>"
+export CLIENT_SECRET="<client-secret>"
+```
+
 ```javascript
-const BASE_URL = "http://localhost:8080";
-const CLIENT_ID = "<client-id>";
-const CLIENT_SECRET = "<client-secret>";
+const BASE_URL = process.env.BASE_URL || "http://localhost:8080";
+const CLIENT_ID = process.env.CLIENT_ID || "<client-id>";
+const CLIENT_SECRET = process.env.CLIENT_SECRET || "<client-secret>";
 
 const toBase64 = (value) => Buffer.from(value, "utf8").toString("base64");
 
@@ -85,6 +100,13 @@ main().catch((error) => {
   process.exit(1);
 });
 ```
+
+## Common Mistakes
+
+- Sending UTF-8 plaintext directly instead of base64 in transit/secrets payloads
+- Reformatting `ciphertext` for decrypt instead of passing encrypt response as-is
+- Missing `Authorization: Bearer <token>` header on protected endpoints
+- Reusing transit create for existing keys without fallback to rotate on `409`
 
 ## See also
 

--- a/docs/examples/python.md
+++ b/docs/examples/python.md
@@ -4,13 +4,29 @@
 
 ⚠️ Security Warning: base64 is encoding, not encryption. Always use HTTPS/TLS.
 
+## Bootstrap
+
+Prerequisites:
+
+- Python 3.10+
+- `requests` library (`pip install requests`)
+
+Recommended environment variables:
+
+```bash
+export BASE_URL="http://localhost:8080"
+export CLIENT_ID="<client-id>"
+export CLIENT_SECRET="<client-secret>"
+```
+
 ```python
 import base64
+import os
 import requests
 
-BASE_URL = "http://localhost:8080"
-CLIENT_ID = "<client-id>"
-CLIENT_SECRET = "<client-secret>"
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8080")
+CLIENT_ID = os.getenv("CLIENT_ID", "<client-id>")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET", "<client-secret>")
 
 
 def b64(value: str) -> str:
@@ -78,6 +94,13 @@ if __name__ == "__main__":
     create_secret(token)
     transit_encrypt_decrypt(token)
 ```
+
+## Common Mistakes
+
+- Passing raw plaintext instead of base64-encoded `value`/`plaintext`
+- Constructing decrypt `ciphertext` manually instead of using encrypt output
+- Forgetting `Bearer` prefix in `Authorization` header
+- Retrying transit create for an existing key name instead of handling `409` with rotate
 
 ## See also
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -19,6 +19,7 @@ Use this quick route before diving into detailed sections:
 
 - [401 Unauthorized](#401-unauthorized)
 - [403 Forbidden](#403-forbidden)
+- [409 Conflict](#409-conflict)
 - [422 Unprocessable Entity](#422-unprocessable-entity)
 - [Database connection failure](#database-connection-failure)
 - [Migration failure](#migration-failure)
@@ -45,6 +46,23 @@ Use this quick route before diving into detailed sections:
   - verify capability mapping for endpoint (`read`, `write`, `delete`, `encrypt`, `decrypt`, `rotate`)
   - verify path pattern (`*`, exact path, or prefix with `/*`)
   - update client policy and retry
+
+## 409 Conflict
+
+- Symptom: request returns `409 Conflict`
+- Likely cause: resource already exists with unique key constraints
+
+Common 409 case:
+
+| Endpoint | Common cause | Fix |
+| --- | --- | --- |
+| `POST /v1/transit/keys` | transit key `name` already has initial `version=1` | use `POST /v1/transit/keys/:name/rotate` for a new version, or pick a new key name |
+
+- Fix:
+  - use create only for first-time key initialization
+  - use rotate for subsequent key versions
+  - migration note: if legacy automation retries create for existing names, update it to call rotate
+    after receiving `409 Conflict`
 
 ## 422 Unprocessable Entity
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -162,6 +162,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TransitKeyResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Transit key already exists (same name with initial version)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: conflict
+                message: transit key already exists
+        "422":
+          $ref: "#/components/responses/ValidationError"
   /v1/transit/keys/{name}/encrypt:
     post:
       tags: [transit]

--- a/docs/operations/failure-playbooks.md
+++ b/docs/operations/failure-playbooks.md
@@ -1,0 +1,67 @@
+# 🚑 Failure Playbooks
+
+> Last updated: 2026-02-14
+
+Use this page for fast incident triage on common API failures.
+
+## 401 Spike (Unauthorized)
+
+Symptoms:
+
+- sudden increase in `401` across multiple endpoints
+
+Triage steps:
+
+1. Verify token issuance with `POST /v1/token`
+2. Confirm callers send `Authorization: Bearer <token>`
+3. Check token expiry and client active state
+4. Inspect audit logs for broad denied patterns
+
+## 403 Spike (Policy/Capability Mismatch)
+
+Symptoms:
+
+- valid tokens but access denied with `403`
+
+Triage steps:
+
+1. Identify failing endpoint path and required capability
+2. Confirm client policy path matching (`*`, exact, `/*` prefix)
+3. Validate capability mapping for endpoint (`read`, `write`, `delete`, `encrypt`, `decrypt`, `rotate`)
+4. Re-issue token after policy update
+
+## 409 on Transit Key Create
+
+Symptoms:
+
+- `POST /v1/transit/keys` returns `409 Conflict`
+
+Triage steps:
+
+1. Treat conflict as "key already initialized"
+2. Call `POST /v1/transit/keys/:name/rotate` to create a new active version
+3. Confirm encrypt/decrypt still work after rotation
+4. Update automation to avoid repeated create for existing names
+
+## Quick Commands
+
+```bash
+# Health
+curl -s http://localhost:8080/health
+
+# Token check
+curl -i -X POST http://localhost:8080/v1/token \
+  -H "Content-Type: application/json" \
+  -d '{"client_id":"<client-id>","client_secret":"<client-secret>"}'
+
+# Audit logs snapshot
+curl -s "http://localhost:8080/v1/audit-logs?limit=50&offset=0" \
+  -H "Authorization: Bearer <token>"
+```
+
+## See also
+
+- [Troubleshooting](../getting-started/troubleshooting.md)
+- [Policies cookbook](../api/policies.md)
+- [Transit API](../api/transit.md)
+- [Production operations](production.md)

--- a/docs/operations/key-management.md
+++ b/docs/operations/key-management.md
@@ -79,6 +79,21 @@ Operational step:
 4. Verify secret read/write and transit encrypt/decrypt
 5. Review audit logs for anomalies
 
+## Transit Create/Rotate Automation
+
+When automating transit key lifecycle:
+
+- call create once per key name (`POST /v1/transit/keys`)
+- if create returns `409 Conflict`, treat it as "key already initialized"
+- call rotate (`POST /v1/transit/keys/:name/rotate`) to create a new active version
+
+Example decision flow:
+
+```text
+create key -> 201 Created: continue
+create key -> 409 Conflict: rotate key
+```
+
 ## Related
 
 - 🏭 Production deployment: `docs/operations/production.md`

--- a/docs/tools/check_example_shapes.py
+++ b/docs/tools/check_example_shapes.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import json
+import re
+from pathlib import Path
+
+
+def extract_json_block(content: str, label: str) -> dict:
+    pattern = re.compile(re.escape(label) + r"\n\n```json\n(.*?)\n```", re.DOTALL)
+    match = pattern.search(content)
+    if not match:
+        raise ValueError(f"missing JSON block for label: {label}")
+    return json.loads(match.group(1))
+
+
+def require_keys(payload: dict, keys: list[str], label: str) -> None:
+    missing = [key for key in keys if key not in payload]
+    if missing:
+        raise ValueError(f"missing keys for {label}: {', '.join(missing)}")
+
+
+def main() -> None:
+    response_shapes = Path("docs/api/response-shapes.md").read_text(encoding="utf-8")
+    transit_api = Path("docs/api/transit.md").read_text(encoding="utf-8")
+
+    token = extract_json_block(response_shapes, "Token issuance:")
+    require_keys(token, ["token", "expires_at"], "Token issuance")
+
+    client_creation = extract_json_block(response_shapes, "Client creation:")
+    require_keys(client_creation, ["id", "secret"], "Client creation")
+
+    secret_write = extract_json_block(response_shapes, "Secret write:")
+    require_keys(secret_write, ["id", "path", "version", "created_at"], "Secret write")
+
+    secret_read = extract_json_block(response_shapes, "Secret read:")
+    require_keys(
+        secret_read, ["id", "path", "version", "value", "created_at"], "Secret read"
+    )
+
+    transit_encrypt = extract_json_block(response_shapes, "Transit encrypt:")
+    require_keys(transit_encrypt, ["ciphertext", "version"], "Transit encrypt")
+
+    transit_decrypt = extract_json_block(response_shapes, "Transit decrypt:")
+    require_keys(transit_decrypt, ["plaintext"], "Transit decrypt")
+
+    conflict = extract_json_block(transit_api, "`409 Conflict`")
+    require_keys(conflict, ["error", "message"], "Transit conflict")
+    if conflict["error"] != "conflict":
+        raise ValueError("Transit conflict payload must use error=conflict")
+
+    print("example shape checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/transit/domain/errors.go
+++ b/internal/transit/domain/errors.go
@@ -21,4 +21,7 @@ var (
 
 	// ErrTransitKeyNotFound indicates the transit key was not found.
 	ErrTransitKeyNotFound = errors.Wrap(errors.ErrNotFound, "transit key not found")
+
+	// ErrTransitKeyAlreadyExists indicates a transit key with the same name and version already exists.
+	ErrTransitKeyAlreadyExists = errors.Wrap(errors.ErrConflict, "transit key already exists")
 )


### PR DESCRIPTION
- Clarifies transit key create behavior (returns 409 when key name already exists at version=1) and documents that rotate is required for subsequent versions.
- Adds comprehensive endpoint error matrices, failure playbooks for 401/403/409 incidents, API versioning policy page, glossary, and ADRs for envelope encryption and transit ciphertext contract.
- Introduces executable example shape checks (make docs-check-examples) with CI integration to validate JSON payloads used in documentation.
- Updates all API reference pages with status code quick-reference tables and cross-links.
- Enhances example pages (curl/python/javascript/go) with environment bootstrap sections and common mistakes guidance.
- Transit create usecase now returns ErrTransitKeyAlreadyExists (409) when attempting to create duplicate key names, preventing silent failures in automation workflows.