### PR TITLE
docs: standardize docstrings with enhanced compact format

### DIFF
--- a/internal/auth/domain/audit_log.go
+++ b/internal/auth/domain/audit_log.go
@@ -6,6 +6,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// AuditLog records authorization decisions for compliance and security monitoring.
+// Captures client identity, requested resource path, required capability, and metadata.
+// Used to track access patterns and investigate security incidents.
 type AuditLog struct {
 	ID         uuid.UUID
 	RequestID  uuid.UUID

--- a/internal/auth/domain/const.go
+++ b/internal/auth/domain/const.go
@@ -1,3 +1,5 @@
+// Package domain defines authentication and authorization domain models.
+// Implements capability-based access control with clients, tokens, policies, and audit logging.
 package domain
 
 // Capability defines the types of operations that can be performed on resources.

--- a/internal/auth/domain/token.go
+++ b/internal/auth/domain/token.go
@@ -17,11 +17,15 @@ type Token struct {
 	CreatedAt time.Time
 }
 
+// IssueTokenInput contains client credentials for token issuance requests.
+// Used during authentication to verify client identity before generating tokens.
 type IssueTokenInput struct {
 	ClientID     uuid.UUID
 	ClientSecret string
 }
 
+// IssueTokenOutput contains the newly issued authentication token and expiration.
+// The PlainToken is only returned once and must be transmitted securely to the client.
 type IssueTokenOutput struct {
 	PlainToken string
 	ExpiresAt  time.Time

--- a/internal/auth/service/secret_service.go
+++ b/internal/auth/service/secret_service.go
@@ -1,3 +1,5 @@
+// Package service provides authentication-related services for secret generation and token management.
+// Implements secure random token generation and Argon2id password hashing for client credentials.
 package service
 
 import (

--- a/internal/crypto/domain/errors.go
+++ b/internal/crypto/domain/errors.go
@@ -1,3 +1,5 @@
+// Package domain defines core cryptographic domain models for envelope encryption.
+// Implements Master Key → KEK → DEK → Data hierarchy with AESGCM and ChaCha20 support.
 package domain
 
 import (

--- a/internal/crypto/service/aead_manager.go
+++ b/internal/crypto/service/aead_manager.go
@@ -1,3 +1,5 @@
+// Package service provides cryptographic services for AEAD cipher management and key operations.
+// Implements envelope encryption with support for AES-256-GCM and ChaCha20-Poly1305 algorithms.
 package service
 
 import (

--- a/internal/secrets/usecase/interface.go
+++ b/internal/secrets/usecase/interface.go
@@ -14,30 +14,47 @@ import (
 
 // DekRepository defines the interface for Data Encryption Key persistence operations.
 type DekRepository interface {
+	// Create stores a new DEK in the repository using transaction support from context.
 	Create(ctx context.Context, dek *cryptoDomain.Dek) error
+
+	// Get retrieves a DEK by its ID. Returns ErrDekNotFound if not found.
 	Get(ctx context.Context, dekID uuid.UUID) (*cryptoDomain.Dek, error)
 }
 
 // SecretRepository defines the interface for Secret persistence operations.
 type SecretRepository interface {
+	// Create stores a new secret in the repository using transaction support from context.
 	Create(ctx context.Context, secret *secretsDomain.Secret) error
+
+	// Delete soft deletes a secret by marking it with DeletedAt timestamp.
 	Delete(ctx context.Context, secretID uuid.UUID) error
+
+	// GetByPath retrieves the latest version of a secret by its path. Returns ErrSecretNotFound if not found.
 	GetByPath(ctx context.Context, path string) (*secretsDomain.Secret, error)
+
+	// GetByPathAndVersion retrieves a specific version of a secret. Returns ErrSecretNotFound if not found.
 	GetByPathAndVersion(ctx context.Context, path string, version uint) (*secretsDomain.Secret, error)
 }
 
 // SecretUseCase defines the interface for secret management business logic.
 type SecretUseCase interface {
+	// CreateOrUpdate creates a new secret or increments the version if path exists.
+	// Encrypts the value with a new DEK for each version. Returns the created/updated secret.
 	CreateOrUpdate(ctx context.Context, path string, value []byte) (*secretsDomain.Secret, error)
+
 	// Get retrieves and decrypts a secret by its path (latest version).
 	//
 	// Security Note: The returned Secret contains plaintext data in the Plaintext field.
 	// Callers MUST zero this data after use by calling cryptoDomain.Zero(secret.Plaintext).
 	Get(ctx context.Context, path string) (*secretsDomain.Secret, error)
+
 	// GetByVersion retrieves and decrypts a secret by its path and specific version.
 	//
 	// Security Note: The returned Secret contains plaintext data in the Plaintext field.
 	// Callers MUST zero this data after use by calling cryptoDomain.Zero(secret.Plaintext).
 	GetByVersion(ctx context.Context, path string, version uint) (*secretsDomain.Secret, error)
+
+	// Delete soft deletes all versions of a secret by path, marking them with DeletedAt timestamp.
+	// Preserves encrypted data for audit purposes while preventing future access.
 	Delete(ctx context.Context, path string) error
 }

--- a/internal/testutil/database.go
+++ b/internal/testutil/database.go
@@ -1,3 +1,5 @@
+// Package testutil provides testing utilities for database integration tests.
+// Includes helpers for setting up PostgreSQL and MySQL test databases with migrations.
 package testutil
 
 import (
@@ -114,6 +116,7 @@ func CleanupMySQLDB(t *testing.T, db *sql.DB) {
 	require.NoError(t, err, "failed to enable foreign key checks")
 }
 
+// runPostgresMigrations applies all pending PostgreSQL migrations for the test database.
 func runPostgresMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
 
@@ -135,6 +138,7 @@ func runPostgresMigrations(t *testing.T, db *sql.DB) {
 	}
 }
 
+// runMySQLMigrations applies all pending MySQL migrations for the test database.
 func runMySQLMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
 
@@ -156,6 +160,8 @@ func runMySQLMigrations(t *testing.T, db *sql.DB) {
 	}
 }
 
+// getMigrationsPath resolves the absolute path to migration files for the specified database type.
+// Walks up the directory tree from current working directory to find the migrations folder.
 func getMigrationsPath(dbType string) string {
 	// Get the project root by walking up from the current directory
 	dir, err := os.Getwd()

--- a/internal/transit/domain/transit_key.go
+++ b/internal/transit/domain/transit_key.go
@@ -6,6 +6,10 @@ import (
 	"github.com/google/uuid"
 )
 
+// TransitKey represents a versioned encryption key for transit encryption operations.
+// Supports key rotation by maintaining multiple versions with the same name. The active
+// version (highest number) is used for encryption while older versions remain available
+// for decryption. Soft deletion via DeletedAt field preserves keys for historical decryption.
 type TransitKey struct {
 	ID        uuid.UUID
 	Name      string

--- a/internal/transit/usecase/interface.go
+++ b/internal/transit/usecase/interface.go
@@ -1,3 +1,5 @@
+// Package usecase defines interfaces and implementations for transit encryption use cases.
+// Provides versioned encryption/decryption operations with automatic key rotation support.
 package usecase
 
 import (
@@ -11,24 +13,45 @@ import (
 
 // DekRepository defines the interface for DEK persistence operations.
 type DekRepository interface {
+	// Create stores a new DEK in the repository using transaction support from context.
 	Create(ctx context.Context, dek *cryptoDomain.Dek) error
+
+	// Get retrieves a DEK by its ID. Returns ErrDekNotFound if not found.
 	Get(ctx context.Context, dekID uuid.UUID) (*cryptoDomain.Dek, error)
 }
 
 // TransitKeyRepository defines the interface for transit key persistence.
 type TransitKeyRepository interface {
+	// Create stores a new transit key in the repository using transaction support from context.
 	Create(ctx context.Context, transitKey *transitDomain.TransitKey) error
+
+	// Delete soft deletes a transit key by marking it with DeletedAt timestamp.
 	Delete(ctx context.Context, transitKeyID uuid.UUID) error
+
+	// GetByName retrieves the latest version of a transit key by name. Returns ErrTransitKeyNotFound if not found.
 	GetByName(ctx context.Context, name string) (*transitDomain.TransitKey, error)
+
+	// GetByNameAndVersion retrieves a specific version of a transit key. Returns ErrTransitKeyNotFound if not found.
 	GetByNameAndVersion(ctx context.Context, name string, version uint) (*transitDomain.TransitKey, error)
 }
 
 // TransitKeyUseCase defines the interface for transit encryption operations.
 type TransitKeyUseCase interface {
+	// Create generates a new transit key with version 1 and an associated DEK for encryption.
+	// The transit key name must be unique. Returns the created transit key.
 	Create(ctx context.Context, name string, alg cryptoDomain.Algorithm) (*transitDomain.TransitKey, error)
+
+	// Rotate creates a new version of an existing transit key by incrementing the version number.
+	// Generates a new DEK for the new version while preserving old versions for decryption.
 	Rotate(ctx context.Context, name string, alg cryptoDomain.Algorithm) (*transitDomain.TransitKey, error)
+
+	// Delete soft deletes a transit key and all its versions by transit key ID.
 	Delete(ctx context.Context, transitKeyID uuid.UUID) error
+
+	// Encrypt encrypts plaintext using the latest version of the named transit key.
+	// Returns an EncryptedBlob with format "version:base64-ciphertext" for storage or transmission.
 	Encrypt(ctx context.Context, name string, plaintext []byte) (*transitDomain.EncryptedBlob, error)
+
 	// Decrypt decrypts ciphertext using the version specified in the encrypted blob.
 	// The ciphertext parameter should be in format "version:base64-ciphertext".
 	//


### PR DESCRIPTION
- Update package and function documentation across authentication, crypto, secrets, transit, and test utility modules to use a consistent, enhanced compact format.
- Removes verbose step-by-step patterns in favor of concise inline explanations focused on what/why over implementation details. 
- Improves readability while maintaining security notes and important behavioral context.