### PR TITLE
feat: add audit log retention cleanup with clean-audit-logs CLI command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,6 +473,9 @@ func main() {
 - `app create-kek [--algorithm aes-gcm|chacha20-poly1305]` - Create initial KEK
 - `app rotate-kek [--algorithm aes-gcm|chacha20-poly1305]` - Rotate existing KEK
 
+**Audit Log Operations:**
+- `app clean-audit-logs --days <days> [--dry-run] [--format text|json]` - Delete old audit logs or preview count
+
 ### Command Testing
 
 When adding new commands:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Secrets is inspired by **HashiCorp Vault** ❤️, but it is intentionally **muc
 The default way to run Secrets is the published Docker image:
 
 ```bash
-docker pull allisson/secrets:v0.1.0
+docker pull allisson/secrets:v0.2.0
 ```
 
 Use pinned tags for reproducible setups. `latest` is also available for fast iteration.
@@ -36,7 +36,7 @@ Then follow the Docker setup guide in [docs/getting-started/docker.md](docs/gett
 - 🧰 **Troubleshooting**: [docs/getting-started/troubleshooting.md](docs/getting-started/troubleshooting.md)
 - ✅ **Smoke test script**: [docs/getting-started/smoke-test.md](docs/getting-started/smoke-test.md)
 - 🧪 **CLI commands reference**: [docs/cli/commands.md](docs/cli/commands.md)
-- 🚀 **v0.1.0 release notes**: [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md)
+- 🚀 **v0.2.0 release notes**: [docs/releases/v0.2.0.md](docs/releases/v0.2.0.md)
 
 - **By Topic**
 - ⚙️ **Environment variables**: [docs/configuration/environment-variables.md](docs/configuration/environment-variables.md)

--- a/cmd/app/commands/clean_audit_logs.go
+++ b/cmd/app/commands/clean_audit_logs.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/allisson/secrets/internal/app"
+	"github.com/allisson/secrets/internal/config"
+)
+
+// RunCleanAuditLogs deletes audit logs older than the specified number of days.
+// Supports dry-run mode to preview deletion count and both text/JSON output formats.
+//
+// Requirements: Database must be migrated and accessible.
+func RunCleanAuditLogs(ctx context.Context, days int, dryRun bool, format string) error {
+	// Validate days parameter
+	if days < 0 {
+		return fmt.Errorf("days must be a positive number, got: %d", days)
+	}
+
+	// Load configuration
+	cfg := config.Load()
+
+	// Create DI container
+	container := app.NewContainer(cfg)
+
+	// Get logger from container
+	logger := container.Logger()
+	logger.Info("cleaning audit logs",
+		slog.Int("days", days),
+		slog.Bool("dry_run", dryRun),
+	)
+
+	// Ensure cleanup on exit
+	defer closeContainer(container, logger)
+
+	// Get audit log use case from container
+	auditLogUseCase, err := container.AuditLogUseCase()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit log use case: %w", err)
+	}
+
+	// Execute deletion or count operation
+	count, err := auditLogUseCase.DeleteOlderThan(ctx, days, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to delete audit logs: %w", err)
+	}
+
+	// Output result based on format
+	if format == "json" {
+		outputCleanJSON(count, days, dryRun)
+	} else {
+		outputCleanText(count, days, dryRun)
+	}
+
+	logger.Info("cleanup completed",
+		slog.Int64("count", count),
+		slog.Int("days", days),
+		slog.Bool("dry_run", dryRun),
+	)
+
+	return nil
+}
+
+// outputCleanText outputs the result in human-readable text format.
+func outputCleanText(count int64, days int, dryRun bool) {
+	if dryRun {
+		fmt.Printf("Dry-run mode: Would delete %d audit log(s) older than %d day(s)\n", count, days)
+	} else {
+		fmt.Printf("Successfully deleted %d audit log(s) older than %d day(s)\n", count, days)
+	}
+}
+
+// outputCleanJSON outputs the result in JSON format for machine consumption.
+func outputCleanJSON(count int64, days int, dryRun bool) {
+	result := map[string]interface{}{
+		"count":   count,
+		"days":    days,
+		"dry_run": dryRun,
+	}
+
+	jsonBytes, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonBytes))
+}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -159,6 +159,38 @@ func main() {
 					)
 				},
 			},
+			{
+				Name:  "clean-audit-logs",
+				Usage: "Delete audit logs older than specified days",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:     "days",
+						Aliases:  []string{"d"},
+						Required: true,
+						Usage:    "Delete audit logs older than this many days",
+					},
+					&cli.BoolFlag{
+						Name:    "dry-run",
+						Aliases: []string{"n"},
+						Value:   false,
+						Usage:   "Show how many logs would be deleted without deleting",
+					},
+					&cli.StringFlag{
+						Name:    "format",
+						Aliases: []string{"f"},
+						Value:   "text",
+						Usage:   "Output format: 'text' or 'json'",
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return commands.RunCleanAuditLogs(
+						ctx,
+						cmd.Int("days"),
+						cmd.Bool("dry-run"),
+						cmd.String("format"),
+					)
+				},
+			},
 		},
 	}
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 > Last updated: 2026-02-14
 
+## 2026-02-14 (docs v3 - v0.2.0 release prep)
+
+- Added `clean-audit-logs` command documentation with dry-run and JSON/text output examples
+- Added audit-log retention cleanup runbook to production operations guide
+- Clarified audit log retention is a CLI cleanup workflow, while API remains list/query (`GET /v1/audit-logs`)
+- Updated pinned Docker image tags and release references from `v0.1.0` to `v0.2.0`
+- Added release notes page: `docs/releases/v0.2.0.md` and kept `v0.1.0` as historical
+
 ## 2026-02-14 (docs v2 - v0.1.0 release prep)
 
 - Added first-client bootstrap flow to Docker and local development guides using `create-client`

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,12 +55,13 @@ Welcome to the full documentation for Secrets. Pick a path and dive in 🚀
 
 OpenAPI scope note:
 
-- `openapi.yaml` is a baseline subset for common API flows in `v0.1.0`
+- `openapi.yaml` is a baseline subset for common API flows in `v0.2.0`
 - Full endpoint behavior is documented in the endpoint pages under `docs/api/`
 
 ## 🚀 Releases
 
-- 📦 [releases/v0.1.0.md](releases/v0.1.0.md)
+- 📦 [releases/v0.2.0.md](releases/v0.2.0.md)
+- 📦 [releases/v0.1.0.md](releases/v0.1.0.md) (historical)
 
 ## 🧠 ADRs
 

--- a/docs/api/audit-logs.md
+++ b/docs/api/audit-logs.md
@@ -78,6 +78,18 @@ Example response (`200 OK`):
 - 🌐 Spot unusual source IP changes per client
 - 🧭 Correlate a request with app logs via `request_id`
 
+## Retention and Cleanup
+
+- Audit log cleanup is an operator workflow via CLI, not an HTTP delete endpoint
+- Use `clean-audit-logs` to delete old records by retention days
+- Start with `--dry-run` to preview affected rows before deletion
+
+Example:
+
+```bash
+./bin/app clean-audit-logs --days 90 --dry-run --format json
+```
+
 ## Common Errors
 
 - `401 Unauthorized`: missing/invalid bearer token

--- a/docs/api/versioning-policy.md
+++ b/docs/api/versioning-policy.md
@@ -11,7 +11,7 @@ This page defines compatibility expectations for HTTP API changes.
 - Existing endpoint paths and JSON field names are treated as stable unless explicitly deprecated
 - OpenAPI source of truth: `docs/openapi.yaml`
 
-## OpenAPI Coverage (v0.1.0)
+## OpenAPI Coverage (v0.2.0)
 
 - `docs/openapi.yaml` is a baseline subset focused on high-traffic/common integration flows
 - Endpoint pages in `docs/api/*.md` define full public behavior for covered operations
@@ -19,7 +19,7 @@ This page defines compatibility expectations for HTTP API changes.
 
 ## App Version vs API Version
 
-- Application release `v0.1.0` is pre-1.0 software and may evolve quickly
+- Application release `v0.2.0` is pre-1.0 software and may evolve quickly
 - API v1 path contract (`/v1/*`) remains the compatibility baseline for consumers
 - Breaking API behavior changes require explicit documentation and migration notes
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -12,10 +12,10 @@ Local binary:
 ./bin/app <command> [flags]
 ```
 
-Docker image (v0.1.0):
+Docker image (v0.2.0):
 
 ```bash
-docker run --rm --env-file .env allisson/secrets:v0.1.0 <command> [flags]
+docker run --rm --env-file .env allisson/secrets:v0.2.0 <command> [flags]
 ```
 
 ## Core Runtime
@@ -132,6 +132,53 @@ Flags:
 - Prefer `--format json` for automation
 - Store client secrets in a secure secret manager
 - Use least-privilege policies per workload and path
+
+## Audit Log Maintenance
+
+### `clean-audit-logs`
+
+Deletes audit logs older than a specified retention period.
+
+Flags:
+
+- `--days`, `-d` (required): delete logs older than this many days
+- `--dry-run`, `-n` (default `false`): preview count without deleting
+- `--format`, `-f`: `text` (default) or `json`
+
+Examples:
+
+```bash
+# Preview (no deletion)
+./bin/app clean-audit-logs --days 90 --dry-run
+
+# Execute deletion
+./bin/app clean-audit-logs --days 90 --format text
+
+# Docker form
+docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.2.0 \
+  clean-audit-logs --days 90 --dry-run --format json
+```
+
+Example text output:
+
+```text
+Dry-run mode: Would delete 1234 audit log(s) older than 90 day(s)
+```
+
+Example JSON output:
+
+```json
+{
+  "count": 1234,
+  "days": 90,
+  "dry_run": true
+}
+```
+
+Requirements:
+
+- Database must be reachable and migrated
+- Use `--dry-run` before deletion in production environments
 
 ## See also
 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -4,7 +4,7 @@
 
 This is the default way to run Secrets.
 
-For release reproducibility, this guide uses the pinned image tag `allisson/secrets:v0.1.0`.
+For release reproducibility, this guide uses the pinned image tag `allisson/secrets:v0.2.0`.
 You can use `allisson/secrets:latest` for fast iteration.
 
 ## ⚡ Quickstart Copy Block
@@ -12,7 +12,7 @@ You can use `allisson/secrets:latest` for fast iteration.
 Use this minimal flow when you just want to get a working instance quickly:
 
 ```bash
-docker pull allisson/secrets:v0.1.0
+docker pull allisson/secrets:v0.2.0
 docker network create secrets-net || true
 
 docker run -d --name secrets-postgres --network secrets-net \
@@ -21,19 +21,19 @@ docker run -d --name secrets-postgres --network secrets-net \
   -e POSTGRES_DB=mydb \
   postgres:16-alpine
 
-docker run --rm allisson/secrets:v0.1.0 create-master-key --id default
+docker run --rm allisson/secrets:v0.2.0 create-master-key --id default
 # copy generated MASTER_KEYS and ACTIVE_MASTER_KEY_ID into .env
 
-docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.1.0 migrate
-docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.1.0 create-kek --algorithm aes-gcm
+docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.2.0 migrate
+docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.2.0 create-kek --algorithm aes-gcm
 docker run --rm --name secrets-api --network secrets-net --env-file .env -p 8080:8080 \
-  allisson/secrets:v0.1.0 server
+  allisson/secrets:v0.2.0 server
 ```
 
 ## 1) Pull the image
 
 ```bash
-docker pull allisson/secrets:v0.1.0
+docker pull allisson/secrets:v0.2.0
 ```
 
 ## 2) Start PostgreSQL
@@ -51,7 +51,7 @@ docker run -d --name secrets-postgres --network secrets-net \
 ## 3) Generate a master key
 
 ```bash
-docker run --rm allisson/secrets:v0.1.0 create-master-key --id default
+docker run --rm allisson/secrets:v0.2.0 create-master-key --id default
 ```
 
 Copy the generated values into a local `.env` file.
@@ -80,15 +80,15 @@ EOF
 ## 5) Run migrations and bootstrap KEK
 
 ```bash
-docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.1.0 migrate
-docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.1.0 create-kek --algorithm aes-gcm
+docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.2.0 migrate
+docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.2.0 create-kek --algorithm aes-gcm
 ```
 
 ## 6) Start the API server
 
 ```bash
 docker run --rm --name secrets-api --network secrets-net --env-file .env -p 8080:8080 \
-  allisson/secrets:v0.1.0 server
+  allisson/secrets:v0.2.0 server
 ```
 
 ## 7) Verify
@@ -108,7 +108,7 @@ Expected:
 Use the CLI command to create your first API client and policy set:
 
 ```bash
-docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.1.0 create-client \
+docker run --rm --network secrets-net --env-file .env allisson/secrets:v0.2.0 create-client \
   --name bootstrap-admin \
   --active \
   --policies '[{"path":"*","capabilities":["read","write","delete","encrypt","decrypt","rotate"]}]' \

--- a/docs/operations/production.md
+++ b/docs/operations/production.md
@@ -41,6 +41,7 @@ Minimal reverse proxy checklist:
 - Use encrypted storage and restricted DB network access
 - Monitor connection pool metrics and error rates
 - Run migrations before rolling out new app versions
+- Define and execute audit log retention cleanup on a fixed cadence
 
 Backup/restore checklist:
 
@@ -48,6 +49,16 @@ Backup/restore checklist:
 2. Retention policy defined
 3. Restore drill tested in non-production
 4. Recovery time objective documented
+
+Audit log retention routine (recommended monthly):
+
+```bash
+# 1) Preview rows older than 90 days
+./bin/app clean-audit-logs --days 90 --dry-run --format json
+
+# 2) Execute deletion
+./bin/app clean-audit-logs --days 90 --format text
+```
 
 ## 4) Key Rotation Schedule
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,53 @@
+# 🚀 Secrets v0.2.0 Release Notes
+
+> Release date: 2026-02-14
+
+This release adds operational support for audit log retention cleanup.
+
+## Highlights
+
+- New CLI command: `clean-audit-logs`
+- Supports retention by age in days (`--days`)
+- Supports safe preview mode (`--dry-run`) before deletion
+- Supports machine-friendly output (`--format json`) and human-readable output (`--format text`)
+
+## Included CLI Addition
+
+- `clean-audit-logs --days <n> [--dry-run] [--format text|json]`
+
+Operational behavior:
+
+- Dry-run mode counts matching rows without deleting
+- Execution mode deletes rows older than the computed UTC cutoff date
+- Works with both PostgreSQL and MySQL repositories
+
+## Runtime and Compatibility
+
+- API baseline remains v1 (`/v1/*`)
+- Local development targets: Linux and macOS
+- CI baseline: Go `1.25.5`, PostgreSQL `16-alpine`, MySQL `8.0`
+- Compatibility targets: PostgreSQL `12+`, MySQL `8.0+`
+
+## Operational Notes
+
+- Use `--dry-run` first for production safety
+- Ensure database is reachable and migrated before cleanup runs
+- Keep retention execution on a defined cadence (for example monthly)
+
+Example:
+
+```bash
+./bin/app clean-audit-logs --days 90 --dry-run --format json
+```
+
+## Upgrade Notes
+
+- Non-breaking addition: new CLI command for operations
+- Existing API paths and behavior remain compatible under API v1 documentation
+
+## See also
+
+- [CLI commands reference](../cli/commands.md)
+- [Audit Logs API](../api/audit-logs.md)
+- [Production operations](../operations/production.md)
+- [API compatibility policy](../api/versioning-policy.md)

--- a/internal/auth/http/middleware_test.go
+++ b/internal/auth/http/middleware_test.go
@@ -90,6 +90,11 @@ func (m *mockAuditLogUseCase) List(
 	return args.Get(0).([]*authDomain.AuditLog), args.Error(1)
 }
 
+func (m *mockAuditLogUseCase) DeleteOlderThan(ctx context.Context, days int, dryRun bool) (int64, error) {
+	args := m.Called(ctx, days, dryRun)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // TestMain sets Gin to test mode for all tests in this package.
 func TestMain(m *testing.M) {
 	gin.SetMode(gin.TestMode)

--- a/internal/auth/usecase/interface.go
+++ b/internal/auth/usecase/interface.go
@@ -60,6 +60,12 @@ type AuditLogRepository interface {
 		offset, limit int,
 		createdAtFrom, createdAtTo *time.Time,
 	) ([]*authDomain.AuditLog, error)
+
+	// DeleteOlderThan removes audit logs with created_at before the specified timestamp.
+	// When dryRun is true, returns count via SELECT COUNT(*) without deletion. When false,
+	// executes DELETE and returns affected rows. Supports transaction-aware operations via
+	// context propagation. All timestamps are expected in UTC.
+	DeleteOlderThan(ctx context.Context, olderThan time.Time, dryRun bool) (int64, error)
 }
 
 // ClientUseCase defines business logic operations for managing authentication clients.
@@ -151,4 +157,10 @@ type AuditLogUseCase interface {
 		offset, limit int,
 		createdAtFrom, createdAtTo *time.Time,
 	) ([]*authDomain.AuditLog, error)
+
+	// DeleteOlderThan removes audit logs older than the specified number of days.
+	// When dryRun is true, returns count without deletion. When false, executes DELETE
+	// and returns affected rows. The cutoff date is calculated as current UTC time minus
+	// the specified days.
+	DeleteOlderThan(ctx context.Context, days int, dryRun bool) (int64, error)
 }

--- a/internal/auth/usecase/mocks/mocks.go
+++ b/internal/auth/usecase/mocks/mocks.go
@@ -657,6 +657,78 @@ func (_c *MockAuditLogRepository_Create_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// DeleteOlderThan provides a mock function for the type MockAuditLogRepository
+func (_mock *MockAuditLogRepository) DeleteOlderThan(ctx context.Context, olderThan time.Time, dryRun bool) (int64, error) {
+	ret := _mock.Called(ctx, olderThan, dryRun)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteOlderThan")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Time, bool) (int64, error)); ok {
+		return returnFunc(ctx, olderThan, dryRun)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Time, bool) int64); ok {
+		r0 = returnFunc(ctx, olderThan, dryRun)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, time.Time, bool) error); ok {
+		r1 = returnFunc(ctx, olderThan, dryRun)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAuditLogRepository_DeleteOlderThan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOlderThan'
+type MockAuditLogRepository_DeleteOlderThan_Call struct {
+	*mock.Call
+}
+
+// DeleteOlderThan is a helper method to define mock.On call
+//   - ctx context.Context
+//   - olderThan time.Time
+//   - dryRun bool
+func (_e *MockAuditLogRepository_Expecter) DeleteOlderThan(ctx interface{}, olderThan interface{}, dryRun interface{}) *MockAuditLogRepository_DeleteOlderThan_Call {
+	return &MockAuditLogRepository_DeleteOlderThan_Call{Call: _e.mock.On("DeleteOlderThan", ctx, olderThan, dryRun)}
+}
+
+func (_c *MockAuditLogRepository_DeleteOlderThan_Call) Run(run func(ctx context.Context, olderThan time.Time, dryRun bool)) *MockAuditLogRepository_DeleteOlderThan_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAuditLogRepository_DeleteOlderThan_Call) Return(n int64, err error) *MockAuditLogRepository_DeleteOlderThan_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockAuditLogRepository_DeleteOlderThan_Call) RunAndReturn(run func(ctx context.Context, olderThan time.Time, dryRun bool) (int64, error)) *MockAuditLogRepository_DeleteOlderThan_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // List provides a mock function for the type MockAuditLogRepository
 func (_mock *MockAuditLogRepository) List(ctx context.Context, offset int, limit int, createdAtFrom *time.Time, createdAtTo *time.Time) ([]*domain.AuditLog, error) {
 	ret := _mock.Called(ctx, offset, limit, createdAtFrom, createdAtTo)
@@ -1367,6 +1439,78 @@ func (_c *MockAuditLogUseCase_Create_Call) Return(err error) *MockAuditLogUseCas
 }
 
 func (_c *MockAuditLogUseCase_Create_Call) RunAndReturn(run func(ctx context.Context, requestID uuid.UUID, clientID uuid.UUID, capability domain.Capability, path string, metadata map[string]any) error) *MockAuditLogUseCase_Create_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteOlderThan provides a mock function for the type MockAuditLogUseCase
+func (_mock *MockAuditLogUseCase) DeleteOlderThan(ctx context.Context, days int, dryRun bool) (int64, error) {
+	ret := _mock.Called(ctx, days, dryRun)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteOlderThan")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, bool) (int64, error)); ok {
+		return returnFunc(ctx, days, dryRun)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, bool) int64); ok {
+		r0 = returnFunc(ctx, days, dryRun)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, bool) error); ok {
+		r1 = returnFunc(ctx, days, dryRun)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAuditLogUseCase_DeleteOlderThan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOlderThan'
+type MockAuditLogUseCase_DeleteOlderThan_Call struct {
+	*mock.Call
+}
+
+// DeleteOlderThan is a helper method to define mock.On call
+//   - ctx context.Context
+//   - days int
+//   - dryRun bool
+func (_e *MockAuditLogUseCase_Expecter) DeleteOlderThan(ctx interface{}, days interface{}, dryRun interface{}) *MockAuditLogUseCase_DeleteOlderThan_Call {
+	return &MockAuditLogUseCase_DeleteOlderThan_Call{Call: _e.mock.On("DeleteOlderThan", ctx, days, dryRun)}
+}
+
+func (_c *MockAuditLogUseCase_DeleteOlderThan_Call) Run(run func(ctx context.Context, days int, dryRun bool)) *MockAuditLogUseCase_DeleteOlderThan_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAuditLogUseCase_DeleteOlderThan_Call) Return(n int64, err error) *MockAuditLogUseCase_DeleteOlderThan_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockAuditLogUseCase_DeleteOlderThan_Call) RunAndReturn(run func(ctx context.Context, days int, dryRun bool) (int64, error)) *MockAuditLogUseCase_DeleteOlderThan_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Add operational support for audit log retention management via a new CLI command that enables safe deletion of old audit logs by age. The command supports dry-run preview mode to show affected row counts before deletion and provides both human-readable text and machine-friendly JSON output formats.

Implementation:
- Add clean-audit-logs CLI command with --days, --dry-run, and --format flags
- Implement DeleteOlderThan() method across repository, use case, and interface layers
- Support both PostgreSQL and MySQL with parameterized DELETE queries and COUNT-based dry-run
- Calculate UTC-based cutoff timestamps (current time minus retention days)
- Return affected row count for both dry-run (via SELECT COUNT) and execution (via RowsAffected)

Testing:
- Add comprehensive use case tests covering success, error, dry-run, and zero-result scenarios
- Update mock interfaces (middleware test, generated mocks) with new DeleteOlderThan signature

Documentation:
- Add command reference to CLI guide with examples and Docker usage patterns
- Add retention cleanup runbook to production operations guide
- Clarify audit log retention is CLI-based (no HTTP DELETE endpoint)
- Update version references from v0.1.0 to v0.2.0 across documentation
- Add v0.2.0 release notes with operational guidance and upgrade notes

Project files updated:
- AGENTS.md: add clean-audit-logs to available commands list
- README.md: update pinned Docker tag to v0.2.0 and release link
- docs/CHANGELOG.md: add v0.2.0 documentation changes entry