### PR TITLE
refactor(test): remove database driver selection

### DIFF
--- a/internal/app/di_auth.go
+++ b/internal/app/di_auth.go
@@ -18,7 +18,7 @@ func (c *Container) SecretService() authService.SecretService {
 	return c.secretService
 }
 
-// ClientRepository returns the client repository based on database driver.
+// ClientRepository returns the client repository.
 func (c *Container) ClientRepository(ctx context.Context) (authUseCase.ClientRepository, error) {
 	var err error
 	c.clientRepositoryInit.Do(func() {
@@ -62,7 +62,7 @@ func (c *Container) TokenService() authService.TokenService {
 	return c.tokenService
 }
 
-// TokenRepository returns the token repository based on database driver.
+// TokenRepository returns the token repository.
 func (c *Container) TokenRepository(ctx context.Context) (authUseCase.TokenRepository, error) {
 	var err error
 	c.tokenRepositoryInit.Do(func() {
@@ -80,7 +80,7 @@ func (c *Container) TokenRepository(ctx context.Context) (authUseCase.TokenRepos
 	return c.tokenRepository, nil
 }
 
-// AuditLogRepository returns the audit log repository based on database driver.
+// AuditLogRepository returns the audit log repository.
 func (c *Container) AuditLogRepository(ctx context.Context) (authUseCase.AuditLogRepository, error) {
 	var err error
 	c.auditLogRepositoryInit.Do(func() {
@@ -193,7 +193,7 @@ func (c *Container) initSecretService() authService.SecretService {
 	return authService.NewSecretService()
 }
 
-// initClientRepository creates the client repository based on the database driver.
+// initClientRepository creates the client repository.
 func (c *Container) initClientRepository(ctx context.Context) (authUseCase.ClientRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {
@@ -252,7 +252,7 @@ func (c *Container) initTokenService() authService.TokenService {
 	return authService.NewTokenService()
 }
 
-// initTokenRepository creates the token repository based on the database driver.
+// initTokenRepository creates the token repository.
 func (c *Container) initTokenRepository(ctx context.Context) (authUseCase.TokenRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {
@@ -262,7 +262,7 @@ func (c *Container) initTokenRepository(ctx context.Context) (authUseCase.TokenR
 	return authRepository.NewTokenRepository(db), nil
 }
 
-// initAuditLogRepository creates the audit log repository based on the database driver.
+// initAuditLogRepository creates the audit log repository.
 func (c *Container) initAuditLogRepository(ctx context.Context) (authUseCase.AuditLogRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {

--- a/internal/app/di_crypto.go
+++ b/internal/app/di_crypto.go
@@ -88,7 +88,7 @@ func (c *Container) KekUseCase(ctx context.Context) (cryptoUseCase.KekUseCase, e
 	return c.kekUseCase, nil
 }
 
-// CryptoDekRepository returns the DEK repository for the crypto use case based on database driver.
+// CryptoDekRepository returns the DEK repository for the crypto use case.
 func (c *Container) CryptoDekRepository(ctx context.Context) (cryptoUseCase.DekRepository, error) {
 	var err error
 	c.cryptoDekRepositoryInit.Do(func() {
@@ -159,7 +159,7 @@ func (c *Container) initKMSService() cryptoDomain.KMSService {
 	return cryptoService.NewKMSService()
 }
 
-// initKekRepository creates the KEK repository based on the database driver.
+// initKekRepository creates the KEK repository.
 func (c *Container) initKekRepository(ctx context.Context) (cryptoUseCase.KekRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {
@@ -186,7 +186,7 @@ func (c *Container) initKekUseCase(ctx context.Context) (cryptoUseCase.KekUseCas
 	return cryptoUseCase.NewKekUseCase(txManager, kekRepository, keyManager), nil
 }
 
-// initCryptoDekRepository creates the DEK repository for crypto use case based on the database driver.
+// initCryptoDekRepository creates the DEK repository for crypto use case.
 func (c *Container) initCryptoDekRepository(ctx context.Context) (cryptoUseCase.DekRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {

--- a/internal/app/di_secrets.go
+++ b/internal/app/di_secrets.go
@@ -11,7 +11,7 @@ import (
 	secretsUseCase "github.com/allisson/secrets/internal/secrets/usecase"
 )
 
-// DekRepository returns the DEK repository based on database driver.
+// DekRepository returns the DEK repository.
 func (c *Container) DekRepository(ctx context.Context) (secretsUseCase.DekRepository, error) {
 	var err error
 	c.dekRepositoryInit.Do(func() {
@@ -29,7 +29,7 @@ func (c *Container) DekRepository(ctx context.Context) (secretsUseCase.DekReposi
 	return c.dekRepository, nil
 }
 
-// SecretRepository returns the secret repository based on database driver.
+// SecretRepository returns the secret repository.
 func (c *Container) SecretRepository(ctx context.Context) (secretsUseCase.SecretRepository, error) {
 	var err error
 	c.secretRepositoryInit.Do(func() {
@@ -83,7 +83,7 @@ func (c *Container) SecretHandler(ctx context.Context) (*secretsHTTP.SecretHandl
 	return c.secretHandler, nil
 }
 
-// initDekRepository creates the DEK repository based on the database driver.
+// initDekRepository creates the DEK repository.
 func (c *Container) initDekRepository(ctx context.Context) (secretsUseCase.DekRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {
@@ -93,7 +93,7 @@ func (c *Container) initDekRepository(ctx context.Context) (secretsUseCase.DekRe
 	return cryptoRepository.NewDekRepository(db), nil
 }
 
-// initSecretRepository creates the secret repository based on the database driver.
+// initSecretRepository creates the secret repository.
 func (c *Container) initSecretRepository(ctx context.Context) (secretsUseCase.SecretRepository, error) {
 	db, err := c.DB(ctx)
 	if err != nil {

--- a/internal/app/di_transit.go
+++ b/internal/app/di_transit.go
@@ -100,7 +100,7 @@ func (c *Container) CryptoHandler(ctx context.Context) (*transitHTTP.CryptoHandl
 	return c.cryptoHandler, nil
 }
 
-// initTransitKeyRepository creates the transit key repository based on the database driver.
+// initTransitKeyRepository creates the transit key repository.
 func (c *Container) initTransitKeyRepository(
 	ctx context.Context,
 ) (transitUseCase.TransitKeyRepository, error) {

--- a/internal/auth/repository/audit_log_repository_test.go
+++ b/internal/auth/repository/audit_log_repository_test.go
@@ -33,7 +33,7 @@ func TestAuditLogRepository_Create(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client to satisfy FK constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-create")
+	clientID := testutil.CreateTestClient(t, db, "test-create")
 
 	auditLog := &authDomain.AuditLog{
 		ID:         uuid.Must(uuid.NewV7()),
@@ -67,7 +67,7 @@ func TestAuditLogRepository_Create_WithNilMetadata(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client to satisfy FK constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-nil-metadata")
+	clientID := testutil.CreateTestClient(t, db, "test-nil-metadata")
 
 	auditLog := &authDomain.AuditLog{
 		ID:         uuid.Must(uuid.NewV7()),
@@ -102,7 +102,7 @@ func TestAuditLogRepository_Create_WithEmptyMetadata(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client to satisfy FK constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-empty-metadata")
+	clientID := testutil.CreateTestClient(t, db, "test-empty-metadata")
 
 	auditLog := &authDomain.AuditLog{
 		ID:         uuid.Must(uuid.NewV7()),
@@ -137,8 +137,8 @@ func TestAuditLogRepository_Create_MultipleAuditLogs(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test clients to satisfy FK constraint
-	clientID1 := testutil.CreateTestClient(t, db, "postgres", "test-multiple-1")
-	clientID2 := testutil.CreateTestClient(t, db, "postgres", "test-multiple-2")
+	clientID1 := testutil.CreateTestClient(t, db, "test-multiple-1")
+	clientID2 := testutil.CreateTestClient(t, db, "test-multiple-2")
 
 	// Create first audit log
 	auditLog1 := &authDomain.AuditLog{
@@ -186,7 +186,7 @@ func TestAuditLogRepository_Create_AllCapabilities(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client to satisfy FK constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-capabilities")
+	clientID := testutil.CreateTestClient(t, db, "test-capabilities")
 
 	capabilities := []authDomain.Capability{
 		authDomain.ReadCapability,
@@ -231,7 +231,7 @@ func TestAuditLogRepository_Create_WithTransaction(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client to satisfy FK constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-tx")
+	clientID := testutil.CreateTestClient(t, db, "test-tx")
 
 	auditLog := &authDomain.AuditLog{
 		ID:         uuid.Must(uuid.NewV7()),
@@ -281,7 +281,7 @@ func TestAuditLogRepository_Create_TransactionRollback(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client to satisfy FK constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-rollback")
+	clientID := testutil.CreateTestClient(t, db, "test-rollback")
 
 	auditLog := &authDomain.AuditLog{
 		ID:         uuid.Must(uuid.NewV7()),
@@ -332,7 +332,7 @@ func TestAuditLogRepository_ListCursor_FirstPage(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client for foreign key constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-cursor-first")
+	clientID := testutil.CreateTestClient(t, db, "test-cursor-first")
 
 	// Create 5 audit logs
 	now := time.Now().UTC()
@@ -372,7 +372,7 @@ func TestAuditLogRepository_ListCursor_SubsequentPages(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client for foreign key constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-cursor-pages")
+	clientID := testutil.CreateTestClient(t, db, "test-cursor-pages")
 
 	// Create 10 audit logs
 	now := time.Now().UTC()
@@ -442,7 +442,7 @@ func TestAuditLogRepository_ListCursor_WithFilters(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test client for foreign key constraint
-	clientID := testutil.CreateTestClient(t, db, "postgres", "test-cursor-filters")
+	clientID := testutil.CreateTestClient(t, db, "test-cursor-filters")
 
 	// Create audit logs with different timestamps
 	now := time.Now().UTC().Truncate(time.Microsecond)
@@ -481,8 +481,8 @@ func TestAuditLogRepository_ListCursor_ByClientID(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test clients
-	clientID1 := testutil.CreateTestClient(t, db, "postgres", "client-1")
-	clientID2 := testutil.CreateTestClient(t, db, "postgres", "client-2")
+	clientID1 := testutil.CreateTestClient(t, db, "client-1")
+	clientID2 := testutil.CreateTestClient(t, db, "client-2")
 
 	// Create logs for client 1
 	for i := 0; i < 3; i++ {

--- a/internal/secrets/repository/secret_repository_test.go
+++ b/internal/secrets/repository/secret_repository_test.go
@@ -1248,8 +1248,8 @@ func TestSecretRepository_ListCursor_FirstPage(t *testing.T) {
 	ctx := context.Background()
 
 	// Create KEK and DEK for FK constraint
-	kekID := testutil.CreateTestKek(t, db, "postgres", "test-kek")
-	dekID := testutil.CreateTestDek(t, db, "postgres", "test-dek", kekID)
+	kekID := testutil.CreateTestKek(t, db, "test-kek")
+	dekID := testutil.CreateTestDek(t, db, "test-dek", kekID)
 
 	// Create 5 secrets with different paths (alphabetically ordered)
 	paths := []string{"a-secret", "b-secret", "c-secret", "d-secret", "e-secret"}
@@ -1286,8 +1286,8 @@ func TestSecretRepository_ListCursor_SubsequentPages(t *testing.T) {
 	ctx := context.Background()
 
 	// Create KEK and DEK for FK constraint
-	kekID := testutil.CreateTestKek(t, db, "postgres", "test-kek-2")
-	dekID := testutil.CreateTestDek(t, db, "postgres", "test-dek-2", kekID)
+	kekID := testutil.CreateTestKek(t, db, "test-kek-2")
+	dekID := testutil.CreateTestDek(t, db, "test-dek-2", kekID)
 
 	// Create 10 secrets with alphabetically ordered paths
 	paths := []string{"a-secret", "b-secret", "c-secret", "d-secret", "e-secret",

--- a/internal/testutil/database.go
+++ b/internal/testutil/database.go
@@ -150,15 +150,10 @@ func getMigrationsPath() (string, error) {
 	}
 }
 
-// uuidToDriverValue converts a UUID to the PostgreSQL driver value.
-func uuidToDriverValue(id uuid.UUID, driver string) (interface{}, error) {
-	return id, nil
-}
-
 // CreateTestClient creates a minimal active test client for repository tests.
 // Returns the client ID for use in foreign key relationships. The client is
 // created with a wildcard policy allowing all capabilities on all paths.
-func CreateTestClient(t *testing.T, db *sql.DB, driver, name string) uuid.UUID {
+func CreateTestClient(t *testing.T, db *sql.DB, name string) uuid.UUID {
 	t.Helper()
 
 	clientID := uuid.Must(uuid.NewV7())
@@ -184,7 +179,7 @@ func CreateTestClient(t *testing.T, db *sql.DB, driver, name string) uuid.UUID {
 // CreateTestKek creates a minimal test KEK for repository tests that need
 // to reference a KEK (e.g., signed audit logs). Returns the KEK ID.
 // The KEK is created with algorithm 'aes-gcm' and random encrypted key data.
-func CreateTestKek(t *testing.T, db *sql.DB, driver, name string) uuid.UUID {
+func CreateTestKek(t *testing.T, db *sql.DB, name string) uuid.UUID {
 	t.Helper()
 
 	kekID := uuid.Must(uuid.NewV7())
@@ -217,10 +212,10 @@ func CreateTestKek(t *testing.T, db *sql.DB, driver, name string) uuid.UUID {
 
 // CreateTestClientAndKek creates both a test client and KEK, returning both IDs.
 // Convenience wrapper for tests that need both fixtures.
-func CreateTestClientAndKek(t *testing.T, db *sql.DB, driver, baseName string) (clientID, kekID uuid.UUID) {
+func CreateTestClientAndKek(t *testing.T, db *sql.DB, baseName string) (clientID, kekID uuid.UUID) {
 	t.Helper()
-	clientID = CreateTestClient(t, db, driver, baseName+"-client")
-	kekID = CreateTestKek(t, db, driver, baseName+"-kek")
+	clientID = CreateTestClient(t, db, baseName+"-client")
+	kekID = CreateTestKek(t, db, baseName+"-kek")
 	return clientID, kekID
 }
 
@@ -243,7 +238,7 @@ func SkipIfNoPostgres(t *testing.T) {
 
 // CreateTestDek creates a minimal test DEK (Data Encryption Key) for repository tests.
 // Returns the DEK ID. The DEK is associated with the provided KEK ID.
-func CreateTestDek(t *testing.T, db *sql.DB, driver, name string, kekID uuid.UUID) uuid.UUID {
+func CreateTestDek(t *testing.T, db *sql.DB, name string, kekID uuid.UUID) uuid.UUID {
 	t.Helper()
 
 	dekID := uuid.Must(uuid.NewV7())
@@ -275,7 +270,7 @@ func CreateTestDek(t *testing.T, db *sql.DB, driver, name string, kekID uuid.UUI
 // ValidateTestClient verifies that a test client was created with expected values.
 // Returns true if the client exists and is active, false if it does not exist.
 // Fails the test if a database error occurs.
-func ValidateTestClient(t *testing.T, db *sql.DB, driver string, clientID uuid.UUID) bool {
+func ValidateTestClient(t *testing.T, db *sql.DB, clientID uuid.UUID) bool {
 	t.Helper()
 
 	ctx := context.Background()
@@ -295,7 +290,7 @@ func ValidateTestClient(t *testing.T, db *sql.DB, driver string, clientID uuid.U
 // ValidateTestKek verifies that a test KEK was created with expected values.
 // Returns true if the KEK exists, false if it does not exist.
 // Fails the test if a database error occurs.
-func ValidateTestKek(t *testing.T, db *sql.DB, driver string, kekID uuid.UUID) bool {
+func ValidateTestKek(t *testing.T, db *sql.DB, kekID uuid.UUID) bool {
 	t.Helper()
 
 	ctx := context.Background()
@@ -315,7 +310,7 @@ func ValidateTestKek(t *testing.T, db *sql.DB, driver string, kekID uuid.UUID) b
 // ValidateTestDek verifies that a test DEK was created with expected values.
 // Returns true if the DEK exists, false if it does not exist.
 // Fails the test if a database error occurs.
-func ValidateTestDek(t *testing.T, db *sql.DB, driver string, dekID uuid.UUID) bool {
+func ValidateTestDek(t *testing.T, db *sql.DB, dekID uuid.UUID) bool {
 	t.Helper()
 
 	ctx := context.Background()

--- a/internal/testutil/database_test.go
+++ b/internal/testutil/database_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,17 +71,6 @@ func TestGetMigrationsPathFromDifferentWorkingDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, path)
 	assert.Equal(t, "migrations", filepath.Base(path))
-}
-
-func TestUuidToDriverValue(t *testing.T) {
-	testID := uuid.Must(uuid.NewV7())
-
-	value, err := uuidToDriverValue(testID, "postgres")
-	require.NoError(t, err)
-
-	gotUUID, ok := value.(uuid.UUID)
-	require.True(t, ok, "value should be uuid.UUID")
-	assert.Equal(t, testID, gotUUID)
 }
 
 func TestSetupPostgresDB(t *testing.T) {

--- a/internal/tokenization/repository/repository_test.go
+++ b/internal/tokenization/repository/repository_test.go
@@ -547,8 +547,8 @@ func TestTokenizationKeyRepository_ListCursor_FirstPage(t *testing.T) {
 	ctx := context.Background()
 
 	// Create KEK and DEK for FK constraint
-	kekID := testutil.CreateTestKek(t, db, "postgres", "test-kek")
-	dekID := testutil.CreateTestDek(t, db, "postgres", "test-dek", kekID)
+	kekID := testutil.CreateTestKek(t, db, "test-kek")
+	dekID := testutil.CreateTestDek(t, db, "test-dek", kekID)
 
 	// Create 5 tokenization keys with different names (alphabetically ordered)
 	names := []string{"a-key", "b-key", "c-key", "d-key", "e-key"}
@@ -585,8 +585,8 @@ func TestTokenizationKeyRepository_ListCursor_SubsequentPages(t *testing.T) {
 	ctx := context.Background()
 
 	// Create KEK and DEK for FK constraint
-	kekID := testutil.CreateTestKek(t, db, "postgres", "test-kek-2")
-	dekID := testutil.CreateTestDek(t, db, "postgres", "test-dek-2", kekID)
+	kekID := testutil.CreateTestKek(t, db, "test-kek-2")
+	dekID := testutil.CreateTestDek(t, db, "test-dek-2", kekID)
 
 	// Create 10 tokenization keys with alphabetically ordered names
 	names := []string{"a-key", "b-key", "c-key", "d-key", "e-key",

--- a/internal/transit/repository/transit_key_repository_test.go
+++ b/internal/transit/repository/transit_key_repository_test.go
@@ -888,8 +888,8 @@ func TestTransitKeyRepository_ListCursor_FirstPage(t *testing.T) {
 	ctx := context.Background()
 
 	// Create KEK and DEK for FK constraint
-	kekID := testutil.CreateTestKek(t, db, "postgres", "test-kek")
-	dekID := testutil.CreateTestDek(t, db, "postgres", "test-dek", kekID)
+	kekID := testutil.CreateTestKek(t, db, "test-kek")
+	dekID := testutil.CreateTestDek(t, db, "test-dek", kekID)
 
 	// Create 5 transit keys with different names (alphabetically ordered)
 	names := []string{"a-key", "b-key", "c-key", "d-key", "e-key"}
@@ -924,8 +924,8 @@ func TestTransitKeyRepository_ListCursor_SubsequentPages(t *testing.T) {
 	ctx := context.Background()
 
 	// Create KEK and DEK for FK constraint
-	kekID := testutil.CreateTestKek(t, db, "postgres", "test-kek-2")
-	dekID := testutil.CreateTestDek(t, db, "postgres", "test-dek-2", kekID)
+	kekID := testutil.CreateTestKek(t, db, "test-kek-2")
+	dekID := testutil.CreateTestDek(t, db, "test-dek-2", kekID)
 
 	// Create 10 transit keys with alphabetically ordered names
 	names := []string{"a-key", "b-key", "c-key", "d-key", "e-key",

--- a/test/integration/additional_scenarios_test.go
+++ b/test/integration/additional_scenarios_test.go
@@ -29,18 +29,9 @@ func TestIntegration_Auth_TokenExpiry(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup with 2-second token expiration for fast testing
-			ctx := setupIntegrationTestWithTokenExpiration(t, tc.dbDriver, 2*time.Second)
-			defer teardownIntegrationTest(t, ctx)
+	// Setup with 2-second token expiration for fast testing
+	ctx := setupIntegrationTestWithTokenExpiration(t, 2*time.Second)
+	defer teardownIntegrationTest(t, ctx)
 
 			var (
 				testClientID     string
@@ -155,9 +146,7 @@ func TestIntegration_Auth_TokenExpiry(t *testing.T) {
 				assert.Equal(t, http.StatusOK, resp2.StatusCode, "new token should work")
 			})
 
-			t.Logf("Token expiry test passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("Token expiry test passed")
 }
 
 // TestIntegration_Transit_DecryptAfterRotation tests that ciphertexts encrypted
@@ -168,17 +157,8 @@ func TestIntegration_Transit_DecryptAfterRotation(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
 			keyName := "test-rotation-key"
 			plaintext := []byte("sensitive-data-before-rotation")
@@ -284,9 +264,7 @@ func TestIntegration_Transit_DecryptAfterRotation(t *testing.T) {
 				assert.Equal(t, uint(2), response.Version, "should indicate decrypted with version 2")
 			})
 
-			t.Logf("Transit rotation test passed for %s: old and new versions both decrypt successfully", tc.dbDriver)
-		})
-	}
+	t.Logf("Transit rotation test passed: old and new versions both decrypt successfully")
 }
 
 // TestIntegration_Transit_DeleteKey tests deleting a transit key and verifying
@@ -297,17 +275,8 @@ func TestIntegration_Transit_DeleteKey(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
 			keyName := "test-delete-key"
 			plaintext := []byte("test-data")
@@ -361,9 +330,7 @@ func TestIntegration_Transit_DeleteKey(t *testing.T) {
 				assert.Equal(t, http.StatusNotFound, resp.StatusCode, "key should not be found after deletion")
 			})
 
-			t.Logf("Transit delete key test passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("Transit delete key test passed")
 }
 
 // TestIntegration_Auth_UnlockAccount tests the account unlock functionality.
@@ -374,18 +341,9 @@ func TestIntegration_Auth_UnlockAccount(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup with lockout: 3 max attempts, 5 minute lockout duration
-			ctx := setupIntegrationTestWithLockout(t, tc.dbDriver, 3, 5*time.Minute)
-			defer teardownIntegrationTest(t, ctx)
+	// Setup with lockout: 3 max attempts, 5 minute lockout duration
+	ctx := setupIntegrationTestWithLockout(t, 3, 5*time.Minute)
+	defer teardownIntegrationTest(t, ctx)
 
 			var (
 				testClientID     string
@@ -490,7 +448,5 @@ func TestIntegration_Auth_UnlockAccount(t *testing.T) {
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
 			})
 
-			t.Logf("Account unlock test passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("Account unlock test passed")
 }

--- a/test/integration/audit_log_signature_test.go
+++ b/test/integration/audit_log_signature_test.go
@@ -29,321 +29,305 @@ func TestAuditLogSignature_EndToEnd(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	dbConfigs := []struct {
-		name   string
-		driver string
-		dsn    string
-	}{
-		{
-			name:   "PostgreSQL",
-			driver: "postgres",
-			dsn:    testutil.GetPostgresTestDSN(),
-		},
-	}
+	ctx := context.Background()
+	dsn := testutil.GetPostgresTestDSN()
 
-	for _, dbConfig := range dbConfigs {
-		t.Run(dbConfig.name, func(t *testing.T) {
-			ctx := context.Background()
-			driver := dbConfig.driver // Capture driver for inner test functions
+	// Setup test database and dependencies
+	testCtx := setupAuditLogTestContext(t, dsn)
+	defer cleanupAuditLogTestContext(t, testCtx)
 
-			// Setup test database and dependencies
-			testCtx := setupAuditLogTestContext(t, driver, dbConfig.dsn)
-			defer cleanupAuditLogTestContext(t, testCtx)
+	// Create audit signer and load KEK chain
+	auditSigner := authService.NewAuditSigner()
+	kekChain := testCtx.kekChain
 
-			// Create audit signer and load KEK chain
-			auditSigner := authService.NewAuditSigner()
-			kekChain := testCtx.kekChain
+	// Get repositories from container
+	auditLogRepo, err := testCtx.container.AuditLogRepository(context.Background())
+	require.NoError(t, err, "failed to get audit log repository")
 
-			// Get repositories from container
-			auditLogRepo, err := testCtx.container.AuditLogRepository(context.Background())
-			require.NoError(t, err, "failed to get audit log repository")
+	// Create use case with signing enabled
+	auditLogUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, auditSigner, kekChain)
 
-			// Create use case with signing enabled
-			auditLogUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, auditSigner, kekChain)
+	t.Run("CreateSignedAuditLog", func(t *testing.T) {
+		// Create a signed audit log
+		requestID := uuid.Must(uuid.NewV7())
+		clientID := testCtx.rootClient.ID
+		capability := authDomain.ReadCapability
+		path := "/api/v1/secrets/test-key"
+		metadata := map[string]any{
+			"user_agent": "integration-test",
+			"ip_address": "127.0.0.1",
+		}
 
-			t.Run("CreateSignedAuditLog", func(t *testing.T) {
-				// Create a signed audit log
-				requestID := uuid.Must(uuid.NewV7())
-				clientID := testCtx.rootClient.ID
-				capability := authDomain.ReadCapability
-				path := "/api/v1/secrets/test-key"
-				metadata := map[string]any{
-					"user_agent": "integration-test",
-					"ip_address": "127.0.0.1",
-				}
+		err := auditLogUseCase.Create(ctx, requestID, clientID, capability, path, metadata)
+		require.NoError(t, err, "failed to create audit log")
 
-				err := auditLogUseCase.Create(ctx, requestID, clientID, capability, path, metadata)
-				require.NoError(t, err, "failed to create audit log")
+		// Retrieve the created log
+		logs, err := auditLogUseCase.ListCursor(ctx, nil, 1, nil, nil, nil)
+		require.NoError(t, err, "failed to list audit logs")
+		require.Len(t, logs, 1, "expected exactly one audit log")
 
-				// Retrieve the created log
-				logs, err := auditLogUseCase.ListCursor(ctx, nil, 1, nil, nil, nil)
-				require.NoError(t, err, "failed to list audit logs")
-				require.Len(t, logs, 1, "expected exactly one audit log")
+		log := logs[0]
 
-				log := logs[0]
+		// Verify signature fields are populated
+		assert.True(t, log.IsSigned, "audit log should be signed")
+		assert.NotNil(t, log.KekID, "kek_id should not be nil")
+		assert.NotEmpty(t, log.Signature, "signature should not be empty")
+		assert.Equal(t, kekChain.ActiveKekID(), *log.KekID, "kek_id should match active KEK")
 
-				// Verify signature fields are populated
-				assert.True(t, log.IsSigned, "audit log should be signed")
-				assert.NotNil(t, log.KekID, "kek_id should not be nil")
-				assert.NotEmpty(t, log.Signature, "signature should not be empty")
-				assert.Equal(t, kekChain.ActiveKekID(), *log.KekID, "kek_id should match active KEK")
+		// Verify the signature is valid
+		err = auditLogUseCase.VerifyIntegrity(ctx, log.ID)
+		assert.NoError(t, err, "signature verification should succeed")
+	})
 
-				// Verify the signature is valid
-				err = auditLogUseCase.VerifyIntegrity(ctx, log.ID)
-				assert.NoError(t, err, "signature verification should succeed")
-			})
+	t.Run("TamperDetection", func(t *testing.T) {
+		// Create a signed audit log
+		requestID := uuid.Must(uuid.NewV7())
+		clientID := testCtx.rootClient.ID
 
-			t.Run("TamperDetection", func(t *testing.T) {
-				// Create a signed audit log
-				requestID := uuid.Must(uuid.NewV7())
-				clientID := testCtx.rootClient.ID
+		err := auditLogUseCase.Create(
+			ctx,
+			requestID,
+			clientID,
+			authDomain.WriteCapability,
+			"/api/v1/secrets/tamper-test",
+			nil,
+		)
+		require.NoError(t, err, "failed to create audit log")
 
-				err := auditLogUseCase.Create(
-					ctx,
-					requestID,
-					clientID,
-					authDomain.WriteCapability,
-					"/api/v1/secrets/tamper-test",
-					nil,
-				)
-				require.NoError(t, err, "failed to create audit log")
+		// Retrieve the log
+		logs, err := auditLogUseCase.ListCursor(ctx, nil, 1, nil, nil, nil)
+		require.NoError(t, err, "failed to list audit logs")
+		require.Len(t, logs, 1, "expected exactly one audit log")
 
-				// Retrieve the log
-				logs, err := auditLogUseCase.ListCursor(ctx, nil, 1, nil, nil, nil)
-				require.NoError(t, err, "failed to list audit logs")
-				require.Len(t, logs, 1, "expected exactly one audit log")
+		log := logs[0]
 
-				log := logs[0]
+		// Tamper with the log by modifying the path directly in the database
+		result, execErr := testCtx.db.Exec(
+			"UPDATE audit_logs SET path = '/api/v1/secrets/tampered' WHERE id = $1",
+			log.ID,
+		)
+		require.NoError(t, execErr, "failed to tamper with audit log")
 
-				// Tamper with the log by modifying the path directly in the database
-				result, execErr := testCtx.db.Exec(
-					"UPDATE audit_logs SET path = '/api/v1/secrets/tampered' WHERE id = $1",
-					log.ID,
-				)
-				require.NoError(t, execErr, "failed to tamper with audit log")
+		// Verify the UPDATE actually modified a row
+		rowsAffected, _ := result.RowsAffected()
+		require.Equal(t, int64(1), rowsAffected, "UPDATE should affect exactly 1 row")
 
-				// Verify the UPDATE actually modified a row
-				rowsAffected, _ := result.RowsAffected()
-				require.Equal(t, int64(1), rowsAffected, "UPDATE should affect exactly 1 row")
+		// Verification should now fail
+		err = auditLogUseCase.VerifyIntegrity(ctx, log.ID)
+		assert.Error(t, err, "signature verification should fail for tampered log")
+		assert.ErrorIs(t, err, authDomain.ErrSignatureInvalid, "error should be ErrSignatureInvalid")
+	})
 
-				// Verification should now fail
-				err = auditLogUseCase.VerifyIntegrity(ctx, log.ID)
-				assert.Error(t, err, "signature verification should fail for tampered log")
-				assert.ErrorIs(t, err, authDomain.ErrSignatureInvalid, "error should be ErrSignatureInvalid")
-			})
+	t.Run("VerifyRotationAuditLog", func(t *testing.T) {
+		// Setup UseCases
+		clientUseCase, _ := testCtx.container.ClientUseCase(ctx)
+		auditLogUseCase, _ := testCtx.container.AuditLogUseCase(ctx)
 
-			t.Run("VerifyRotationAuditLog", func(t *testing.T) {
-				// Setup UseCases
-				clientUseCase, _ := testCtx.container.ClientUseCase(ctx)
-				auditLogUseCase, _ := testCtx.container.AuditLogUseCase(ctx)
+		// Create a client to rotate
+		clientRequest := &authDomain.CreateClientInput{
+			Name:     "Rotation Audit Test",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
+		}
+		createOutput, err := clientUseCase.Create(ctx, clientRequest)
+		require.NoError(t, err)
 
-				// Create a client to rotate
-				clientRequest := &authDomain.CreateClientInput{
-					Name:     "Rotation Audit Test",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
-				}
-				createOutput, err := clientUseCase.Create(ctx, clientRequest)
-				require.NoError(t, err)
+		// Perform rotation
+		_, err = clientUseCase.RotateSecret(ctx, createOutput.ID)
+		require.NoError(t, err)
 
-				// Perform rotation
-				_, err = clientUseCase.RotateSecret(ctx, createOutput.ID)
-				require.NoError(t, err)
+		// List audit logs for this client and path
+		logs, err := auditLogUseCase.ListCursor(ctx, nil, 10, nil, nil, nil)
+		require.NoError(t, err)
 
-				// List audit logs for this client and path
-				logs, err := auditLogUseCase.ListCursor(ctx, nil, 10, nil, nil, nil)
-				require.NoError(t, err)
+		var rotationLog *authDomain.AuditLog
+		expectedPath := "/v1/clients/" + createOutput.ID.String() + "/rotate-secret"
+		for _, log := range logs {
+			if log.ClientID == createOutput.ID && log.Path == expectedPath {
+				rotationLog = log
+				break
+			}
+		}
 
-				var rotationLog *authDomain.AuditLog
-				expectedPath := "/v1/clients/" + createOutput.ID.String() + "/rotate-secret"
-				for _, log := range logs {
-					if log.ClientID == createOutput.ID && log.Path == expectedPath {
-						rotationLog = log
-						break
-					}
-				}
+		require.NotNil(t, rotationLog, "rotation audit log not found")
+		assert.True(t, rotationLog.IsSigned, "rotation audit log should be signed")
+		assert.Equal(t, authDomain.RotateCapability, rotationLog.Capability)
 
-				require.NotNil(t, rotationLog, "rotation audit log not found")
-				assert.True(t, rotationLog.IsSigned, "rotation audit log should be signed")
-				assert.Equal(t, authDomain.RotateCapability, rotationLog.Capability)
+		// Verify integrity
+		err = auditLogUseCase.VerifyIntegrity(ctx, rotationLog.ID)
+		assert.NoError(t, err, "rotation audit log signature should be valid")
+	})
 
-				// Verify integrity
-				err = auditLogUseCase.VerifyIntegrity(ctx, rotationLog.ID)
-				assert.NoError(t, err, "rotation audit log signature should be valid")
-			})
+	t.Run("VerifyBatch_AllValid", func(t *testing.T) {
+		// Create multiple signed audit logs
+		startTime := time.Now().UTC()
+		clientID := testCtx.rootClient.ID
 
-			t.Run("VerifyBatch_AllValid", func(t *testing.T) {
-				// Create multiple signed audit logs
-				startTime := time.Now().UTC()
-				clientID := testCtx.rootClient.ID
+		for i := 0; i < 5; i++ {
+			requestID := uuid.Must(uuid.NewV7())
+			path := "/api/v1/secrets/batch-test-" + string(rune('a'+i))
 
-				for i := 0; i < 5; i++ {
-					requestID := uuid.Must(uuid.NewV7())
-					path := "/api/v1/secrets/batch-test-" + string(rune('a'+i))
+			err := auditLogUseCase.Create(
+				ctx,
+				requestID,
+				clientID,
+				authDomain.ReadCapability,
+				path,
+				nil,
+			)
+			require.NoError(t, err, "failed to create audit log")
 
-					err := auditLogUseCase.Create(
-						ctx,
-						requestID,
-						clientID,
-						authDomain.ReadCapability,
-						path,
-						nil,
-					)
-					require.NoError(t, err, "failed to create audit log")
+			time.Sleep(10 * time.Millisecond) // Ensure distinct timestamps
+		}
 
-					time.Sleep(10 * time.Millisecond) // Ensure distinct timestamps
-				}
+		endTime := time.Now().UTC().Add(1 * time.Second)
 
-				endTime := time.Now().UTC().Add(1 * time.Second)
+		// Verify batch
+		report, err := auditLogUseCase.VerifyBatch(ctx, startTime, endTime)
+		require.NoError(t, err, "batch verification should succeed")
 
-				// Verify batch
-				report, err := auditLogUseCase.VerifyBatch(ctx, startTime, endTime)
-				require.NoError(t, err, "batch verification should succeed")
+		assert.Equal(t, int64(5), report.TotalChecked, "should check 5 logs")
+		assert.Equal(t, int64(5), report.SignedCount, "all 5 should be signed")
+		assert.Equal(t, int64(5), report.ValidCount, "all 5 should be valid")
+		assert.Equal(t, int64(0), report.InvalidCount, "no invalid logs")
+		assert.Empty(t, report.InvalidLogs, "no invalid log IDs")
+	})
 
-				assert.Equal(t, int64(5), report.TotalChecked, "should check 5 logs")
-				assert.Equal(t, int64(5), report.SignedCount, "all 5 should be signed")
-				assert.Equal(t, int64(5), report.ValidCount, "all 5 should be valid")
-				assert.Equal(t, int64(0), report.InvalidCount, "no invalid logs")
-				assert.Empty(t, report.InvalidLogs, "no invalid log IDs")
-			})
+	t.Run("VerifyBatch_WithInvalid", func(t *testing.T) {
+		// Create signed audit logs
+		startTime := time.Now().UTC()
+		clientID := testCtx.rootClient.ID
 
-			t.Run("VerifyBatch_WithInvalid", func(t *testing.T) {
-				// Create signed audit logs
-				startTime := time.Now().UTC()
-				clientID := testCtx.rootClient.ID
+		var logIDs []uuid.UUID
+		for i := 0; i < 3; i++ {
+			requestID := uuid.Must(uuid.NewV7())
+			path := "/api/v1/secrets/invalid-test-" + string(rune('a'+i))
 
-				var logIDs []uuid.UUID
-				for i := 0; i < 3; i++ {
-					requestID := uuid.Must(uuid.NewV7())
-					path := "/api/v1/secrets/invalid-test-" + string(rune('a'+i))
+			err := auditLogUseCase.Create(
+				ctx,
+				requestID,
+				clientID,
+				authDomain.WriteCapability,
+				path,
+				nil,
+			)
+			require.NoError(t, err, "failed to create audit log")
 
-					err := auditLogUseCase.Create(
-						ctx,
-						requestID,
-						clientID,
-						authDomain.WriteCapability,
-						path,
-						nil,
-					)
-					require.NoError(t, err, "failed to create audit log")
+			time.Sleep(10 * time.Millisecond)
+		}
 
-					time.Sleep(10 * time.Millisecond)
-				}
+		// Get the created logs
+		endTime := time.Now().UTC().Add(1 * time.Second)
+		logs, err := auditLogUseCase.ListCursor(ctx, nil, 3, &startTime, &endTime, nil)
+		require.NoError(t, err, "failed to list audit logs")
+		require.Len(t, logs, 3, "expected 3 audit logs")
 
-				// Get the created logs
-				endTime := time.Now().UTC().Add(1 * time.Second)
-				logs, err := auditLogUseCase.ListCursor(ctx, nil, 3, &startTime, &endTime, nil)
-				require.NoError(t, err, "failed to list audit logs")
-				require.Len(t, logs, 3, "expected 3 audit logs")
+		for _, log := range logs {
+			logIDs = append(logIDs, log.ID)
+		}
 
-				for _, log := range logs {
-					logIDs = append(logIDs, log.ID)
-				}
+		// Tamper with the middle log
+		_, execErr := testCtx.db.Exec(
+			"UPDATE audit_logs SET capability = 'delete' WHERE id = $1",
+			logIDs[1],
+		)
+		require.NoError(t, execErr, "failed to tamper with audit log")
 
-				// Tamper with the middle log
-				_, execErr := testCtx.db.Exec(
-					"UPDATE audit_logs SET capability = 'delete' WHERE id = $1",
-					logIDs[1],
-				)
-				require.NoError(t, execErr, "failed to tamper with audit log")
+		// Verify batch
+		report, err := auditLogUseCase.VerifyBatch(ctx, startTime, endTime)
+		require.NoError(t, err, "batch verification should not error")
 
-				// Verify batch
-				report, err := auditLogUseCase.VerifyBatch(ctx, startTime, endTime)
-				require.NoError(t, err, "batch verification should not error")
+		assert.Equal(t, int64(3), report.TotalChecked, "should check 3 logs")
+		assert.Equal(t, int64(3), report.SignedCount, "all 3 should be signed")
+		assert.Equal(t, int64(2), report.ValidCount, "2 should be valid")
+		assert.Equal(t, int64(1), report.InvalidCount, "1 should be invalid")
+		assert.Len(t, report.InvalidLogs, 1, "should have 1 invalid log ID")
+		assert.Equal(t, logIDs[1], report.InvalidLogs[0], "invalid log ID should match tampered log")
+	})
 
-				assert.Equal(t, int64(3), report.TotalChecked, "should check 3 logs")
-				assert.Equal(t, int64(3), report.SignedCount, "all 3 should be signed")
-				assert.Equal(t, int64(2), report.ValidCount, "2 should be valid")
-				assert.Equal(t, int64(1), report.InvalidCount, "1 should be invalid")
-				assert.Len(t, report.InvalidLogs, 1, "should have 1 invalid log ID")
-				assert.Equal(t, logIDs[1], report.InvalidLogs[0], "invalid log ID should match tampered log")
-			})
+	t.Run("LegacyUnsignedLogs", func(t *testing.T) {
+		// Create an unsigned legacy audit log (using nil signer and chain)
+		legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil, nil)
 
-			t.Run("LegacyUnsignedLogs", func(t *testing.T) {
-				// Create an unsigned legacy audit log (using nil signer and chain)
-				legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil, nil)
+		requestID := uuid.Must(uuid.NewV7())
+		clientID := testCtx.rootClient.ID
 
-				requestID := uuid.Must(uuid.NewV7())
-				clientID := testCtx.rootClient.ID
+		err := legacyUseCase.Create(
+			ctx,
+			requestID,
+			clientID,
+			authDomain.ReadCapability,
+			"/api/v1/secrets/legacy",
+			nil,
+		)
+		require.NoError(t, err, "failed to create legacy audit log")
 
-				err := legacyUseCase.Create(
-					ctx,
-					requestID,
-					clientID,
-					authDomain.ReadCapability,
-					"/api/v1/secrets/legacy",
-					nil,
-				)
-				require.NoError(t, err, "failed to create legacy audit log")
+		// Retrieve the log
+		logs, err := legacyUseCase.ListCursor(ctx, nil, 1, nil, nil, nil)
+		require.NoError(t, err, "failed to list audit logs")
+		require.Len(t, logs, 1, "expected exactly one audit log")
 
-				// Retrieve the log
-				logs, err := legacyUseCase.ListCursor(ctx, nil, 1, nil, nil, nil)
-				require.NoError(t, err, "failed to list audit logs")
-				require.Len(t, logs, 1, "expected exactly one audit log")
+		log := logs[0]
 
-				log := logs[0]
+		// Verify it's unsigned
+		assert.False(t, log.IsSigned, "audit log should not be signed")
+		assert.Nil(t, log.KekID, "kek_id should be nil")
+		assert.Empty(t, log.Signature, "signature should be empty")
 
-				// Verify it's unsigned
-				assert.False(t, log.IsSigned, "audit log should not be signed")
-				assert.Nil(t, log.KekID, "kek_id should be nil")
-				assert.Empty(t, log.Signature, "signature should be empty")
+		// Verification should return ErrSignatureMissing
+		err = auditLogUseCase.VerifyIntegrity(ctx, log.ID)
+		assert.Error(t, err, "verification should fail for unsigned log")
+		assert.ErrorIs(t, err, authDomain.ErrSignatureMissing, "error should be ErrSignatureMissing")
+	})
 
-				// Verification should return ErrSignatureMissing
-				err = auditLogUseCase.VerifyIntegrity(ctx, log.ID)
-				assert.Error(t, err, "verification should fail for unsigned log")
-				assert.ErrorIs(t, err, authDomain.ErrSignatureMissing, "error should be ErrSignatureMissing")
-			})
+	t.Run("VerifyBatch_MixedSignedAndLegacy", func(t *testing.T) {
+		startTime := time.Now().UTC()
+		clientID := testCtx.rootClient.ID
 
-			t.Run("VerifyBatch_MixedSignedAndLegacy", func(t *testing.T) {
-				startTime := time.Now().UTC()
-				clientID := testCtx.rootClient.ID
+		// Create 2 signed logs
+		signedUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, auditSigner, kekChain)
+		for i := 0; i < 2; i++ {
+			requestID := uuid.Must(uuid.NewV7())
+			err := signedUseCase.Create(
+				ctx,
+				requestID,
+				clientID,
+				authDomain.ReadCapability,
+				"/signed",
+				nil,
+			)
+			require.NoError(t, err)
+			time.Sleep(10 * time.Millisecond)
+		}
 
-				// Create 2 signed logs
-				signedUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, auditSigner, kekChain)
-				for i := 0; i < 2; i++ {
-					requestID := uuid.Must(uuid.NewV7())
-					err := signedUseCase.Create(
-						ctx,
-						requestID,
-						clientID,
-						authDomain.ReadCapability,
-						"/signed",
-						nil,
-					)
-					require.NoError(t, err)
-					time.Sleep(10 * time.Millisecond)
-				}
+		// Create 2 unsigned legacy logs
+		legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil, nil)
+		for i := 0; i < 2; i++ {
+			requestID := uuid.Must(uuid.NewV7())
+			err := legacyUseCase.Create(
+				ctx,
+				requestID,
+				clientID,
+				authDomain.WriteCapability,
+				"/legacy",
+				nil,
+			)
+			require.NoError(t, err)
+			time.Sleep(10 * time.Millisecond)
+		}
 
-				// Create 2 unsigned legacy logs
-				legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil, nil)
-				for i := 0; i < 2; i++ {
-					requestID := uuid.Must(uuid.NewV7())
-					err := legacyUseCase.Create(
-						ctx,
-						requestID,
-						clientID,
-						authDomain.WriteCapability,
-						"/legacy",
-						nil,
-					)
-					require.NoError(t, err)
-					time.Sleep(10 * time.Millisecond)
-				}
+		endTime := time.Now().UTC().Add(1 * time.Second)
 
-				endTime := time.Now().UTC().Add(1 * time.Second)
+		// Verify batch
+		report, err := signedUseCase.VerifyBatch(ctx, startTime, endTime)
+		require.NoError(t, err, "batch verification should succeed")
 
-				// Verify batch
-				report, err := signedUseCase.VerifyBatch(ctx, startTime, endTime)
-				require.NoError(t, err, "batch verification should succeed")
-
-				assert.Equal(t, int64(4), report.TotalChecked, "should check 4 logs")
-				assert.Equal(t, int64(2), report.SignedCount, "2 should be signed")
-				assert.Equal(t, int64(2), report.UnsignedCount, "2 should be unsigned")
-				assert.Equal(t, int64(2), report.ValidCount, "2 signed should be valid")
-				assert.Equal(t, int64(0), report.InvalidCount, "no invalid logs")
-			})
-		})
-	}
+		assert.Equal(t, int64(4), report.TotalChecked, "should check 4 logs")
+		assert.Equal(t, int64(2), report.SignedCount, "2 should be signed")
+		assert.Equal(t, int64(2), report.UnsignedCount, "2 should be unsigned")
+		assert.Equal(t, int64(2), report.ValidCount, "2 signed should be valid")
+		assert.Equal(t, int64(0), report.InvalidCount, "no invalid logs")
+	})
 }
 
 // auditLogTestContext holds test dependencies for audit log signature tests.
@@ -355,7 +339,7 @@ type auditLogTestContext struct {
 }
 
 // setupAuditLogTestContext creates a test environment with database, KEK chain, and root client.
-func setupAuditLogTestContext(t *testing.T, driver, dsn string) *auditLogTestContext {
+func setupAuditLogTestContext(t *testing.T, dsn string) *auditLogTestContext {
 	t.Helper()
 
 	// Initialize test database with migrations
@@ -429,6 +413,7 @@ func setupAuditLogTestContext(t *testing.T, driver, dsn string) *auditLogTestCon
 		rootClient: rootClient,
 	}
 }
+
 
 // cleanupAuditLogTestContext closes database and container resources.
 func cleanupAuditLogTestContext(t *testing.T, testCtx *auditLogTestContext) {

--- a/test/integration/auth_flow_test.go
+++ b/test/integration/auth_flow_test.go
@@ -24,430 +24,419 @@ func TestIntegration_Auth_CompleteFlow(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
+	// Setup
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	// Variables to store created resource IDs for later operations
+	var (
+		newClientID uuid.UUID
+	)
 
-			// Variables to store created resource IDs for later operations
-			var (
-				newClientID uuid.UUID
-			)
+	// [1/8] Test POST /v1/token - Issue authentication token
+	t.Run("01_IssueToken", func(t *testing.T) {
+		requestBody := authDTO.IssueTokenRequest{
+			ClientID:     ctx.rootClient.ID.String(),
+			ClientSecret: ctx.rootSecret,
+		}
 
-			// [1/8] Test POST /v1/token - Issue authentication token
-			t.Run("01_IssueToken", func(t *testing.T) {
-				requestBody := authDTO.IssueTokenRequest{
-					ClientID:     ctx.rootClient.ID.String(),
-					ClientSecret: ctx.rootSecret,
-				}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		var response authDTO.IssueTokenResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.Token)
+		assert.False(t, response.ExpiresAt.IsZero())
 
-				var response authDTO.IssueTokenResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.Token)
-				assert.False(t, response.ExpiresAt.IsZero())
+		// Update token for subsequent requests
+		ctx.rootToken = response.Token
+	})
 
-				// Update token for subsequent requests
-				ctx.rootToken = response.Token
-			})
-
-			// [2/8] Test POST /v1/clients - Create new client
-			t.Run("02_CreateClient", func(t *testing.T) {
-				requestBody := authDTO.CreateClientRequest{
-					Name:     "Test Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{
-						{
-							Path: "/v1/secrets/test/*",
-							Capabilities: []authDomain.Capability{
-								authDomain.ReadCapability,
-								authDomain.WriteCapability,
-							},
-						},
+	// [2/8] Test POST /v1/clients - Create new client
+	t.Run("02_CreateClient", func(t *testing.T) {
+		requestBody := authDTO.CreateClientRequest{
+			Name:     "Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path: "/v1/secrets/test/*",
+					Capabilities: []authDomain.Capability{
+						authDomain.ReadCapability,
+						authDomain.WriteCapability,
 					},
-				}
+				},
+			},
+		}
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", requestBody, true)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", requestBody, true)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var response authDTO.CreateClientResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.ID)
-				assert.NotEmpty(t, response.Secret)
+		var response authDTO.CreateClientResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.ID)
+		assert.NotEmpty(t, response.Secret)
 
-				// Store client ID for later operations
-				parsedID, err := uuid.Parse(response.ID)
-				require.NoError(t, err)
-				newClientID = parsedID
-			})
+		// Store client ID for later operations
+		parsedID, err := uuid.Parse(response.ID)
+		require.NoError(t, err)
+		newClientID = parsedID
+	})
 
-			// [3/8] Test GET /v1/clients/:id - Get client by ID
-			t.Run("03_GetClient", func(t *testing.T) {
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodGet,
-					"/v1/clients/"+newClientID.String(),
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// [3/8] Test GET /v1/clients/:id - Get client by ID
+	t.Run("03_GetClient", func(t *testing.T) {
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodGet,
+			"/v1/clients/"+newClientID.String(),
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ClientResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, newClientID.String(), response.ID)
-				assert.Equal(t, "Test Client", response.Name)
-				assert.True(t, response.IsActive)
-				assert.Len(t, response.Policies, 1)
-			})
+		var response authDTO.ClientResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, newClientID.String(), response.ID)
+		assert.Equal(t, "Test Client", response.Name)
+		assert.True(t, response.IsActive)
+		assert.Len(t, response.Policies, 1)
+	})
 
-			// [4/8] Test PUT /v1/clients/:id - Update client
-			t.Run("04_UpdateClient", func(t *testing.T) {
-				requestBody := authDTO.UpdateClientRequest{
-					Name:     "Updated Test Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{
-						{
-							Path: "/v1/secrets/*",
-							Capabilities: []authDomain.Capability{
-								authDomain.ReadCapability,
-							},
-						},
+	// [4/8] Test PUT /v1/clients/:id - Update client
+	t.Run("04_UpdateClient", func(t *testing.T) {
+		requestBody := authDTO.UpdateClientRequest{
+			Name:     "Updated Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path: "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{
+						authDomain.ReadCapability,
 					},
-				}
+				},
+			},
+		}
 
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodPut,
-					"/v1/clients/"+newClientID.String(),
-					requestBody,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodPut,
+			"/v1/clients/"+newClientID.String(),
+			requestBody,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ClientResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, "Updated Test Client", response.Name)
-				assert.True(t, response.IsActive)
-				assert.Len(t, response.Policies, 1)
-			})
+		var response authDTO.ClientResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Test Client", response.Name)
+		assert.True(t, response.IsActive)
+		assert.Len(t, response.Policies, 1)
+	})
 
-			// [5/8] Test GET /v1/clients - List clients
-			t.Run("05_ListClients", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/clients", nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// [5/8] Test GET /v1/clients - List clients
+	t.Run("05_ListClients", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/clients", nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ListClientsResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.Data)
-				assert.GreaterOrEqual(t, len(response.Data), 2, "should have at least root + new client")
-			})
+		var response authDTO.ListClientsResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.Data)
+		assert.GreaterOrEqual(t, len(response.Data), 2, "should have at least root + new client")
+	})
 
-			// [6/8] Test GET /v1/audit-logs - List audit logs
-			t.Run("06_ListAuditLogs", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/audit-logs", nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// [6/8] Test GET /v1/audit-logs - List audit logs
+	t.Run("06_ListAuditLogs", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/audit-logs", nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ListAuditLogsResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.Data)
+		var response authDTO.ListAuditLogsResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.Data)
 
-				// Verify some audit log entries exist for our operations
-				assert.GreaterOrEqual(t, len(response.Data), 5, "should have multiple audit log entries")
+		// Verify some audit log entries exist for our operations
+		assert.GreaterOrEqual(t, len(response.Data), 5, "should have multiple audit log entries")
 
-				// Verify audit log structure
-				firstLog := response.Data[0]
-				assert.NotEmpty(t, firstLog.ID)
-				assert.NotEmpty(t, firstLog.ClientID)
-				assert.NotEmpty(t, firstLog.Capability)
-			})
+		// Verify audit log structure
+		firstLog := response.Data[0]
+		assert.NotEmpty(t, firstLog.ID)
+		assert.NotEmpty(t, firstLog.ClientID)
+		assert.NotEmpty(t, firstLog.Capability)
+	})
 
-			// [7/8] Test DELETE /v1/clients/:id - Delete client (soft delete)
-			t.Run("07_DeleteClient", func(t *testing.T) {
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodDelete,
-					"/v1/clients/"+newClientID.String(),
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-				assert.Empty(t, body)
-			})
+	// [7/8] Test DELETE /v1/clients/:id - Delete client (soft delete)
+	t.Run("07_DeleteClient", func(t *testing.T) {
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodDelete,
+			"/v1/clients/"+newClientID.String(),
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Empty(t, body)
+	})
 
-			// [8/8] Test GET /v1/clients/:id - Verify client is inactive after deletion
-			t.Run("08_VerifyClientInactive", func(t *testing.T) {
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodGet,
-					"/v1/clients/"+newClientID.String(),
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// [8/8] Test GET /v1/clients/:id - Verify client is inactive after deletion
+	t.Run("08_VerifyClientInactive", func(t *testing.T) {
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodGet,
+			"/v1/clients/"+newClientID.String(),
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ClientResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.False(t, response.IsActive, "client should be inactive after deletion")
-			})
+		var response authDTO.ClientResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.False(t, response.IsActive, "client should be inactive after deletion")
+	})
 
-			// [9/10] Test DELETE /v1/token - Self-revocation
-			t.Run("09_SelfRevokeToken", func(t *testing.T) {
-				// Create a temporary client and token
-				clientRequest := authDTO.CreateClientRequest{
-					Name:     "Revoke Test Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
-				}
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
+	// [9/10] Test DELETE /v1/token - Self-revocation
+	t.Run("09_SelfRevokeToken", func(t *testing.T) {
+		// Create a temporary client and token
+		clientRequest := authDTO.CreateClientRequest{
+			Name:     "Revoke Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
+		}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var clientResponse authDTO.CreateClientResponse
-				err := json.Unmarshal(body, &clientResponse)
-				require.NoError(t, err)
+		var clientResponse authDTO.CreateClientResponse
+		err := json.Unmarshal(body, &clientResponse)
+		require.NoError(t, err)
 
-				issueRequest := authDTO.IssueTokenRequest{
-					ClientID:     clientResponse.ID,
-					ClientSecret: clientResponse.Secret,
-				}
-				resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
+		issueRequest := authDTO.IssueTokenRequest{
+			ClientID:     clientResponse.ID,
+			ClientSecret: clientResponse.Secret,
+		}
+		resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var tokenResponse authDTO.IssueTokenResponse
-				err = json.Unmarshal(body, &tokenResponse)
-				require.NoError(t, err)
-				tempToken := tokenResponse.Token
+		var tokenResponse authDTO.IssueTokenResponse
+		err = json.Unmarshal(body, &tokenResponse)
+		require.NoError(t, err)
+		tempToken := tokenResponse.Token
 
-				// Verify token works
-				req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
-				req.Header.Set("Authorization", "Bearer "+tempToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		// Verify token works
+		req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
+		req.Header.Set("Authorization", "Bearer "+tempToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				// Revoke token
-				req, _ = http.NewRequest(http.MethodDelete, ctx.server.URL+"/v1/token", nil)
-				req.Header.Set("Authorization", "Bearer "+tempToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		// Revoke token
+		req, _ = http.NewRequest(http.MethodDelete, ctx.server.URL+"/v1/token", nil)
+		req.Header.Set("Authorization", "Bearer "+tempToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-				// Verify token NO LONGER works
-				req, _ = http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
-				req.Header.Set("Authorization", "Bearer "+tempToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-			})
+		// Verify token NO LONGER works
+		req, _ = http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
+		req.Header.Set("Authorization", "Bearer "+tempToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
 
-			// [10/10] Test DELETE /v1/clients/:id/tokens - Client-wide revocation
-			t.Run("10_ClientWideRevocation", func(t *testing.T) {
-				// Create a temporary client
-				clientRequest := authDTO.CreateClientRequest{
-					Name:     "Multi Revoke Test Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
-				}
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
+	// [10/10] Test DELETE /v1/clients/:id/tokens - Client-wide revocation
+	t.Run("10_ClientWideRevocation", func(t *testing.T) {
+		// Create a temporary client
+		clientRequest := authDTO.CreateClientRequest{
+			Name:     "Multi Revoke Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
+		}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var clientResponse authDTO.CreateClientResponse
-				err := json.Unmarshal(body, &clientResponse)
-				require.NoError(t, err)
+		var clientResponse authDTO.CreateClientResponse
+		err := json.Unmarshal(body, &clientResponse)
+		require.NoError(t, err)
 
-				// Issue 2 tokens
-				issueRequest := authDTO.IssueTokenRequest{
-					ClientID:     clientResponse.ID,
-					ClientSecret: clientResponse.Secret,
-				}
+		// Issue 2 tokens
+		issueRequest := authDTO.IssueTokenRequest{
+			ClientID:     clientResponse.ID,
+			ClientSecret: clientResponse.Secret,
+		}
 
-				resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
-				var t1 authDTO.IssueTokenResponse
-				json.Unmarshal(body, &t1)
+		resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
+		var t1 authDTO.IssueTokenResponse
+		json.Unmarshal(body, &t1)
 
-				resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
-				var t2 authDTO.IssueTokenResponse
-				json.Unmarshal(body, &t2)
+		resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
+		var t2 authDTO.IssueTokenResponse
+		json.Unmarshal(body, &t2)
 
-				// Revoke all tokens for this client
-				resp, _ = ctx.makeRequest(t, http.MethodDelete, "/v1/clients/"+clientResponse.ID+"/tokens", nil, true)
-				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		// Revoke all tokens for this client
+		resp, _ = ctx.makeRequest(t, http.MethodDelete, "/v1/clients/"+clientResponse.ID+"/tokens", nil, true)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-				// Verify BOTH tokens are rejected
-				for _, token := range []string{t1.Token, t2.Token} {
-					req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
-					req.Header.Set("Authorization", "Bearer "+token)
-					resp, err = http.DefaultClient.Do(req)
-					require.NoError(t, err)
-					assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-				}
-			})
+		// Verify BOTH tokens are rejected
+		for _, token := range []string{t1.Token, t2.Token} {
+			req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		}
+	})
 
-			// [11/11] Test POST /v1/clients/:id/rotate-secret - Client secret rotation
-			t.Run("11_ClientSecretRotation", func(t *testing.T) {
-				// Create a temporary client
-				clientRequest := authDTO.CreateClientRequest{
-					Name:     "Rotation Test Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability, authDomain.RotateCapability}}},
-				}
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
+	// [11/11] Test POST /v1/clients/:id/rotate-secret - Client secret rotation
+	t.Run("11_ClientSecretRotation", func(t *testing.T) {
+		// Create a temporary client
+		clientRequest := authDTO.CreateClientRequest{
+			Name:     "Rotation Test Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability, authDomain.RotateCapability}}},
+		}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var clientResponse authDTO.CreateClientResponse
-				err := json.Unmarshal(body, &clientResponse)
-				require.NoError(t, err)
-				originalSecret := clientResponse.Secret
+		var clientResponse authDTO.CreateClientResponse
+		err := json.Unmarshal(body, &clientResponse)
+		require.NoError(t, err)
+		originalSecret := clientResponse.Secret
 
-				// Issue a token
-				issueRequest := authDTO.IssueTokenRequest{
-					ClientID:     clientResponse.ID,
-					ClientSecret: originalSecret,
-				}
-				resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
-				var tokenResponse authDTO.IssueTokenResponse
-				json.Unmarshal(body, &tokenResponse)
-				originalToken := tokenResponse.Token
+		// Issue a token
+		issueRequest := authDTO.IssueTokenRequest{
+			ClientID:     clientResponse.ID,
+			ClientSecret: originalSecret,
+		}
+		resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		var tokenResponse authDTO.IssueTokenResponse
+		json.Unmarshal(body, &tokenResponse)
+		originalToken := tokenResponse.Token
 
-				// Verify token works
-				req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
-				req.Header.Set("Authorization", "Bearer "+originalToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		// Verify token works
+		req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
+		req.Header.Set("Authorization", "Bearer "+originalToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				// Rotate secret (Self-service)
-				req, _ = http.NewRequest(http.MethodPost, ctx.server.URL+"/v1/clients/self/rotate-secret", nil)
-				req.Header.Set("Authorization", "Bearer "+originalToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				body, _ = io.ReadAll(resp.Body)
-				resp.Body.Close()
+		// Rotate secret (Self-service)
+		req, _ = http.NewRequest(http.MethodPost, ctx.server.URL+"/v1/clients/self/rotate-secret", nil)
+		req.Header.Set("Authorization", "Bearer "+originalToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
 
-				var rotateResponse authDTO.CreateClientResponse
-				err = json.Unmarshal(body, &rotateResponse)
-				require.NoError(t, err)
-				newSecret := rotateResponse.Secret
-				assert.NotEqual(t, originalSecret, newSecret)
-				assert.Equal(t, "Rotation Test Client", rotateResponse.Name)
+		var rotateResponse authDTO.CreateClientResponse
+		err = json.Unmarshal(body, &rotateResponse)
+		require.NoError(t, err)
+		newSecret := rotateResponse.Secret
+		assert.NotEqual(t, originalSecret, newSecret)
+		assert.Equal(t, "Rotation Test Client", rotateResponse.Name)
 
-				// Verify original token NO LONGER works
-				req, _ = http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
-				req.Header.Set("Authorization", "Bearer "+originalToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		// Verify original token NO LONGER works
+		req, _ = http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+clientResponse.ID, nil)
+		req.Header.Set("Authorization", "Bearer "+originalToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
-				// Verify original secret NO LONGER works for issuing new tokens
-				resp, _ = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
-				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		// Verify original secret NO LONGER works for issuing new tokens
+		resp, _ = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
-				// Verify NEW secret works for issuing new tokens
-				newIssueRequest := authDTO.IssueTokenRequest{
-					ClientID:     clientResponse.ID,
-					ClientSecret: newSecret,
-				}
-				resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", newIssueRequest, false)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		// Verify NEW secret works for issuing new tokens
+		newIssueRequest := authDTO.IssueTokenRequest{
+			ClientID:     clientResponse.ID,
+			ClientSecret: newSecret,
+		}
+		resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", newIssueRequest, false)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var newTokenResponse authDTO.IssueTokenResponse
-				json.Unmarshal(body, &newTokenResponse)
-				assert.NotEmpty(t, newTokenResponse.Token)
-			})
+		var newTokenResponse authDTO.IssueTokenResponse
+		json.Unmarshal(body, &newTokenResponse)
+		assert.NotEmpty(t, newTokenResponse.Token)
+	})
 
-			// [12/12] Test GET /v1/audit-logs - Filter by client ID
-			t.Run("12_AuditLogFilteringByClient", func(t *testing.T) {
-				// Create another client to have logs for a different client
-				clientRequest := authDTO.CreateClientRequest{
-					Name:     "Another Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
-				}
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
+	// [12/12] Test GET /v1/audit-logs - Filter by client ID
+	t.Run("12_AuditLogFilteringByClient", func(t *testing.T) {
+		// Create another client to have logs for a different client
+		clientRequest := authDTO.CreateClientRequest{
+			Name:     "Another Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{{Path: "*", Capabilities: []authDomain.Capability{authDomain.ReadCapability}}},
+		}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", clientRequest, true)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var clientResponse authDTO.CreateClientResponse
-				err := json.Unmarshal(body, &clientResponse)
-				require.NoError(t, err)
-				anotherClientID := clientResponse.ID
-				anotherClientSecret := clientResponse.Secret
+		var clientResponse authDTO.CreateClientResponse
+		err := json.Unmarshal(body, &clientResponse)
+		require.NoError(t, err)
+		anotherClientID := clientResponse.ID
+		anotherClientSecret := clientResponse.Secret
 
-				// Issue token for another client
-				issueRequest := authDTO.IssueTokenRequest{
-					ClientID:     anotherClientID,
-					ClientSecret: anotherClientSecret,
-				}
-				resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
-				require.Equal(t, http.StatusCreated, resp.StatusCode)
-				var tokenResponse authDTO.IssueTokenResponse
-				json.Unmarshal(body, &tokenResponse)
-				anotherToken := tokenResponse.Token
+		// Issue token for another client
+		issueRequest := authDTO.IssueTokenRequest{
+			ClientID:     anotherClientID,
+			ClientSecret: anotherClientSecret,
+		}
+		resp, body = ctx.makeRequest(t, http.MethodPost, "/v1/token", issueRequest, false)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		var tokenResponse authDTO.IssueTokenResponse
+		json.Unmarshal(body, &tokenResponse)
+		anotherToken := tokenResponse.Token
 
-				// Perform an action with another client (GET self)
-				req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+anotherClientID, nil)
-				req.Header.Set("Authorization", "Bearer "+anotherToken)
-				resp, err = http.DefaultClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		// Perform an action with another client (GET self)
+		req, _ := http.NewRequest(http.MethodGet, ctx.server.URL+"/v1/clients/"+anotherClientID, nil)
+		req.Header.Set("Authorization", "Bearer "+anotherToken)
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				// List audit logs filtered by the another client (using root token)
-				resp, body = ctx.makeRequest(
-					t,
-					http.MethodGet,
-					"/v1/audit-logs?client_id="+anotherClientID,
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		// List audit logs filtered by the another client (using root token)
+		resp, body = ctx.makeRequest(
+			t,
+			http.MethodGet,
+			"/v1/audit-logs?client_id="+anotherClientID,
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ListAuditLogsResponse
-				err = json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.Data)
+		var response authDTO.ListAuditLogsResponse
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.Data)
 
-				// All returned logs should belong to anotherClientID
-				for _, log := range response.Data {
-					assert.Equal(t, anotherClientID, log.ClientID)
-				}
+		// All returned logs should belong to anotherClientID
+		for _, log := range response.Data {
+			assert.Equal(t, anotherClientID, log.ClientID)
+		}
 
-				// List audit logs filtered by root client
-				resp, body = ctx.makeRequest(
-					t,
-					http.MethodGet,
-					"/v1/audit-logs?client_id="+ctx.rootClient.ID.String(),
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		// List audit logs filtered by root client
+		resp, body = ctx.makeRequest(
+			t,
+			http.MethodGet,
+			"/v1/audit-logs?client_id="+ctx.rootClient.ID.String(),
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				err = json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.Data)
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.Data)
 
-				for _, log := range response.Data {
-					assert.Equal(t, ctx.rootClient.ID.String(), log.ClientID)
-				}
-			})
+		for _, log := range response.Data {
+			assert.Equal(t, ctx.rootClient.ID.String(), log.ClientID)
+		}
+	})
 
-			t.Logf("All 12 auth endpoint tests passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("All 12 auth endpoint tests passed")
 }

--- a/test/integration/auth_lockout_test.go
+++ b/test/integration/auth_lockout_test.go
@@ -22,115 +22,104 @@ func TestIntegration_AccountLockout_CompleteFlow(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
+	// Setup with lockout: 3 max attempts, 5 minute lockout duration
+	ctx := setupIntegrationTestWithLockout(t, 3, 5*time.Minute)
+	defer teardownIntegrationTest(t, ctx)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup with lockout: 3 max attempts, 5 minute lockout duration
-			ctx := setupIntegrationTestWithLockout(t, tc.dbDriver, 3, 5*time.Minute)
-			defer teardownIntegrationTest(t, ctx)
+	var (
+		victimClientID     string
+		victimClientSecret string
+	)
 
-			var (
-				victimClientID     string
-				victimClientSecret string
-			)
-
-			// [1/5] Create a victim client that will be locked out
-			t.Run("01_CreateVictimClient", func(t *testing.T) {
-				requestBody := authDTO.CreateClientRequest{
-					Name:     "Victim Client",
-					IsActive: true,
-					Policies: []authDomain.PolicyDocument{
-						{
-							Path: "/v1/secrets/*",
-							Capabilities: []authDomain.Capability{
-								authDomain.ReadCapability,
-							},
-						},
+	// [1/5] Create a victim client that will be locked out
+	t.Run("01_CreateVictimClient", func(t *testing.T) {
+		requestBody := authDTO.CreateClientRequest{
+			Name:     "Victim Client",
+			IsActive: true,
+			Policies: []authDomain.PolicyDocument{
+				{
+					Path: "/v1/secrets/*",
+					Capabilities: []authDomain.Capability{
+						authDomain.ReadCapability,
 					},
-				}
+				},
+			},
+		}
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", requestBody, true)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/clients", requestBody, true)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var response authDTO.CreateClientResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.ID)
-				assert.NotEmpty(t, response.Secret)
+		var response authDTO.CreateClientResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.ID)
+		assert.NotEmpty(t, response.Secret)
 
-				victimClientID = response.ID
-				victimClientSecret = response.Secret
-			})
+		victimClientID = response.ID
+		victimClientSecret = response.Secret
+	})
 
-			// [2/5] Exhaust failed attempts (3×401) — each returns 401, 3rd attempt sets lock
-			t.Run("02_FailedAttempts_Accumulate", func(t *testing.T) {
-				for range 3 {
-					requestBody := authDTO.IssueTokenRequest{
-						ClientID:     victimClientID,
-						ClientSecret: "wrong-secret",
-					}
+	// [2/5] Exhaust failed attempts (3×401) — each returns 401, 3rd attempt sets lock
+	t.Run("02_FailedAttempts_Accumulate", func(t *testing.T) {
+		for range 3 {
+			requestBody := authDTO.IssueTokenRequest{
+				ClientID:     victimClientID,
+				ClientSecret: "wrong-secret",
+			}
 
-					resp, _ := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
-					assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-				}
-			})
+			resp, _ := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		}
+	})
 
-			// [3/5] Next attempt triggers lockout — 423 with client_locked error
-			t.Run("03_LockedAttempt", func(t *testing.T) {
-				requestBody := authDTO.IssueTokenRequest{
-					ClientID:     victimClientID,
-					ClientSecret: "wrong-secret",
-				}
+	// [3/5] Next attempt triggers lockout — 423 with client_locked error
+	t.Run("03_LockedAttempt", func(t *testing.T) {
+		requestBody := authDTO.IssueTokenRequest{
+			ClientID:     victimClientID,
+			ClientSecret: "wrong-secret",
+		}
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
-				assert.Equal(t, http.StatusLocked, resp.StatusCode)
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
+		assert.Equal(t, http.StatusLocked, resp.StatusCode)
 
-				var response map[string]string
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, "client_locked", response["error"])
-			})
+		var response map[string]string
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, "client_locked", response["error"])
+	})
 
-			// [4/5] Admin unlocks the victim client
-			t.Run("04_UnlockClient", func(t *testing.T) {
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodPost,
-					"/v1/clients/"+victimClientID+"/unlock",
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// [4/5] Admin unlocks the victim client
+	t.Run("04_UnlockClient", func(t *testing.T) {
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodPost,
+			"/v1/clients/"+victimClientID+"/unlock",
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				var response authDTO.ClientResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, victimClientID, response.ID)
-			})
+		var response authDTO.ClientResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, victimClientID, response.ID)
+	})
 
-			// [5/5] Victim can authenticate again after unlock
-			t.Run("05_AuthAfterUnlock", func(t *testing.T) {
-				requestBody := authDTO.IssueTokenRequest{
-					ClientID:     victimClientID,
-					ClientSecret: victimClientSecret,
-				}
+	// [5/5] Victim can authenticate again after unlock
+	t.Run("05_AuthAfterUnlock", func(t *testing.T) {
+		requestBody := authDTO.IssueTokenRequest{
+			ClientID:     victimClientID,
+			ClientSecret: victimClientSecret,
+		}
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/token", requestBody, false)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				var response authDTO.IssueTokenResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.Token)
-			})
+		var response authDTO.IssueTokenResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.Token)
+	})
 
-			t.Logf("All 5 account lockout tests passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("All 5 account lockout tests passed")
 }

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -19,42 +19,31 @@ func TestIntegration_Health_BasicChecks(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
+	// Setup
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	// [1/2] Test GET /health - Health check endpoint
+	t.Run("01_HealthCheck", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/health", nil, false)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [1/2] Test GET /health - Health check endpoint
-			t.Run("01_HealthCheck", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/health", nil, false)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response map[string]string
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, "healthy", response["status"])
+	})
 
-				var response map[string]string
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, "healthy", response["status"])
-			})
+	// [2/2] Test GET /ready - Readiness check endpoint
+	t.Run("02_ReadinessCheck", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/ready", nil, false)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [2/2] Test GET /ready - Readiness check endpoint
-			t.Run("02_ReadinessCheck", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/ready", nil, false)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response map[string]interface{}
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, "ready", response["status"])
+	})
 
-				var response map[string]interface{}
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, "ready", response["status"])
-			})
-
-			t.Logf("All 2 health endpoint tests passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("All 2 health endpoint tests passed")
 }

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -44,7 +44,6 @@ type integrationTestContext struct {
 	rootToken      string
 	rootSecret     string
 	masterKeyChain *cryptoDomain.MasterKeyChain
-	dbDriver       string
 	kmsKeyURI      string
 }
 
@@ -230,7 +229,7 @@ func createMasterKeyChainWithKMS(
 }
 
 // setupIntegrationTestWithKMS initializes all components for integration testing with KMS-encrypted master keys.
-func setupIntegrationTestWithKMS(t *testing.T, dbDriver string) *integrationTestContext {
+func setupIntegrationTestWithKMS(t *testing.T) *integrationTestContext {
 	t.Helper()
 
 	// Set Gin to test mode
@@ -320,7 +319,7 @@ func setupIntegrationTestWithKMS(t *testing.T, dbDriver string) *integrationTest
 
 	testServer := httptest.NewServer(handler)
 
-	t.Logf("Integration test setup complete for %s with KMS (client_id=%s)", dbDriver, rootClient.ID)
+	t.Logf("Integration test setup complete with KMS (client_id=%s)", rootClient.ID)
 
 	return &integrationTestContext{
 		container:      container,
@@ -330,13 +329,12 @@ func setupIntegrationTestWithKMS(t *testing.T, dbDriver string) *integrationTest
 		rootToken:      tokenOutput.PlainToken,
 		rootSecret:     rootClientOutput.PlainSecret,
 		masterKeyChain: masterKeyChain,
-		dbDriver:       dbDriver,
 		kmsKeyURI:      kmsKeyURI,
 	}
 }
 
 // setupIntegrationTest initializes all components for integration testing.
-func setupIntegrationTest(t *testing.T, dbDriver string) *integrationTestContext {
+func setupIntegrationTest(t *testing.T) *integrationTestContext {
 	t.Helper()
 
 	// Set Gin to test mode
@@ -430,7 +428,7 @@ func setupIntegrationTest(t *testing.T, dbDriver string) *integrationTestContext
 	// Create test server with the handler
 	testServer := httptest.NewServer(handler)
 
-	t.Logf("Integration test setup complete for %s with KMS (client_id=%s)", dbDriver, rootClient.ID)
+	t.Logf("Integration test setup complete with KMS (client_id=%s)", rootClient.ID)
 
 	return &integrationTestContext{
 		container:      container,
@@ -440,7 +438,6 @@ func setupIntegrationTest(t *testing.T, dbDriver string) *integrationTestContext
 		rootToken:      tokenOutput.PlainToken,
 		rootSecret:     rootClientOutput.PlainSecret,
 		masterKeyChain: masterKeyChain,
-		dbDriver:       dbDriver,
 		kmsKeyURI:      kmsKeyURI,
 	}
 }
@@ -449,7 +446,6 @@ func setupIntegrationTest(t *testing.T, dbDriver string) *integrationTestContext
 // Useful for testing token expiry behavior without long wait times.
 func setupIntegrationTestWithTokenExpiration(
 	t *testing.T,
-	dbDriver string,
 	tokenExpiration time.Duration,
 ) *integrationTestContext {
 	t.Helper()
@@ -544,8 +540,8 @@ func setupIntegrationTestWithTokenExpiration(
 	// Create test server with the handler
 	testServer := httptest.NewServer(handler)
 
-	t.Logf("Integration test setup complete for %s with custom token expiration %v (client_id=%s)",
-		dbDriver, tokenExpiration, rootClient.ID)
+	t.Logf("Integration test setup complete with custom token expiration %v (client_id=%s)",
+		tokenExpiration, rootClient.ID)
 
 	return &integrationTestContext{
 		container:      container,
@@ -555,7 +551,6 @@ func setupIntegrationTestWithTokenExpiration(
 		rootToken:      tokenOutput.PlainToken,
 		rootSecret:     rootClientOutput.PlainSecret,
 		masterKeyChain: masterKeyChain,
-		dbDriver:       dbDriver,
 		kmsKeyURI:      kmsKeyURI,
 	}
 }
@@ -563,7 +558,6 @@ func setupIntegrationTestWithTokenExpiration(
 // setupIntegrationTestWithLockout initializes all components for integration testing with account lockout enabled.
 func setupIntegrationTestWithLockout(
 	t *testing.T,
-	dbDriver string,
 	maxAttempts int,
 	lockoutDuration time.Duration,
 ) *integrationTestContext {
@@ -658,8 +652,8 @@ func setupIntegrationTestWithLockout(
 
 	testServer := httptest.NewServer(handler)
 
-	t.Logf("Integration test setup complete for %s with lockout and KMS (max_attempts=%d, client_id=%s)",
-		dbDriver, maxAttempts, rootClient.ID)
+	t.Logf("Integration test setup complete with lockout and KMS (max_attempts=%d, client_id=%s)",
+		maxAttempts, rootClient.ID)
 
 	return &integrationTestContext{
 		container:      container,
@@ -669,7 +663,6 @@ func setupIntegrationTestWithLockout(
 		rootToken:      tokenOutput.PlainToken,
 		rootSecret:     rootClientOutput.PlainSecret,
 		masterKeyChain: masterKeyChain,
-		dbDriver:       dbDriver,
 		kmsKeyURI:      kmsKeyURI,
 	}
 }
@@ -711,5 +704,5 @@ func teardownIntegrationTest(t *testing.T, ctx *integrationTestContext) {
 		t.Logf("Warning: failed to unset KMS_KEY_URI: %v", err)
 	}
 
-	t.Logf("Integration test teardown complete for %s", ctx.dbDriver)
+	t.Logf("Integration test teardown complete")
 }

--- a/test/integration/kms_flow_test.go
+++ b/test/integration/kms_flow_test.go
@@ -32,233 +32,222 @@ func TestIntegration_KMS_CompleteFlow(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
+	// Setup with KMS
+	ctx := setupIntegrationTestWithKMS(t)
+	defer teardownIntegrationTest(t, ctx)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup with KMS
-			ctx := setupIntegrationTestWithKMS(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	var (
+		//nolint:gosec // test data path, not credentials
+		secretPath       = "/kms-test/password"
+		secretPathStored = "kms-test/password"
+		plaintextValue   = []byte("kms-protected-secret-value")
+		plaintextBase64  = base64.StdEncoding.EncodeToString(plaintextValue)
+	)
 
-			var (
-				//nolint:gosec // test data path, not credentials
-				secretPath       = "/kms-test/password"
-				secretPathStored = "kms-test/password"
-				plaintextValue   = []byte("kms-protected-secret-value")
-				plaintextBase64  = base64.StdEncoding.EncodeToString(plaintextValue)
-			)
+	// [1/7] Verify KMS master key loaded
+	t.Run("01_VerifyKMSMasterKeyLoaded", func(t *testing.T) {
+		// Verify master key chain is not nil
+		assert.NotNil(t, ctx.masterKeyChain)
 
-			// [1/7] Verify KMS master key loaded
-			t.Run("01_VerifyKMSMasterKeyLoaded", func(t *testing.T) {
-				// Verify master key chain is not nil
-				assert.NotNil(t, ctx.masterKeyChain)
+		// Verify active master key exists
+		activeKey, exists := ctx.masterKeyChain.Get(ctx.masterKeyChain.ActiveMasterKeyID())
+		assert.True(t, exists, "active master key should exist")
+		assert.NotNil(t, activeKey, "active master key should not be nil")
+		assert.Equal(t, "test-key-1", activeKey.ID)
 
-				// Verify active master key exists
-				activeKey, exists := ctx.masterKeyChain.Get(ctx.masterKeyChain.ActiveMasterKeyID())
-				assert.True(t, exists, "active master key should exist")
-				assert.NotNil(t, activeKey, "active master key should not be nil")
-				assert.Equal(t, "test-key-1", activeKey.ID)
+		t.Logf("KMS master key loaded: id=%s", activeKey.ID)
+	})
 
-				t.Logf("KMS master key loaded: id=%s", activeKey.ID)
-			})
+	// [2/7] Verify KEK created with KMS master key
+	t.Run("02_VerifyKEKCreated", func(t *testing.T) {
+		// KEK was created during setup - verify it exists in database
+		// This validates KMS-decrypted master key successfully encrypted KEK
 
-			// [2/7] Verify KEK created with KMS master key
-			t.Run("02_VerifyKEKCreated", func(t *testing.T) {
-				// KEK was created during setup - verify it exists in database
-				// This validates KMS-decrypted master key successfully encrypted KEK
+		kekUseCase, err := ctx.container.KekUseCase(context.Background())
+		require.NoError(t, err)
 
-				kekUseCase, err := ctx.container.KekUseCase(context.Background())
-				require.NoError(t, err)
+		kekChain, err := kekUseCase.Unwrap(context.Background(), ctx.masterKeyChain)
+		require.NoError(t, err)
+		require.NotNil(t, kekChain, "KEK chain should not be nil")
 
-				kekChain, err := kekUseCase.Unwrap(context.Background(), ctx.masterKeyChain)
-				require.NoError(t, err)
-				require.NotNil(t, kekChain, "KEK chain should not be nil")
+		// Verify at least one KEK exists
+		activeKek, exists := kekChain.Get(kekChain.ActiveKekID())
+		assert.True(t, exists, "active KEK should exist")
+		assert.NotNil(t, activeKek, "active KEK should not be nil")
 
-				// Verify at least one KEK exists
-				activeKek, exists := kekChain.Get(kekChain.ActiveKekID())
-				assert.True(t, exists, "active KEK should exist")
-				assert.NotNil(t, activeKek, "active KEK should not be nil")
+		t.Logf("KEK created with KMS-protected master key: version=%d", activeKek.Version)
+	})
 
-				t.Logf("KEK created with KMS-protected master key: version=%d", activeKek.Version)
-			})
+	// [3/7] Create secret (encrypt with KMS-protected KEK)
+	t.Run("03_CreateSecret", func(t *testing.T) {
+		requestBody := secretsDTO.CreateOrUpdateSecretRequest{
+			Value: plaintextBase64,
+		}
 
-			// [3/7] Create secret (encrypt with KMS-protected KEK)
-			t.Run("03_CreateSecret", func(t *testing.T) {
-				requestBody := secretsDTO.CreateOrUpdateSecretRequest{
-					Value: plaintextBase64,
-				}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/secrets"+secretPath, requestBody, true)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/secrets"+secretPath, requestBody, true)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.ID)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(1), response.Version)
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.ID)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(1), response.Version)
+		t.Logf("Secret encrypted through KMS chain: path=%s", secretPath)
+	})
 
-				t.Logf("Secret encrypted through KMS chain: path=%s", secretPath)
-			})
+	// [4/7] Read secret (decrypt with KMS-protected KEK)
+	t.Run("04_ReadSecret", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [4/7] Read secret (decrypt with KMS-protected KEK)
-			t.Run("04_ReadSecret", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(1), response.Version)
+		assert.Equal(t, plaintextBase64, response.Value)
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(1), response.Version)
-				assert.Equal(t, plaintextBase64, response.Value)
+		// Verify decryption worked correctly
+		decoded, err := base64.StdEncoding.DecodeString(response.Value)
+		require.NoError(t, err)
+		assert.Equal(t, plaintextValue, decoded)
 
-				// Verify decryption worked correctly
-				decoded, err := base64.StdEncoding.DecodeString(response.Value)
-				require.NoError(t, err)
-				assert.Equal(t, plaintextValue, decoded)
+		t.Logf("Secret decrypted through KMS chain: verified")
+	})
 
-				t.Logf("Secret decrypted through KMS chain: verified")
-			})
+	// [5/7] Rotate master key with KMS
+	t.Run("05_RotateMasterKeyWithKMS", func(t *testing.T) {
+		// Generate new master key
+		newMasterKey := &cryptoDomain.MasterKey{
+			ID:  "test-key-2",
+			Key: make([]byte, 32),
+		}
+		_, err := rand.Read(newMasterKey.Key)
+		require.NoError(t, err)
 
-			// [5/7] Rotate master key with KMS
-			t.Run("05_RotateMasterKeyWithKMS", func(t *testing.T) {
-				// Generate new master key
-				newMasterKey := &cryptoDomain.MasterKey{
-					ID:  "test-key-2",
-					Key: make([]byte, 32),
-				}
-				_, err := rand.Read(newMasterKey.Key)
-				require.NoError(t, err)
+		// Encrypt new master key with KMS
+		kmsService := cryptoService.NewKMSService()
+		keeperInterface, err := kmsService.OpenKeeper(context.Background(), ctx.kmsKeyURI)
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, keeperInterface.Close())
+		}()
 
-				// Encrypt new master key with KMS
-				kmsService := cryptoService.NewKMSService()
-				keeperInterface, err := kmsService.OpenKeeper(context.Background(), ctx.kmsKeyURI)
-				require.NoError(t, err)
-				defer func() {
-					assert.NoError(t, keeperInterface.Close())
-				}()
+		keeper, ok := keeperInterface.(*secrets.Keeper)
+		require.True(t, ok)
 
-				keeper, ok := keeperInterface.(*secrets.Keeper)
-				require.True(t, ok)
+		newCiphertext, err := keeper.Encrypt(context.Background(), newMasterKey.Key)
+		require.NoError(t, err)
+		newEncodedCiphertext := base64.StdEncoding.EncodeToString(newCiphertext)
 
-				newCiphertext, err := keeper.Encrypt(context.Background(), newMasterKey.Key)
-				require.NoError(t, err)
-				newEncodedCiphertext := base64.StdEncoding.EncodeToString(newCiphertext)
+		// Get old master key ciphertext from environment
+		oldMasterKeys := os.Getenv("MASTER_KEYS")
 
-				// Get old master key ciphertext from environment
-				oldMasterKeys := os.Getenv("MASTER_KEYS")
+		// Update MASTER_KEYS with both old and new (comma-separated)
+		dualKeys := fmt.Sprintf("%s,%s:%s", oldMasterKeys, newMasterKey.ID, newEncodedCiphertext)
+		err = os.Setenv("MASTER_KEYS", dualKeys)
+		require.NoError(t, err)
 
-				// Update MASTER_KEYS with both old and new (comma-separated)
-				dualKeys := fmt.Sprintf("%s,%s:%s", oldMasterKeys, newMasterKey.ID, newEncodedCiphertext)
-				err = os.Setenv("MASTER_KEYS", dualKeys)
-				require.NoError(t, err)
+		err = os.Setenv("ACTIVE_MASTER_KEY_ID", newMasterKey.ID)
+		require.NoError(t, err)
 
-				err = os.Setenv("ACTIVE_MASTER_KEY_ID", newMasterKey.ID)
-				require.NoError(t, err)
+		// Reload master key chain with both keys
+		cfg := &config.Config{
+			KMSProvider: "localsecrets",
+			KMSKeyURI:   ctx.kmsKeyURI,
+		}
+		logger := slog.New(
+			slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}),
+		)
 
-				// Reload master key chain with both keys
-				cfg := &config.Config{
-					KMSProvider: "localsecrets",
-					KMSKeyURI:   ctx.kmsKeyURI,
-				}
-				logger := slog.New(
-					slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}),
-				)
+		// Close old chain before loading new one
+		ctx.masterKeyChain.Close()
 
-				// Close old chain before loading new one
-				ctx.masterKeyChain.Close()
+		newChain, err := cryptoDomain.LoadMasterKeyChain(
+			context.Background(),
+			cfg,
+			kmsService,
+			logger,
+		)
+		require.NoError(t, err)
+		ctx.masterKeyChain = newChain
 
-				newChain, err := cryptoDomain.LoadMasterKeyChain(
-					context.Background(),
-					cfg,
-					kmsService,
-					logger,
-				)
-				require.NoError(t, err)
-				ctx.masterKeyChain = newChain
+		// Verify both keys loaded
+		oldKey, oldExists := ctx.masterKeyChain.Get("test-key-1")
+		assert.True(t, oldExists, "old master key should still exist")
+		assert.NotNil(t, oldKey)
 
-				// Verify both keys loaded
-				oldKey, oldExists := ctx.masterKeyChain.Get("test-key-1")
-				assert.True(t, oldExists, "old master key should still exist")
-				assert.NotNil(t, oldKey)
+		activeKey, activeExists := ctx.masterKeyChain.Get("test-key-2")
+		assert.True(t, activeExists, "new master key should exist")
+		assert.NotNil(t, activeKey)
+		assert.Equal(t, "test-key-2", ctx.masterKeyChain.ActiveMasterKeyID())
 
-				activeKey, activeExists := ctx.masterKeyChain.Get("test-key-2")
-				assert.True(t, activeExists, "new master key should exist")
-				assert.NotNil(t, activeKey)
-				assert.Equal(t, "test-key-2", ctx.masterKeyChain.ActiveMasterKeyID())
+		t.Logf("Master key rotated: old=%s, new=%s (active)", "test-key-1", "test-key-2")
+	})
 
-				t.Logf("Master key rotated: old=%s, new=%s (active)", "test-key-1", "test-key-2")
-			})
+	// [6/7] Verify dual master key support (backward compatibility)
+	t.Run("06_VerifyBackwardCompatibility", func(t *testing.T) {
+		// Read old secret encrypted with old master key
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [6/7] Verify dual master key support (backward compatibility)
-			t.Run("06_VerifyBackwardCompatibility", func(t *testing.T) {
-				// Read old secret encrypted with old master key
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, plaintextBase64, response.Value)
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, plaintextBase64, response.Value)
+		// Verify old secret still decrypts correctly
+		decoded, err := base64.StdEncoding.DecodeString(response.Value)
+		require.NoError(t, err)
+		assert.Equal(t, plaintextValue, decoded)
 
-				// Verify old secret still decrypts correctly
-				decoded, err := base64.StdEncoding.DecodeString(response.Value)
-				require.NoError(t, err)
-				assert.Equal(t, plaintextValue, decoded)
+		t.Logf("Old secret decrypts after rotation: backward compatibility verified")
+	})
 
-				t.Logf("Old secret decrypts after rotation: backward compatibility verified")
-			})
+	// [7/7] Create secret after rotation (uses new master key)
+	t.Run("07_CreateSecretAfterRotation", func(t *testing.T) {
+		//nolint:gosec // test data paths, not credentials
+		newSecretPath := "/kms-test/new-secret"
+		//nolint:gosec // test data paths, not credentials
+		newSecretPathStored := "kms-test/new-secret"
+		newPlaintext := []byte("secret-created-after-rotation")
+		newPlaintextBase64 := base64.StdEncoding.EncodeToString(newPlaintext)
 
-			// [7/7] Create secret after rotation (uses new master key)
-			t.Run("07_CreateSecretAfterRotation", func(t *testing.T) {
-				//nolint:gosec // test data paths, not credentials
-				newSecretPath := "/kms-test/new-secret"
-				//nolint:gosec // test data paths, not credentials
-				newSecretPathStored := "kms-test/new-secret"
-				newPlaintext := []byte("secret-created-after-rotation")
-				newPlaintextBase64 := base64.StdEncoding.EncodeToString(newPlaintext)
+		requestBody := secretsDTO.CreateOrUpdateSecretRequest{
+			Value: newPlaintextBase64,
+		}
 
-				requestBody := secretsDTO.CreateOrUpdateSecretRequest{
-					Value: newPlaintextBase64,
-				}
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodPost,
+			"/v1/secrets"+newSecretPath,
+			requestBody,
+			true,
+		)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodPost,
-					"/v1/secrets"+newSecretPath,
-					requestBody,
-					true,
-				)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		var createResponse secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &createResponse)
+		require.NoError(t, err)
+		assert.Equal(t, newSecretPathStored, createResponse.Path)
 
-				var createResponse secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &createResponse)
-				require.NoError(t, err)
-				assert.Equal(t, newSecretPathStored, createResponse.Path)
+		// Read back and verify
+		resp, body = ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+newSecretPath, nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-				// Read back and verify
-				resp, body = ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+newSecretPath, nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var readResponse secretsDTO.SecretResponse
+		err = json.Unmarshal(body, &readResponse)
+		require.NoError(t, err)
+		assert.Equal(t, newPlaintextBase64, readResponse.Value)
 
-				var readResponse secretsDTO.SecretResponse
-				err = json.Unmarshal(body, &readResponse)
-				require.NoError(t, err)
-				assert.Equal(t, newPlaintextBase64, readResponse.Value)
+		decoded, err := base64.StdEncoding.DecodeString(readResponse.Value)
+		require.NoError(t, err)
+		assert.Equal(t, newPlaintext, decoded)
 
-				decoded, err := base64.StdEncoding.DecodeString(readResponse.Value)
-				require.NoError(t, err)
-				assert.Equal(t, newPlaintext, decoded)
+		t.Logf("New secret created with rotated master key: verified")
+	})
 
-				t.Logf("New secret created with rotated master key: verified")
-			})
-
-			t.Logf("All 7 KMS endpoint tests passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("All 7 KMS endpoint tests passed")
 }

--- a/test/integration/secrets_flow_test.go
+++ b/test/integration/secrets_flow_test.go
@@ -22,140 +22,129 @@ func TestIntegration_Secrets_CompleteFlow(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
+	// Setup
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	// Variables to store test data
+	var (
+		secretPath            = "/integration-test/password"
+		secretPathStored      = "integration-test/password" // API stores without leading slash
+		plaintextValue1       = []byte("super-secret-value-v1")
+		plaintextValue2       = []byte("super-secret-value-v2-updated")
+		plaintextValue1Base64 = base64.StdEncoding.EncodeToString(plaintextValue1)
+		plaintextValue2Base64 = base64.StdEncoding.EncodeToString(plaintextValue2)
+	)
 
-			// Variables to store test data
-			var (
-				secretPath            = "/integration-test/password"
-				secretPathStored      = "integration-test/password" // API stores without leading slash
-				plaintextValue1       = []byte("super-secret-value-v1")
-				plaintextValue2       = []byte("super-secret-value-v2-updated")
-				plaintextValue1Base64 = base64.StdEncoding.EncodeToString(plaintextValue1)
-				plaintextValue2Base64 = base64.StdEncoding.EncodeToString(plaintextValue2)
-			)
+	// [1/6] Test POST /v1/secrets/*path - Create secret (version 1)
+	t.Run("01_CreateSecret", func(t *testing.T) {
+		requestBody := secretsDTO.CreateOrUpdateSecretRequest{
+			Value: plaintextValue1Base64,
+		}
 
-			// [1/6] Test POST /v1/secrets/*path - Create secret (version 1)
-			t.Run("01_CreateSecret", func(t *testing.T) {
-				requestBody := secretsDTO.CreateOrUpdateSecretRequest{
-					Value: plaintextValue1Base64,
-				}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/secrets"+secretPath, requestBody, true)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/secrets"+secretPath, requestBody, true)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.ID)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(1), response.Version)
+		assert.Empty(t, response.Value, "value should not be returned on create")
+	})
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.ID)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(1), response.Version)
-				assert.Empty(t, response.Value, "value should not be returned on create")
-			})
+	// [2/6] Test GET /v1/secrets/*path - Read secret
+	t.Run("02_ReadSecret", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [2/6] Test GET /v1/secrets/*path - Read secret
-			t.Run("02_ReadSecret", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.ID)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(1), response.Version)
+		assert.Equal(t, plaintextValue1Base64, response.Value)
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.ID)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(1), response.Version)
-				assert.Equal(t, plaintextValue1Base64, response.Value)
+		// Verify the value decodes correctly
+		decoded, err := base64.StdEncoding.DecodeString(response.Value)
+		require.NoError(t, err)
+		assert.Equal(t, plaintextValue1, decoded)
+	})
 
-				// Verify the value decodes correctly
-				decoded, err := base64.StdEncoding.DecodeString(response.Value)
-				require.NoError(t, err)
-				assert.Equal(t, plaintextValue1, decoded)
-			})
+	// [3/6] Test POST /v1/secrets/*path - Update secret (version 2)
+	t.Run("03_UpdateSecret", func(t *testing.T) {
+		requestBody := secretsDTO.CreateOrUpdateSecretRequest{
+			Value: plaintextValue2Base64,
+		}
 
-			// [3/6] Test POST /v1/secrets/*path - Update secret (version 2)
-			t.Run("03_UpdateSecret", func(t *testing.T) {
-				requestBody := secretsDTO.CreateOrUpdateSecretRequest{
-					Value: plaintextValue2Base64,
-				}
+		resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/secrets"+secretPath, requestBody, true)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-				resp, body := ctx.makeRequest(t, http.MethodPost, "/v1/secrets"+secretPath, requestBody, true)
-				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.ID)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(2), response.Version, "version should increment to 2")
+		assert.Empty(t, response.Value, "value should not be returned on create/update")
+	})
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.NotEmpty(t, response.ID)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(2), response.Version, "version should increment to 2")
-				assert.Empty(t, response.Value, "value should not be returned on create/update")
-			})
+	// [4/6] Test GET /v1/secrets/*path - Read updated secret (latest version)
+	t.Run("04_ReadUpdatedSecret", func(t *testing.T) {
+		resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [4/6] Test GET /v1/secrets/*path - Read updated secret (latest version)
-			t.Run("04_ReadUpdatedSecret", func(t *testing.T) {
-				resp, body := ctx.makeRequest(t, http.MethodGet, "/v1/secrets"+secretPath, nil, true)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(2), response.Version, "should return latest version (v2)")
+		assert.Equal(t, plaintextValue2Base64, response.Value)
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(2), response.Version, "should return latest version (v2)")
-				assert.Equal(t, plaintextValue2Base64, response.Value)
+		// Verify the value decodes correctly
+		decoded, err := base64.StdEncoding.DecodeString(response.Value)
+		require.NoError(t, err)
+		assert.Equal(t, plaintextValue2, decoded, "should return updated value")
+	})
 
-				// Verify the value decodes correctly
-				decoded, err := base64.StdEncoding.DecodeString(response.Value)
-				require.NoError(t, err)
-				assert.Equal(t, plaintextValue2, decoded, "should return updated value")
-			})
+	// [5/6] Test GET /v1/secrets/*path?version=1 - Read specific version
+	t.Run("05_ReadSecretVersion1", func(t *testing.T) {
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodGet,
+			"/v1/secrets"+secretPath+"?version=1",
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			// [5/6] Test GET /v1/secrets/*path?version=1 - Read specific version
-			t.Run("05_ReadSecretVersion1", func(t *testing.T) {
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodGet,
-					"/v1/secrets"+secretPath+"?version=1",
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var response secretsDTO.SecretResponse
+		err := json.Unmarshal(body, &response)
+		require.NoError(t, err)
+		assert.Equal(t, secretPathStored, response.Path)
+		assert.Equal(t, uint(1), response.Version, "should return version 1")
+		assert.Equal(t, plaintextValue1Base64, response.Value)
 
-				var response secretsDTO.SecretResponse
-				err := json.Unmarshal(body, &response)
-				require.NoError(t, err)
-				assert.Equal(t, secretPathStored, response.Path)
-				assert.Equal(t, uint(1), response.Version, "should return version 1")
-				assert.Equal(t, plaintextValue1Base64, response.Value)
+		// Verify the value decodes correctly
+		decoded, err := base64.StdEncoding.DecodeString(response.Value)
+		require.NoError(t, err)
+		assert.Equal(t, plaintextValue1, decoded, "should return original v1 value")
+	})
 
-				// Verify the value decodes correctly
-				decoded, err := base64.StdEncoding.DecodeString(response.Value)
-				require.NoError(t, err)
-				assert.Equal(t, plaintextValue1, decoded, "should return original v1 value")
-			})
+	// [6/6] Test DELETE /v1/secrets/*path - Delete secret
+	t.Run("06_DeleteSecret", func(t *testing.T) {
+		resp, body := ctx.makeRequest(
+			t,
+			http.MethodDelete,
+			"/v1/secrets"+secretPath,
+			nil,
+			true,
+		)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Empty(t, body)
+	})
 
-			// [6/6] Test DELETE /v1/secrets/*path - Delete secret
-			t.Run("06_DeleteSecret", func(t *testing.T) {
-				resp, body := ctx.makeRequest(
-					t,
-					http.MethodDelete,
-					"/v1/secrets"+secretPath,
-					nil,
-					true,
-				)
-				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-				assert.Empty(t, body)
-			})
-
-			t.Logf("All 6 secrets endpoint tests passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("All 6 secrets endpoint tests passed")
 }

--- a/test/integration/tokenization_flow_test.go
+++ b/test/integration/tokenization_flow_test.go
@@ -25,18 +25,9 @@ func TestIntegration_Tokenization_CompleteFlow(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	// Setup
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
 			// Variables to store created resource IDs and tokens for later operations
 			var (
@@ -486,7 +477,5 @@ func TestIntegration_Tokenization_CompleteFlow(t *testing.T) {
 				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 			})
 
-			t.Logf("All 16 tokenization endpoint tests passed for %s", tc.dbDriver)
-		})
-	}
+	t.Logf("All 16 tokenization endpoint tests passed")
 }

--- a/test/integration/transit_flow_test.go
+++ b/test/integration/transit_flow_test.go
@@ -24,18 +24,9 @@ func TestIntegration_Transit_CompleteFlow(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	testCases := []struct {
-		name     string
-		dbDriver string
-	}{
-		{"PostgreSQL", "postgres"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup
-			ctx := setupIntegrationTest(t, tc.dbDriver)
-			defer teardownIntegrationTest(t, ctx)
+	// Setup
+	ctx := setupIntegrationTest(t)
+	defer teardownIntegrationTest(t, ctx)
 
 			// Variables to store created resource IDs and encrypted data for later operations
 			var (
@@ -327,8 +318,5 @@ func TestIntegration_Transit_CompleteFlow(t *testing.T) {
 				assert.Empty(t, body)
 			})
 
-			t.Logf("All 11 transit endpoint tests passed for %s", tc.dbDriver)
-
-		})
-	}
+	t.Logf("All 11 transit endpoint tests passed")
 }


### PR DESCRIPTION
Unified database support around PostgreSQL. Remove redundant driver parameters from test database helpers, container comments, repository tests, and integration test setup.
