### PR TITLE
refactor(auth/http): collapse audit wiring behind an Authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed MySQL support and standardized database configuration, migrations, repositories, and database-backed tests on PostgreSQL.
+- Collapsed HTTP authorization wiring behind a single `Authorizer` that pre-binds the audit log use case and logger; route registrations now read `authz.Require(<capability>)`. No HTTP contract change.
 
 ## [0.28.0] - 2026-03-23
 

--- a/internal/app/di_secrets.go
+++ b/internal/app/di_secrets.go
@@ -112,10 +112,5 @@ func (c *Container) initSecretHandler(ctx context.Context) (*secretsHTTP.SecretH
 		return nil, fmt.Errorf("failed to get secret use case for secret handler: %w", err)
 	}
 
-	auditLogUseCase, err := c.AuditLogUseCase(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get audit log use case for secret handler: %w", err)
-	}
-
-	return secretsHTTP.NewSecretHandler(secretUseCase, auditLogUseCase, c.Logger()), nil
+	return secretsHTTP.NewSecretHandler(secretUseCase, c.Logger()), nil
 }

--- a/internal/auth/http/authorizer.go
+++ b/internal/auth/http/authorizer.go
@@ -1,0 +1,120 @@
+// Package http provides HTTP middleware and utilities for authentication.
+package http
+
+import (
+	"log/slog"
+
+	"github.com/gin-contrib/requestid"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
+	apperrors "github.com/allisson/secrets/internal/errors"
+	"github.com/allisson/secrets/internal/httputil"
+)
+
+// Authorizer enforces capability-based authorization and emits audit logs
+// for every authorization attempt. Construct once at server bootstrap; call
+// Require(cap) per route.
+type Authorizer struct {
+	audit  authUseCase.AuditLogUseCase
+	logger *slog.Logger
+}
+
+// NewAuthorizer binds the audit log use case and logger so per-route middleware
+// only needs the capability.
+func NewAuthorizer(audit authUseCase.AuditLogUseCase, logger *slog.Logger) *Authorizer {
+	return &Authorizer{audit: audit, logger: logger}
+}
+
+// Require returns a Gin middleware that admits requests authorised for
+// capability cap on the request path. MUST follow AuthenticationMiddleware.
+//
+// Path Matching:
+//   - Exact: "/secrets/mykey" matches policy "/secrets/mykey"
+//   - Wildcard: "*" matches all paths
+//   - Prefix: "secret/*" matches paths starting with "secret/"
+//
+// Returns:
+//   - 401 Unauthorized: No authenticated client in context
+//   - 403 Forbidden: Insufficient permissions
+func (a *Authorizer) Require(cap authDomain.Capability) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		client, ok := GetClient(c.Request.Context())
+		if !ok || client == nil {
+			a.logger.Debug("authorization failed: no authenticated client in context")
+			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, a.logger)
+			c.Abort()
+			return
+		}
+
+		path := c.Request.URL.Path
+		allowed := client.IsAllowed(path, cap)
+
+		a.createAuditLog(c, client, cap, path, allowed)
+
+		if !allowed {
+			a.logger.Debug("authorization failed: insufficient permissions",
+				slog.String("client_id", client.ID.String()),
+				slog.String("client_name", client.Name),
+				slog.String("path", path),
+				slog.String("capability", string(cap)))
+			httputil.HandleErrorGin(c, apperrors.ErrForbidden, a.logger)
+			c.Abort()
+			return
+		}
+
+		a.logger.Debug("authorization successful",
+			slog.String("client_id", client.ID.String()),
+			slog.String("client_name", client.Name),
+			slog.String("path", path),
+			slog.String("capability", string(cap)))
+
+		ctx := WithPath(c.Request.Context(), path)
+		ctx = WithCapability(ctx, cap)
+		c.Request = c.Request.WithContext(ctx)
+
+		c.Next()
+	}
+}
+
+// createAuditLog records an authorization attempt. Extracts the request ID
+// from context (or generates a new UUIDv7), attaches client IP and user
+// agent, and logs but does not block the request on audit failure.
+func (a *Authorizer) createAuditLog(
+	c *gin.Context,
+	client *authDomain.Client,
+	cap authDomain.Capability,
+	path string,
+	allowed bool,
+) {
+	requestIDStr := requestid.Get(c)
+	requestID, err := uuid.Parse(requestIDStr)
+	if err != nil {
+		requestID = uuid.Must(uuid.NewV7())
+		a.logger.Debug("invalid request ID, generated new one",
+			slog.String("original", requestIDStr),
+			slog.String("new", requestID.String()))
+	}
+
+	metadata := map[string]any{
+		"allowed":    allowed,
+		"ip":         c.ClientIP(),
+		"user_agent": c.Request.UserAgent(),
+	}
+
+	if err := a.audit.Create(
+		c.Request.Context(),
+		requestID,
+		client.ID,
+		cap,
+		path,
+		metadata,
+	); err != nil {
+		a.logger.Error("failed to create audit log",
+			slog.Any("error", err),
+			slog.String("client_id", client.ID.String()),
+			slog.String("path", path))
+	}
+}

--- a/internal/auth/http/middleware.go
+++ b/internal/auth/http/middleware.go
@@ -5,11 +5,8 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 
-	authDomain "github.com/allisson/secrets/internal/auth/domain"
 	authService "github.com/allisson/secrets/internal/auth/service"
 	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
 	apperrors "github.com/allisson/secrets/internal/errors"
@@ -84,116 +81,5 @@ func AuthenticationMiddleware(
 
 		// Continue to next handler
 		c.Next()
-	}
-}
-
-// AuthorizationMiddleware enforces capability-based authorization for authenticated clients.
-//
-// MUST be used after AuthenticationMiddleware. Retrieves authenticated client from context,
-// extracts request path, and checks if Client.IsAllowed(path, capability) permits access.
-// Creates audit logs for all authorization attempts (both successful and failed).
-//
-// Path Matching:
-//   - Exact: "/secrets/mykey" matches policy "/secrets/mykey"
-//   - Wildcard: "*" matches all paths
-//   - Prefix: "secret/*" matches paths starting with "secret/"
-//
-// Returns:
-//   - 401 Unauthorized: No authenticated client in context
-//   - 403 Forbidden: Insufficient permissions
-func AuthorizationMiddleware(
-	capability authDomain.Capability,
-	auditLogUseCase authUseCase.AuditLogUseCase,
-	logger *slog.Logger,
-) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Retrieve authenticated client from context
-		client, ok := GetClient(c.Request.Context())
-		if !ok || client == nil {
-			logger.Debug("authorization failed: no authenticated client in context")
-			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
-			c.Abort()
-			return
-		}
-
-		// Extract request path
-		path := c.Request.URL.Path
-
-		// Check if client is allowed to perform the capability on the path
-		allowed := client.IsAllowed(path, capability)
-
-		// Create audit log for the authorization attempt
-		createAuditLog(c, auditLogUseCase, client, capability, path, allowed, logger)
-
-		if !allowed {
-			logger.Debug("authorization failed: insufficient permissions",
-				slog.String("client_id", client.ID.String()),
-				slog.String("client_name", client.Name),
-				slog.String("path", path),
-				slog.String("capability", string(capability)))
-			httputil.HandleErrorGin(c, apperrors.ErrForbidden, logger)
-			c.Abort()
-			return
-		}
-
-		logger.Debug("authorization successful",
-			slog.String("client_id", client.ID.String()),
-			slog.String("client_name", client.Name),
-			slog.String("path", path),
-			slog.String("capability", string(capability)))
-
-		// Store path and capability in context for audit logging
-		ctx := WithPath(c.Request.Context(), path)
-		ctx = WithCapability(ctx, capability)
-		c.Request = c.Request.WithContext(ctx)
-
-		// Continue to next handler
-		c.Next()
-	}
-}
-
-// createAuditLog creates an audit log entry for an authorization attempt. Extracts the
-// request ID from context or generates a new UUIDv7 if missing. Includes metadata with
-// authorization outcome, client IP, and user agent. Logs errors but does not block the
-// request if audit log creation fails.
-func createAuditLog(
-	c *gin.Context,
-	auditLogUseCase authUseCase.AuditLogUseCase,
-	client *authDomain.Client,
-	capability authDomain.Capability,
-	path string,
-	allowed bool,
-	logger *slog.Logger,
-) {
-	// Extract or generate request ID
-	requestIDStr := requestid.Get(c)
-	requestID, err := uuid.Parse(requestIDStr)
-	if err != nil {
-		requestID = uuid.Must(uuid.NewV7())
-		logger.Debug("invalid request ID, generated new one",
-			slog.String("original", requestIDStr),
-			slog.String("new", requestID.String()))
-	}
-
-	// Build metadata
-	metadata := map[string]any{
-		"allowed":    allowed,
-		"ip":         c.ClientIP(),
-		"user_agent": c.Request.UserAgent(),
-	}
-
-	// Create audit log (non-blocking on error)
-	if err := auditLogUseCase.Create(
-		c.Request.Context(),
-		requestID,
-		client.ID,
-		capability,
-		path,
-		metadata,
-	); err != nil {
-		logger.Error("failed to create audit log",
-			slog.Any("error", err),
-			slog.String("client_id", client.ID.String()),
-			slog.String("path", path))
 	}
 }

--- a/internal/auth/http/middleware_test.go
+++ b/internal/auth/http/middleware_test.go
@@ -204,7 +204,7 @@ func TestAuthenticationMiddleware(t *testing.T) {
 	})
 }
 
-func TestAuthorizationMiddleware(t *testing.T) {
+func TestAuthorizer_Require(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
@@ -232,7 +232,8 @@ func TestAuthorizationMiddleware(t *testing.T) {
 			c.Request = c.Request.WithContext(WithClient(c.Request.Context(), client))
 			c.Next()
 		})
-		r.Use(AuthorizationMiddleware(authDomain.ReadCapability, mockAuditUC, logger))
+		authz := NewAuthorizer(mockAuditUC, logger)
+		r.Use(authz.Require(authDomain.ReadCapability))
 		r.GET("/test", func(c *gin.Context) {
 			c.Status(http.StatusOK)
 		})
@@ -267,7 +268,8 @@ func TestAuthorizationMiddleware(t *testing.T) {
 			c.Request = c.Request.WithContext(WithClient(c.Request.Context(), client))
 			c.Next()
 		})
-		r.Use(AuthorizationMiddleware(authDomain.ReadCapability, mockAuditUC, logger))
+		authz := NewAuthorizer(mockAuditUC, logger)
+		r.Use(authz.Require(authDomain.ReadCapability))
 		r.GET("/test", func(c *gin.Context) {
 			c.Status(http.StatusOK)
 		})
@@ -288,7 +290,8 @@ func TestAuthorizationMiddleware(t *testing.T) {
 		mockAuditUC := usecaseMocks.NewMockAuditLogUseCase(t)
 		w := httptest.NewRecorder()
 		_, r := gin.CreateTestContext(w)
-		r.Use(AuthorizationMiddleware(authDomain.ReadCapability, mockAuditUC, logger))
+		authz := NewAuthorizer(mockAuditUC, logger)
+		r.Use(authz.Require(authDomain.ReadCapability))
 		r.GET("/test", func(c *gin.Context) {
 			c.Status(http.StatusOK)
 		})

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -133,6 +133,10 @@ func (s *Server) SetupRouter(
 			)
 		}
 
+		// Build the per-route authorizer once; it pre-binds audit + logger so
+		// route registrations only carry the capability.
+		authz := authHTTP.NewAuthorizer(auditLogUseCase, s.logger)
+
 		s.registerAuthRoutes(
 			ctx,
 			v1,
@@ -142,18 +146,18 @@ func (s *Server) SetupRouter(
 			auditLogHandler,
 			tokenUseCase,
 			tokenService,
-			auditLogUseCase,
 			authMiddleware,
 			rateLimitMiddleware,
+			authz,
 		)
-		s.registerSecretRoutes(v1, secretHandler, authMiddleware, rateLimitMiddleware, auditLogUseCase)
+		s.registerSecretRoutes(v1, secretHandler, authMiddleware, rateLimitMiddleware, authz)
 		s.registerTransitRoutes(
 			v1,
 			transitKeyHandler,
 			cryptoHandler,
 			authMiddleware,
 			rateLimitMiddleware,
-			auditLogUseCase,
+			authz,
 		)
 		s.registerTokenizationRoutes(
 			v1,
@@ -161,7 +165,7 @@ func (s *Server) SetupRouter(
 			tokenizationHandler,
 			authMiddleware,
 			rateLimitMiddleware,
-			auditLogUseCase,
+			authz,
 		)
 	}
 
@@ -178,9 +182,9 @@ func (s *Server) registerAuthRoutes(
 	auditLogHandler *authHTTP.AuditLogHandler,
 	tokenUseCase authUseCase.TokenUseCase,
 	tokenService authService.TokenService,
-	auditLogUseCase authUseCase.AuditLogUseCase,
 	authMiddleware gin.HandlerFunc,
 	rateLimitMiddleware gin.HandlerFunc,
+	authz *authHTTP.Authorizer,
 ) {
 	// Create token rate limit middleware (IP-based, for unauthenticated token endpoint)
 	var tokenRateLimitMiddleware gin.HandlerFunc
@@ -211,35 +215,35 @@ func (s *Server) registerAuthRoutes(
 	}
 	{
 		clients.POST("",
-			authHTTP.AuthorizationMiddleware(authDomain.WriteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.WriteCapability),
 			clientHandler.CreateHandler,
 		)
 		clients.GET("",
-			authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.ReadCapability),
 			clientHandler.ListHandler,
 		)
 		clients.GET("/:id",
-			authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.ReadCapability),
 			clientHandler.GetHandler,
 		)
 		clients.PUT("/:id",
-			authHTTP.AuthorizationMiddleware(authDomain.WriteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.WriteCapability),
 			clientHandler.UpdateHandler,
 		)
 		clients.DELETE("/:id",
-			authHTTP.AuthorizationMiddleware(authDomain.DeleteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DeleteCapability),
 			clientHandler.DeleteHandler,
 		)
 		clients.POST("/:id/unlock",
-			authHTTP.AuthorizationMiddleware(authDomain.WriteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.WriteCapability),
 			clientHandler.UnlockHandler,
 		)
 		clients.POST("/:id/rotate-secret",
-			authHTTP.AuthorizationMiddleware(authDomain.RotateCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.RotateCapability),
 			clientHandler.RotateSecretHandler,
 		)
 		clients.DELETE("/:id/tokens",
-			authHTTP.AuthorizationMiddleware(authDomain.DeleteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DeleteCapability),
 			clientHandler.RevokeTokensHandler,
 		)
 	}
@@ -252,7 +256,7 @@ func (s *Server) registerAuthRoutes(
 	}
 	{
 		auditLogs.GET("",
-			authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.ReadCapability),
 			auditLogHandler.ListHandler,
 		)
 	}
@@ -264,7 +268,7 @@ func (s *Server) registerSecretRoutes(
 	secretHandler *secretsHTTP.SecretHandler,
 	authMiddleware gin.HandlerFunc,
 	rateLimitMiddleware gin.HandlerFunc,
-	auditLogUseCase authUseCase.AuditLogUseCase,
+	authz *authHTTP.Authorizer,
 ) {
 	// Secret management endpoints
 	secrets := v1.Group("/secrets")
@@ -274,19 +278,19 @@ func (s *Server) registerSecretRoutes(
 	}
 	{
 		secrets.GET("",
-			authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.ReadCapability),
 			secretHandler.ListHandler,
 		)
 		secrets.POST("/*path",
-			authHTTP.AuthorizationMiddleware(authDomain.EncryptCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.EncryptCapability),
 			secretHandler.CreateOrUpdateHandler,
 		)
 		secrets.GET("/*path",
-			authHTTP.AuthorizationMiddleware(authDomain.DecryptCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DecryptCapability),
 			secretHandler.GetHandler,
 		)
 		secrets.DELETE("/*path",
-			authHTTP.AuthorizationMiddleware(authDomain.DeleteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DeleteCapability),
 			secretHandler.DeleteHandler,
 		)
 	}
@@ -299,7 +303,7 @@ func (s *Server) registerTransitRoutes(
 	cryptoHandler *transitHTTP.CryptoHandler,
 	authMiddleware gin.HandlerFunc,
 	rateLimitMiddleware gin.HandlerFunc,
-	auditLogUseCase authUseCase.AuditLogUseCase,
+	authz *authHTTP.Authorizer,
 ) {
 	// Transit encryption endpoints
 	transit := v1.Group("/transit")
@@ -312,43 +316,43 @@ func (s *Server) registerTransitRoutes(
 		{
 			// List transit keys
 			keys.GET("",
-				authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.ReadCapability),
 				transitKeyHandler.ListHandler,
 			)
 
 			// Get individual transit key
 			keys.GET("/:name",
-				authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.ReadCapability),
 				transitKeyHandler.GetHandler,
 			)
 
 			// Create new transit key
 			keys.POST("",
-				authHTTP.AuthorizationMiddleware(authDomain.WriteCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.WriteCapability),
 				transitKeyHandler.CreateHandler,
 			)
 
 			// Rotate transit key to new version
 			keys.POST("/:name/rotate",
-				authHTTP.AuthorizationMiddleware(authDomain.RotateCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.RotateCapability),
 				transitKeyHandler.RotateHandler,
 			)
 
 			// Delete transit key
 			keys.DELETE("/:name",
-				authHTTP.AuthorizationMiddleware(authDomain.DeleteCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.DeleteCapability),
 				transitKeyHandler.DeleteHandler,
 			)
 
 			// Encrypt plaintext with transit key
 			keys.POST("/:name/encrypt",
-				authHTTP.AuthorizationMiddleware(authDomain.EncryptCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.EncryptCapability),
 				cryptoHandler.EncryptHandler,
 			)
 
 			// Decrypt ciphertext with transit key
 			keys.POST("/:name/decrypt",
-				authHTTP.AuthorizationMiddleware(authDomain.DecryptCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.DecryptCapability),
 				cryptoHandler.DecryptHandler,
 			)
 		}
@@ -362,7 +366,7 @@ func (s *Server) registerTokenizationRoutes(
 	tokenizationHandler *tokenizationHTTP.TokenizationHandler,
 	authMiddleware gin.HandlerFunc,
 	rateLimitMiddleware gin.HandlerFunc,
-	auditLogUseCase authUseCase.AuditLogUseCase,
+	authz *authHTTP.Authorizer,
 ) {
 	// Tokenization endpoints
 	tokenization := v1.Group("/tokenization")
@@ -375,68 +379,68 @@ func (s *Server) registerTokenizationRoutes(
 		{
 			// List tokenization keys
 			keys.GET("",
-				authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.ReadCapability),
 				tokenizationKeyHandler.ListHandler,
 			)
 
 			// Get individual tokenization key
 			keys.GET("/:name",
-				authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.ReadCapability),
 				tokenizationKeyHandler.GetByNameHandler,
 			)
 
 			// Create new tokenization key
 			keys.POST("",
-				authHTTP.AuthorizationMiddleware(authDomain.WriteCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.WriteCapability),
 				tokenizationKeyHandler.CreateHandler,
 			)
 
 			// Rotate tokenization key to new version
 			keys.POST("/:name/rotate",
-				authHTTP.AuthorizationMiddleware(authDomain.RotateCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.RotateCapability),
 				tokenizationKeyHandler.RotateHandler,
 			)
 
 			// Delete tokenization key
 			keys.DELETE("/:name",
-				authHTTP.AuthorizationMiddleware(authDomain.DeleteCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.DeleteCapability),
 				tokenizationKeyHandler.DeleteHandler,
 			)
 
 			// Tokenize plaintext with tokenization key
 			keys.POST("/:name/tokenize",
-				authHTTP.AuthorizationMiddleware(authDomain.EncryptCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.EncryptCapability),
 				tokenizationHandler.TokenizeHandler,
 			)
 
 			// Tokenize batch of plaintexts with tokenization key
 			keys.POST("/:name/tokenize-batch",
-				authHTTP.AuthorizationMiddleware(authDomain.EncryptCapability, auditLogUseCase, s.logger),
+				authz.Require(authDomain.EncryptCapability),
 				tokenizationHandler.TokenizeBatchHandler,
 			)
 		}
 
 		// Detokenize token to retrieve plaintext
 		tokenization.POST("/detokenize",
-			authHTTP.AuthorizationMiddleware(authDomain.DecryptCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DecryptCapability),
 			tokenizationHandler.DetokenizeHandler,
 		)
 
 		// Detokenize batch of tokens to retrieve plaintexts
 		tokenization.POST("/detokenize-batch",
-			authHTTP.AuthorizationMiddleware(authDomain.DecryptCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DecryptCapability),
 			tokenizationHandler.DetokenizeBatchHandler,
 		)
 
 		// Validate token existence and validity
 		tokenization.POST("/validate",
-			authHTTP.AuthorizationMiddleware(authDomain.ReadCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.ReadCapability),
 			tokenizationHandler.ValidateHandler,
 		)
 
 		// Revoke token to prevent further detokenization
 		tokenization.POST("/revoke",
-			authHTTP.AuthorizationMiddleware(authDomain.DeleteCapability, auditLogUseCase, s.logger),
+			authz.Require(authDomain.DeleteCapability),
 			tokenizationHandler.RevokeHandler,
 		)
 	}

--- a/internal/secrets/http/secret_handler.go
+++ b/internal/secrets/http/secret_handler.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
 	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
 	"github.com/allisson/secrets/internal/httputil"
 	secretsDomain "github.com/allisson/secrets/internal/secrets/domain"
@@ -23,23 +22,21 @@ import (
 )
 
 // SecretHandler handles HTTP requests for secret management operations.
-// It coordinates authentication, authorization, and audit logging with the SecretUseCase.
+// Authentication, authorization, and audit logging are enforced by HTTP
+// middleware before the handler runs.
 type SecretHandler struct {
-	secretUseCase   secretsUseCase.SecretUseCase
-	auditLogUseCase authUseCase.AuditLogUseCase
-	logger          *slog.Logger
+	secretUseCase secretsUseCase.SecretUseCase
+	logger        *slog.Logger
 }
 
 // NewSecretHandler creates a new secret handler with required dependencies.
 func NewSecretHandler(
 	secretUseCase secretsUseCase.SecretUseCase,
-	auditLogUseCase authUseCase.AuditLogUseCase,
 	logger *slog.Logger,
 ) *SecretHandler {
 	return &SecretHandler{
-		secretUseCase:   secretUseCase,
-		auditLogUseCase: auditLogUseCase,
-		logger:          logger,
+		secretUseCase: secretUseCase,
+		logger:        logger,
 	}
 }
 

--- a/internal/secrets/http/secret_handler_test.go
+++ b/internal/secrets/http/secret_handler_test.go
@@ -31,7 +31,7 @@ func setupTestHandler(t *testing.T) (*SecretHandler, *mocks.MockSecretUseCase) {
 	mockSecretUseCase := mocks.NewMockSecretUseCase(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	handler := NewSecretHandler(mockSecretUseCase, nil, logger)
+	handler := NewSecretHandler(mockSecretUseCase, logger)
 
 	return handler, mockSecretUseCase
 }


### PR DESCRIPTION
## Summary

- Introduce `internal/auth/http/Authorizer`: built once at server bootstrap with `auditLogUseCase` + logger pre-bound; expose `Require(cap)` per route.
- Route registrations shrink from `AuthorizationMiddleware(cap, audit, logger)` to `authz.Require(cap)`; `auditLogUseCase` drops out of all four `registerXxxRoutes` signatures.
- Remove dead `auditLogUseCase` field and constructor arg from `SecretHandler` (was injected, never called).
- `AuthenticationMiddleware` stays group-shared and untouched — AuthN and AuthZ have different lifecycles.

Behaviour is unchanged; the diff is a wiring refactor.

## Test plan

- [x] `make build`
- [x] `make test` — 1533 tests pass
- [x] `make lint` — 0 issues, govulncheck clean
- [ ] Smoke-test a representative authenticated route in a running server (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)