### PR TITLE
refactor: extract metrics into usecase decorator layer

### DIFF
--- a/internal/app/di.go
+++ b/internal/app/di.go
@@ -364,18 +364,15 @@ func (c *Container) initMetricsProvider(ctx context.Context) (*metrics.Provider,
 	return provider, nil
 }
 
-// initBusinessMetrics creates the business metrics recorder if metrics are enabled.
+// initBusinessMetrics creates the business metrics recorder.
+// Only called when MetricsEnabled is true.
 func (c *Container) initBusinessMetrics(ctx context.Context) (metrics.BusinessMetrics, error) {
-	if !c.config.MetricsEnabled {
-		return metrics.NewNoOpBusinessMetrics(), nil
-	}
-
 	provider, err := c.MetricsProvider(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get metrics provider: %w", err)
 	}
 	if provider == nil {
-		return metrics.NewNoOpBusinessMetrics(), nil
+		return nil, fmt.Errorf("metrics provider is nil despite MetricsEnabled=true")
 	}
 
 	businessMetrics, err := metrics.NewBusinessMetrics(provider.MeterProvider(), c.config.MetricsNamespace)

--- a/internal/app/di_auth.go
+++ b/internal/app/di_auth.go
@@ -8,7 +8,6 @@ import (
 	authRepository "github.com/allisson/secrets/internal/auth/repository"
 	authService "github.com/allisson/secrets/internal/auth/service"
 	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
-	"github.com/allisson/secrets/internal/metrics"
 )
 
 // SecretService returns the secret service for authentication operations.
@@ -228,22 +227,21 @@ func (c *Container) initClientUseCase(ctx context.Context) (authUseCase.ClientUs
 
 	secretService := c.SecretService()
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for client use case: %w", err)
-		}
-	}
-
-	return authUseCase.NewClientUseCase(
+	inner := authUseCase.NewClientUseCase(
 		txManager,
 		clientRepository,
 		tokenRepository,
 		auditLogUseCase,
 		secretService,
-		bm,
-	), nil
+	)
+	if !c.config.MetricsEnabled {
+		return inner, nil
+	}
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for client use case: %w", err)
+	}
+	return authUseCase.NewMetricsClientUseCase(inner, bm, "auth"), nil
 }
 
 // initTokenService creates the token service for authentication.
@@ -291,23 +289,22 @@ func (c *Container) initTokenUseCase(ctx context.Context) (authUseCase.TokenUseC
 	secretService := c.SecretService()
 	tokenService := c.TokenService()
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for token use case: %w", err)
-		}
-	}
-
-	return authUseCase.NewTokenUseCase(
+	inner := authUseCase.NewTokenUseCase(
 		c.config,
 		clientRepository,
 		tokenRepository,
 		auditLogUseCase,
 		secretService,
 		tokenService,
-		bm,
-	), nil
+	)
+	if !c.config.MetricsEnabled {
+		return inner, nil
+	}
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for token use case: %w", err)
+	}
+	return authUseCase.NewMetricsTokenUseCase(inner, bm, "auth"), nil
 }
 
 // initAuditLogUseCase creates the audit log use case with all its dependencies.
@@ -322,15 +319,15 @@ func (c *Container) initAuditLogUseCase(ctx context.Context) (authUseCase.AuditL
 		return nil, fmt.Errorf("failed to get key signer for audit log use case: %w", err)
 	}
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for audit log use case: %w", err)
-		}
+	inner := authUseCase.NewAuditLogUseCase(auditLogRepository, keySigner)
+	if !c.config.MetricsEnabled {
+		return inner, nil
 	}
-
-	return authUseCase.NewAuditLogUseCase(auditLogRepository, keySigner, bm), nil
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for audit log use case: %w", err)
+	}
+	return authUseCase.NewMetricsAuditLogUseCase(inner, bm, "auth"), nil
 }
 
 // initClientHandler creates the client HTTP handler with all its dependencies.

--- a/internal/app/di_secrets.go
+++ b/internal/app/di_secrets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/allisson/secrets/internal/metrics"
 	secretsHTTP "github.com/allisson/secrets/internal/secrets/http"
 	secretsRepository "github.com/allisson/secrets/internal/secrets/repository"
 	secretsUseCase "github.com/allisson/secrets/internal/secrets/usecase"
@@ -89,21 +88,20 @@ func (c *Container) initSecretUseCase(ctx context.Context) (secretsUseCase.Secre
 		return nil, fmt.Errorf("failed to get secret repository for secret use case: %w", err)
 	}
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for secret use case: %w", err)
-		}
-	}
-
-	return secretsUseCase.NewSecretUseCase(
+	inner := secretsUseCase.NewSecretUseCase(
 		txManager,
 		kr,
 		secretRepository,
 		c.config.SecretValueSizeLimitBytes,
-		bm,
-	), nil
+	)
+	if !c.config.MetricsEnabled {
+		return inner, nil
+	}
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for secret use case: %w", err)
+	}
+	return secretsUseCase.NewMetricsSecretUseCase(inner, bm, "secrets"), nil
 }
 
 func (c *Container) initSecretHandler(ctx context.Context) (*secretsHTTP.SecretHandler, error) {

--- a/internal/app/di_tokenization.go
+++ b/internal/app/di_tokenization.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/allisson/secrets/internal/metrics"
 	tokenizationHTTP "github.com/allisson/secrets/internal/tokenization/http"
 	tokenizationRepository "github.com/allisson/secrets/internal/tokenization/repository"
 	tokenizationUseCase "github.com/allisson/secrets/internal/tokenization/usecase"
@@ -165,20 +164,15 @@ func (c *Container) initTokenizationKeyUseCase(
 		return nil, fmt.Errorf("failed to get keyring for tokenization key use case: %w", err)
 	}
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for tokenization key use case: %w", err)
-		}
+	inner := tokenizationUseCase.NewTokenizationKeyUseCase(txManager, tokenizationKeyRepository, kr)
+	if !c.config.MetricsEnabled {
+		return inner, nil
 	}
-
-	return tokenizationUseCase.NewTokenizationKeyUseCase(
-		txManager,
-		tokenizationKeyRepository,
-		kr,
-		bm,
-	), nil
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for tokenization key use case: %w", err)
+	}
+	return tokenizationUseCase.NewMetricsTokenizationKeyUseCase(inner, bm, "tokenization"), nil
 }
 
 func (c *Container) initTokenizationUseCase(
@@ -209,22 +203,21 @@ func (c *Container) initTokenizationUseCase(
 
 	hashService := tokenizationUseCase.NewSHA256HashService()
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for tokenization use case: %w", err)
-		}
-	}
-
-	return tokenizationUseCase.NewTokenizationUseCase(
+	inner := tokenizationUseCase.NewTokenizationUseCase(
 		txManager,
 		tokenizationKeyRepository,
 		tokenRepository,
 		hashService,
 		kr,
-		bm,
-	), nil
+	)
+	if !c.config.MetricsEnabled {
+		return inner, nil
+	}
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for tokenization use case: %w", err)
+	}
+	return tokenizationUseCase.NewMetricsTokenizationUseCase(inner, bm, "tokenization"), nil
 }
 
 func (c *Container) initTokenizationKeyHandler(

--- a/internal/app/di_transit.go
+++ b/internal/app/di_transit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/allisson/secrets/internal/metrics"
 	transitHTTP "github.com/allisson/secrets/internal/transit/http"
 	transitRepository "github.com/allisson/secrets/internal/transit/repository"
 	transitUseCase "github.com/allisson/secrets/internal/transit/usecase"
@@ -105,15 +104,15 @@ func (c *Container) initTransitKeyUseCase(ctx context.Context) (transitUseCase.T
 		return nil, fmt.Errorf("failed to get keyring for transit key use case: %w", err)
 	}
 
-	var bm metrics.BusinessMetrics
-	if c.config.MetricsEnabled {
-		bm, err = c.BusinessMetrics(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get business metrics for transit key use case: %w", err)
-		}
+	inner := transitUseCase.NewTransitKeyUseCase(txManager, transitKeyRepository, kr)
+	if !c.config.MetricsEnabled {
+		return inner, nil
 	}
-
-	return transitUseCase.NewTransitKeyUseCase(txManager, transitKeyRepository, kr, bm), nil
+	bm, err := c.BusinessMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business metrics for transit key use case: %w", err)
+	}
+	return transitUseCase.NewMetricsTransitKeyUseCase(inner, bm, "transit"), nil
 }
 
 func (c *Container) initTransitKeyHandler(ctx context.Context) (*transitHTTP.TransitKeyHandler, error) {

--- a/internal/auth/usecase/audit_log_usecase.go
+++ b/internal/auth/usecase/audit_log_usecase.go
@@ -11,7 +11,6 @@ import (
 	authDomain "github.com/allisson/secrets/internal/auth/domain"
 	apperrors "github.com/allisson/secrets/internal/errors"
 	"github.com/allisson/secrets/internal/keyring"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 )
 
 // auditLogUseCase implements AuditLogUseCase interface for recording and verifying audit logs.
@@ -19,7 +18,6 @@ import (
 type auditLogUseCase struct {
 	auditLogRepo AuditLogRepository
 	keySigner    keyring.KeySigner
-	metrics      metricsLib.BusinessMetrics
 }
 
 // Create records an audit log entry for an authenticated operation. Generates a unique
@@ -34,9 +32,6 @@ func (a *auditLogUseCase) Create(
 	path string,
 	metadata map[string]any,
 ) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, a.metrics, "auth", "audit_log_create", start, err) }()
-
 	// Create the audit log entity
 	// Truncate timestamp to microsecond precision to match database storage (PostgreSQL TIMESTAMPTZ
 	// ). This ensures the signature matches the value
@@ -89,9 +84,6 @@ func (a *auditLogUseCase) ListCursor(
 	createdAtFrom, createdAtTo *time.Time,
 	clientID *uuid.UUID,
 ) (result []*authDomain.AuditLog, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, a.metrics, "auth", "audit_log_list", start, err) }()
-
 	auditLogs, err := a.auditLogRepo.ListCursor(ctx, afterID, limit, createdAtFrom, createdAtTo, clientID)
 	if err != nil {
 		return nil, apperrors.Wrap(err, "failed to list audit logs with cursor")
@@ -109,9 +101,6 @@ func (a *auditLogUseCase) DeleteOlderThan(
 	days int,
 	dryRun bool,
 ) (count int64, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, a.metrics, "auth", "audit_log_delete", start, err) }()
-
 	// Calculate cutoff date in UTC
 	cutoffDate := time.Now().UTC().AddDate(0, 0, -days)
 
@@ -128,9 +117,6 @@ func (a *auditLogUseCase) DeleteOlderThan(
 // Retrieves the log from the repository and validates its HMAC-SHA256 signature
 // using the KEK referenced by log.KekID. Returns nil if valid, error otherwise.
 func (a *auditLogUseCase) VerifyIntegrity(ctx context.Context, id uuid.UUID) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, a.metrics, "auth", "audit_log_verify", start, err) }()
-
 	// Retrieve audit log from repository
 	auditLog, err := a.auditLogRepo.Get(ctx, id)
 	if err != nil {
@@ -164,9 +150,6 @@ func (a *auditLogUseCase) VerifyBatch(
 	ctx context.Context,
 	startTime, endTime time.Time,
 ) (result *VerificationReport, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, a.metrics, "auth", "audit_log_verify_batch", start, err) }()
-
 	report := &VerificationReport{
 		InvalidLogs: []uuid.UUID{},
 	}
@@ -233,11 +216,9 @@ func (a *auditLogUseCase) VerifyBatch(
 func NewAuditLogUseCase(
 	auditLogRepo AuditLogRepository,
 	keySigner keyring.KeySigner,
-	bm metricsLib.BusinessMetrics,
 ) AuditLogUseCase {
 	return &auditLogUseCase{
 		auditLogRepo: auditLogRepo,
 		keySigner:    keySigner,
-		metrics:      bm,
 	}
 }

--- a/internal/auth/usecase/audit_log_usecase_test.go
+++ b/internal/auth/usecase/audit_log_usecase_test.go
@@ -94,7 +94,7 @@ func TestAuditLogUseCase_Create(t *testing.T) {
 			Once()
 
 		// Create use case
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		// Execute
 		err := useCase.Create(ctx, requestID, clientID, capability, path, metadata)
@@ -133,7 +133,7 @@ func TestAuditLogUseCase_Create(t *testing.T) {
 			Once()
 
 		// Create use case
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		// Execute with nil metadata
 		err := useCase.Create(ctx, requestID, clientID, capability, path, nil)
@@ -169,7 +169,7 @@ func TestAuditLogUseCase_Create(t *testing.T) {
 			Times(3)
 
 		// Create use case
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		// Execute multiple times
 		for i := 0; i < 3; i++ {
@@ -223,7 +223,7 @@ func TestAuditLogUseCase_Create(t *testing.T) {
 			Times(len(capabilities))
 
 		// Create use case
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		// Execute for each capability
 		for _, cap := range capabilities {
@@ -256,7 +256,7 @@ func TestAuditLogUseCase_Create(t *testing.T) {
 			Once()
 
 		// Create use case
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		// Execute
 		err := useCase.Create(ctx, requestID, clientID, capability, path, metadata)
@@ -288,7 +288,7 @@ func TestAuditLogUseCase_Create(t *testing.T) {
 			Once()
 
 		// Create use case
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		// Execute
 		beforeCreate := time.Now().UTC()
@@ -349,7 +349,7 @@ func TestAuditLogUseCase_DeleteOlderThan(t *testing.T) {
 			Return(expectedCount, nil).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		count, err := useCase.DeleteOlderThan(ctx, days, dryRun)
 
@@ -369,7 +369,7 @@ func TestAuditLogUseCase_DeleteOlderThan(t *testing.T) {
 			Return(expectedCount, nil).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		count, err := useCase.DeleteOlderThan(ctx, days, dryRun)
 
@@ -390,7 +390,7 @@ func TestAuditLogUseCase_DeleteOlderThan(t *testing.T) {
 			Return(expectedCount, nil).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		count, err := useCase.DeleteOlderThan(ctx, days, dryRun)
 
@@ -420,7 +420,7 @@ func TestAuditLogUseCase_DeleteOlderThan(t *testing.T) {
 					Return(tc.expectedCount, nil).
 					Once()
 
-				useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+				useCase := NewAuditLogUseCase(mockRepo, nil)
 
 				count, err := useCase.DeleteOlderThan(ctx, tc.days, tc.dryRun)
 
@@ -442,7 +442,7 @@ func TestAuditLogUseCase_DeleteOlderThan(t *testing.T) {
 			Return(int64(0), repositoryErr).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		count, err := useCase.DeleteOlderThan(ctx, days, dryRun)
 
@@ -472,7 +472,7 @@ func TestAuditLogUseCase_ListCursor(t *testing.T) {
 			Return(expectedLogs, nil).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		logs, err := useCase.ListCursor(ctx, &afterID, limit, &from, &to, &clientID)
 
@@ -488,7 +488,7 @@ func TestAuditLogUseCase_ListCursor(t *testing.T) {
 			Return([]*authDomain.AuditLog{}, nil).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		logs, err := useCase.ListCursor(ctx, nil, 10, nil, nil, nil)
 
@@ -504,7 +504,7 @@ func TestAuditLogUseCase_ListCursor(t *testing.T) {
 			Return(nil, errors.New("db error")).
 			Once()
 
-		useCase := NewAuditLogUseCase(mockRepo, nil, nil)
+		useCase := NewAuditLogUseCase(mockRepo, nil)
 
 		logs, err := useCase.ListCursor(ctx, nil, 10, nil, nil, nil)
 

--- a/internal/auth/usecase/client_usecase.go
+++ b/internal/auth/usecase/client_usecase.go
@@ -10,7 +10,6 @@ import (
 	authDomain "github.com/allisson/secrets/internal/auth/domain"
 	authService "github.com/allisson/secrets/internal/auth/service"
 	"github.com/allisson/secrets/internal/database"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 )
 
 // clientUseCase implements ClientUseCase interface for managing client authentication.
@@ -20,7 +19,6 @@ type clientUseCase struct {
 	tokenRepo       TokenRepository
 	auditLogUseCase AuditLogUseCase
 	secretService   authService.SecretService
-	metrics         metricsLib.BusinessMetrics
 }
 
 // Create generates and persists a new Client with a random secret.
@@ -30,9 +28,6 @@ func (c *clientUseCase) Create(
 	ctx context.Context,
 	createClientInput *authDomain.CreateClientInput,
 ) (result *authDomain.CreateClientOutput, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_create", start, err) }()
-
 	// Generate a secure random secret
 	plainSecret, hashedSecret, err := c.secretService.GenerateSecret()
 	if err != nil {
@@ -72,9 +67,6 @@ func (c *clientUseCase) Update(
 	clientID uuid.UUID,
 	updateClientInput *authDomain.UpdateClientInput,
 ) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_update", start, err) }()
-
 	// Get the existing client
 	client, err := c.clientRepo.Get(ctx, clientID)
 	if err != nil {
@@ -93,8 +85,6 @@ func (c *clientUseCase) Update(
 // Get retrieves a client by ID.
 // Returns ErrClientNotFound if the client doesn't exist.
 func (c *clientUseCase) Get(ctx context.Context, clientID uuid.UUID) (result *authDomain.Client, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_get", start, err) }()
 	result, err = c.clientRepo.Get(ctx, clientID)
 	return
 }
@@ -102,9 +92,6 @@ func (c *clientUseCase) Get(ctx context.Context, clientID uuid.UUID) (result *au
 // Delete performs a soft delete on a client by setting IsActive to false.
 // This prevents the client from authenticating while preserving audit history.
 func (c *clientUseCase) Delete(ctx context.Context, clientID uuid.UUID) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_delete", start, err) }()
-
 	// Get the existing client
 	client, err := c.clientRepo.Get(ctx, clientID)
 	if err != nil {
@@ -126,8 +113,6 @@ func (c *clientUseCase) ListCursor(
 	afterID *uuid.UUID,
 	limit int,
 ) (result []*authDomain.Client, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_list", start, err) }()
 	result, err = c.clientRepo.ListCursor(ctx, afterID, limit)
 	return
 }
@@ -135,9 +120,6 @@ func (c *clientUseCase) ListCursor(
 // Unlock clears the lockout state for a client, resetting failed_attempts and locked_until.
 // Returns ErrClientNotFound if the client doesn't exist.
 func (c *clientUseCase) Unlock(ctx context.Context, clientID uuid.UUID) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_unlock", start, err) }()
-
 	if _, err = c.clientRepo.Get(ctx, clientID); err != nil {
 		return err
 	}
@@ -146,9 +128,6 @@ func (c *clientUseCase) Unlock(ctx context.Context, clientID uuid.UUID) (err err
 
 // RevokeTokens marks all active tokens for a specific client as revoked.
 func (c *clientUseCase) RevokeTokens(ctx context.Context, clientID uuid.UUID) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_revoke_tokens", start, err) }()
-
 	// Check if client exists
 	if _, err = c.clientRepo.Get(ctx, clientID); err != nil {
 		return err
@@ -179,9 +158,6 @@ func (c *clientUseCase) RotateSecret(
 	ctx context.Context,
 	clientID uuid.UUID,
 ) (result *authDomain.CreateClientOutput, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, c.metrics, "auth", "client_rotate_secret", start, err) }()
-
 	var output *authDomain.CreateClientOutput
 
 	err = c.txManager.WithTx(ctx, func(ctx context.Context) error {
@@ -246,7 +222,6 @@ func NewClientUseCase(
 	tokenRepo TokenRepository,
 	auditLogUseCase AuditLogUseCase,
 	secretService authService.SecretService,
-	bm metricsLib.BusinessMetrics,
 ) ClientUseCase {
 	return &clientUseCase{
 		txManager:       txManager,
@@ -254,6 +229,5 @@ func NewClientUseCase(
 		tokenRepo:       tokenRepo,
 		auditLogUseCase: auditLogUseCase,
 		secretService:   secretService,
-		metrics:         bm,
 	}
 }

--- a/internal/auth/usecase/client_usecase_test.go
+++ b/internal/auth/usecase/client_usecase_test.go
@@ -56,7 +56,6 @@ func TestClientUseCase_Create(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		output, err := uc.Create(ctx, createInput)
 
@@ -98,7 +97,6 @@ func TestClientUseCase_Update(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		err := uc.Update(ctx, clientID, updateInput)
 
@@ -130,7 +128,6 @@ func TestClientUseCase_Get(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		client, err := uc.Get(ctx, clientID)
 
@@ -155,7 +152,6 @@ func TestClientUseCase_RevokeTokens(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 
 		clientID := uuid.Must(uuid.NewV7())
@@ -184,7 +180,6 @@ func TestClientUseCase_RevokeTokens(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 
 		clientID := uuid.Must(uuid.NewV7())
@@ -223,7 +218,6 @@ func TestClientUseCase_Delete(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		err := uc.Delete(ctx, clientID)
 
@@ -256,7 +250,6 @@ func TestClientUseCase_Unlock(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		err := uc.Unlock(ctx, clientID)
 
@@ -312,7 +305,6 @@ func TestClientUseCase_RotateSecret(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		output, err := uc.RotateSecret(ctx, clientID)
 
@@ -347,7 +339,6 @@ func TestClientUseCase_RotateSecret(t *testing.T) {
 			mockTokenRepo,
 			mockAuditLogUseCase,
 			mockSecretService,
-			nil,
 		)
 		output, err := uc.RotateSecret(ctx, clientID)
 

--- a/internal/auth/usecase/metrics_audit_log_usecase.go
+++ b/internal/auth/usecase/metrics_audit_log_usecase.go
@@ -1,0 +1,83 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/metrics"
+)
+
+type metricsAuditLogUseCase struct {
+	inner  AuditLogUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsAuditLogUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsAuditLogUseCase(
+	inner AuditLogUseCase,
+	bm metrics.BusinessMetrics,
+	domain string,
+) AuditLogUseCase {
+	return &metricsAuditLogUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsAuditLogUseCase) Create(
+	ctx context.Context,
+	requestID uuid.UUID,
+	clientID uuid.UUID,
+	capability authDomain.Capability,
+	path string,
+	metadata map[string]any,
+) (err error) {
+	start := time.Now()
+	err = m.inner.Create(ctx, requestID, clientID, capability, path, metadata)
+	metrics.Record(ctx, m.bm, m.domain, "audit_log_create", start, err)
+	return
+}
+
+func (m *metricsAuditLogUseCase) ListCursor(
+	ctx context.Context,
+	afterID *uuid.UUID,
+	limit int,
+	createdAtFrom, createdAtTo *time.Time,
+	clientID *uuid.UUID,
+) (result []*authDomain.AuditLog, err error) {
+	start := time.Now()
+	result, err = m.inner.ListCursor(ctx, afterID, limit, createdAtFrom, createdAtTo, clientID)
+	metrics.Record(ctx, m.bm, m.domain, "audit_log_list", start, err)
+	return
+}
+
+func (m *metricsAuditLogUseCase) DeleteOlderThan(
+	ctx context.Context,
+	days int,
+	dryRun bool,
+) (count int64, err error) {
+	start := time.Now()
+	count, err = m.inner.DeleteOlderThan(ctx, days, dryRun)
+	metrics.Record(ctx, m.bm, m.domain, "audit_log_delete", start, err)
+	return
+}
+
+func (m *metricsAuditLogUseCase) VerifyIntegrity(ctx context.Context, id uuid.UUID) (err error) {
+	start := time.Now()
+	err = m.inner.VerifyIntegrity(ctx, id)
+	metrics.Record(ctx, m.bm, m.domain, "audit_log_verify", start, err)
+	return
+}
+
+func (m *metricsAuditLogUseCase) VerifyBatch(
+	ctx context.Context,
+	startTime, endTime time.Time,
+) (result *VerificationReport, err error) {
+	start := time.Now()
+	result, err = m.inner.VerifyBatch(ctx, startTime, endTime)
+	metrics.Record(ctx, m.bm, m.domain, "audit_log_verify_batch", start, err)
+	return
+}
+
+var _ AuditLogUseCase = (*metricsAuditLogUseCase)(nil)

--- a/internal/auth/usecase/metrics_client_usecase.go
+++ b/internal/auth/usecase/metrics_client_usecase.go
@@ -1,0 +1,97 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/metrics"
+)
+
+type metricsClientUseCase struct {
+	inner  ClientUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsClientUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsClientUseCase(inner ClientUseCase, bm metrics.BusinessMetrics, domain string) ClientUseCase {
+	return &metricsClientUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsClientUseCase) Create(
+	ctx context.Context,
+	input *authDomain.CreateClientInput,
+) (result *authDomain.CreateClientOutput, err error) {
+	start := time.Now()
+	result, err = m.inner.Create(ctx, input)
+	metrics.Record(ctx, m.bm, m.domain, "client_create", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) Update(
+	ctx context.Context,
+	clientID uuid.UUID,
+	input *authDomain.UpdateClientInput,
+) (err error) {
+	start := time.Now()
+	err = m.inner.Update(ctx, clientID, input)
+	metrics.Record(ctx, m.bm, m.domain, "client_update", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) Get(
+	ctx context.Context,
+	clientID uuid.UUID,
+) (result *authDomain.Client, err error) {
+	start := time.Now()
+	result, err = m.inner.Get(ctx, clientID)
+	metrics.Record(ctx, m.bm, m.domain, "client_get", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) Delete(ctx context.Context, clientID uuid.UUID) (err error) {
+	start := time.Now()
+	err = m.inner.Delete(ctx, clientID)
+	metrics.Record(ctx, m.bm, m.domain, "client_delete", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) ListCursor(
+	ctx context.Context,
+	afterID *uuid.UUID,
+	limit int,
+) (result []*authDomain.Client, err error) {
+	start := time.Now()
+	result, err = m.inner.ListCursor(ctx, afterID, limit)
+	metrics.Record(ctx, m.bm, m.domain, "client_list", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) Unlock(ctx context.Context, clientID uuid.UUID) (err error) {
+	start := time.Now()
+	err = m.inner.Unlock(ctx, clientID)
+	metrics.Record(ctx, m.bm, m.domain, "client_unlock", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) RevokeTokens(ctx context.Context, clientID uuid.UUID) (err error) {
+	start := time.Now()
+	err = m.inner.RevokeTokens(ctx, clientID)
+	metrics.Record(ctx, m.bm, m.domain, "client_revoke_tokens", start, err)
+	return
+}
+
+func (m *metricsClientUseCase) RotateSecret(
+	ctx context.Context,
+	clientID uuid.UUID,
+) (result *authDomain.CreateClientOutput, err error) {
+	start := time.Now()
+	result, err = m.inner.RotateSecret(ctx, clientID)
+	metrics.Record(ctx, m.bm, m.domain, "client_rotate_secret", start, err)
+	return
+}
+
+var _ ClientUseCase = (*metricsClientUseCase)(nil)

--- a/internal/auth/usecase/metrics_token_usecase.go
+++ b/internal/auth/usecase/metrics_token_usecase.go
@@ -1,0 +1,56 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
+	"github.com/allisson/secrets/internal/metrics"
+)
+
+type metricsTokenUseCase struct {
+	inner  TokenUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsTokenUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsTokenUseCase(inner TokenUseCase, bm metrics.BusinessMetrics, domain string) TokenUseCase {
+	return &metricsTokenUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsTokenUseCase) Issue(
+	ctx context.Context,
+	input *authDomain.IssueTokenInput,
+) (result *authDomain.IssueTokenOutput, err error) {
+	start := time.Now()
+	result, err = m.inner.Issue(ctx, input)
+	metrics.Record(ctx, m.bm, m.domain, "token_issue", start, err)
+	return
+}
+
+func (m *metricsTokenUseCase) Authenticate(
+	ctx context.Context,
+	rawToken string,
+) (result *authDomain.Client, err error) {
+	start := time.Now()
+	result, err = m.inner.Authenticate(ctx, rawToken)
+	metrics.Record(ctx, m.bm, m.domain, "token_authenticate", start, err)
+	return
+}
+
+func (m *metricsTokenUseCase) Revoke(ctx context.Context, rawToken string) (err error) {
+	start := time.Now()
+	err = m.inner.Revoke(ctx, rawToken)
+	metrics.Record(ctx, m.bm, m.domain, "token_revoke", start, err)
+	return
+}
+
+func (m *metricsTokenUseCase) PurgeExpiredAndRevoked(ctx context.Context, days int) (count int64, err error) {
+	start := time.Now()
+	count, err = m.inner.PurgeExpiredAndRevoked(ctx, days)
+	metrics.Record(ctx, m.bm, m.domain, "token_purge", start, err)
+	return
+}
+
+var _ TokenUseCase = (*metricsTokenUseCase)(nil)

--- a/internal/auth/usecase/token_usecase.go
+++ b/internal/auth/usecase/token_usecase.go
@@ -13,7 +13,6 @@ import (
 	authDomain "github.com/allisson/secrets/internal/auth/domain"
 	authService "github.com/allisson/secrets/internal/auth/service"
 	"github.com/allisson/secrets/internal/config"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 )
 
 // tokenUseCase implements TokenUseCase interface for managing authentication tokens.
@@ -24,7 +23,6 @@ type tokenUseCase struct {
 	auditLogUseCase AuditLogUseCase
 	secretService   authService.SecretService
 	tokenService    authService.TokenService
-	metrics         metricsLib.BusinessMetrics
 }
 
 // Issue authenticates a client and generates a new authentication token.
@@ -38,9 +36,6 @@ func (t *tokenUseCase) Issue(
 	ctx context.Context,
 	issueTokenInput *authDomain.IssueTokenInput,
 ) (result *authDomain.IssueTokenOutput, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "auth", "token_issue", start, err) }()
-
 	// Get the client by ID
 	client, err := t.clientRepo.Get(ctx, issueTokenInput.ClientID)
 	if err != nil {
@@ -122,9 +117,6 @@ func (t *tokenUseCase) Authenticate(
 	ctx context.Context,
 	rawToken string,
 ) (result *authDomain.Client, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "auth", "token_authenticate", start, err) }()
-
 	// Get the token by hash
 	token, err := t.tokenRepo.GetByTokenHash(ctx, t.hashToken(rawToken))
 	if err != nil {
@@ -166,9 +158,6 @@ func (t *tokenUseCase) Authenticate(
 
 // Revoke marks a specific token as revoked given its raw bearer value.
 func (t *tokenUseCase) Revoke(ctx context.Context, rawToken string) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "auth", "token_revoke", start, err) }()
-
 	// Get the token by hash
 	token, err := t.tokenRepo.GetByTokenHash(ctx, t.hashToken(rawToken))
 	if err != nil {
@@ -201,9 +190,6 @@ func (t *tokenUseCase) Revoke(ctx context.Context, rawToken string) (err error) 
 // PurgeExpiredAndRevoked permanently deletes tokens that are either expired or revoked
 // and were created before the specified number of days ago.
 func (t *tokenUseCase) PurgeExpiredAndRevoked(ctx context.Context, days int) (count int64, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "auth", "token_purge", start, err) }()
-
 	// Standard project validation for days/retention parameters
 	// If days is 0, it means delete anything that is already expired or revoked.
 	if days < 0 {
@@ -223,7 +209,6 @@ func NewTokenUseCase(
 	auditLogUseCase AuditLogUseCase,
 	secretService authService.SecretService,
 	tokenService authService.TokenService,
-	bm metricsLib.BusinessMetrics,
 ) TokenUseCase {
 	return &tokenUseCase{
 		config:          config,
@@ -232,6 +217,5 @@ func NewTokenUseCase(
 		auditLogUseCase: auditLogUseCase,
 		secretService:   secretService,
 		tokenService:    tokenService,
-		metrics:         bm,
 	}
 }

--- a/internal/auth/usecase/token_usecase_test.go
+++ b/internal/auth/usecase/token_usecase_test.go
@@ -74,7 +74,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -107,7 +106,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -147,7 +145,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -197,7 +194,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -236,7 +232,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -284,7 +279,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -330,7 +324,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -375,7 +368,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -415,7 +407,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -456,7 +447,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -506,7 +496,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -554,7 +543,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -603,7 +591,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -633,7 +620,6 @@ func TestTokenUseCase_Issue(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		output, err := uc.Issue(ctx, issueInput)
 
@@ -682,7 +668,6 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		result, err := uc.Authenticate(ctx, tokenHash)
 
@@ -693,7 +678,7 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 
 	t.Run("Error_TokenNotFound", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
-		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil)
 
 		tokenHash := "not-found"
 		mockTokenRepo.EXPECT().
@@ -709,7 +694,7 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 
 	t.Run("Error_TokenExpired", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
-		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil)
 
 		tokenHash := "expired"
 		token := &authDomain.Token{
@@ -749,7 +734,6 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 			mockAuditLogUseCase,
 			mockSecretService,
 			mockTokenService,
-			nil,
 		)
 		result, err := uc.Authenticate(ctx, tokenHash)
 
@@ -761,7 +745,7 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 	t.Run("Error_ClientNotFound", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
 		mockClientRepo := usecaseMocks.NewMockClientRepository(t)
-		uc := usecase.NewTokenUseCase(nil, mockClientRepo, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, mockClientRepo, mockTokenRepo, nil, nil, nil)
 
 		tokenHash := "hash"
 		clientID := uuid.Must(uuid.NewV7())
@@ -781,7 +765,7 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 	t.Run("Error_ClientInactive", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
 		mockClientRepo := usecaseMocks.NewMockClientRepository(t)
-		uc := usecase.NewTokenUseCase(nil, mockClientRepo, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, mockClientRepo, mockTokenRepo, nil, nil, nil)
 
 		tokenHash := "hash"
 		clientID := uuid.Must(uuid.NewV7())
@@ -804,7 +788,7 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 
 	t.Run("Error_RepositoryGetTokenFails", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
-		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil)
 
 		tokenHash := "hash"
 		mockTokenRepo.EXPECT().
@@ -822,7 +806,7 @@ func TestTokenUseCase_Authenticate(t *testing.T) {
 	t.Run("Error_RepositoryGetClientFails", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
 		mockClientRepo := usecaseMocks.NewMockClientRepository(t)
-		uc := usecase.NewTokenUseCase(nil, mockClientRepo, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, mockClientRepo, mockTokenRepo, nil, nil, nil)
 
 		tokenHash := "hash"
 		clientID := uuid.Must(uuid.NewV7())
@@ -847,7 +831,7 @@ func TestTokenUseCase_Revoke(t *testing.T) {
 	t.Run("Success_RevokeToken", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
 		mockAuditLogUseCase := usecaseMocks.NewMockAuditLogUseCase(t)
-		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, mockAuditLogUseCase, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, mockAuditLogUseCase, nil, nil)
 
 		tokenHash := "test-token-hash"
 		token := &authDomain.Token{ID: uuid.New(), ClientID: uuid.New()}
@@ -866,7 +850,7 @@ func TestTokenUseCase_Revoke(t *testing.T) {
 	t.Run("Error_TokenNotFound", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
 		mockAuditLogUseCase := usecaseMocks.NewMockAuditLogUseCase(t)
-		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, mockAuditLogUseCase, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, mockAuditLogUseCase, nil, nil)
 
 		tokenHash := "test-token-hash"
 
@@ -885,7 +869,7 @@ func TestTokenUseCase_PurgeExpiredAndRevoked(t *testing.T) {
 
 	t.Run("Success_PurgeTokens", func(t *testing.T) {
 		mockTokenRepo := usecaseMocks.NewMockTokenRepository(t)
-		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, mockTokenRepo, nil, nil, nil)
 
 		days := 30
 		mockTokenRepo.EXPECT().
@@ -899,7 +883,7 @@ func TestTokenUseCase_PurgeExpiredAndRevoked(t *testing.T) {
 	})
 
 	t.Run("Error_InvalidDays", func(t *testing.T) {
-		uc := usecase.NewTokenUseCase(nil, nil, nil, nil, nil, nil, nil)
+		uc := usecase.NewTokenUseCase(nil, nil, nil, nil, nil, nil)
 
 		count, err := uc.PurgeExpiredAndRevoked(ctx, -1)
 		assert.Error(t, err)

--- a/internal/metrics/business.go
+++ b/internal/metrics/business.go
@@ -89,37 +89,10 @@ func (b *businessMetrics) RecordDuration(
 	)
 }
 
-// NoOpBusinessMetrics is a no-op implementation of BusinessMetrics for when metrics are disabled.
-type NoOpBusinessMetrics struct{}
-
-// NewNoOpBusinessMetrics creates a no-op BusinessMetrics implementation.
-func NewNoOpBusinessMetrics() BusinessMetrics {
-	return &NoOpBusinessMetrics{}
-}
-
-// RecordOperation does nothing when metrics are disabled.
-func (n *NoOpBusinessMetrics) RecordOperation(ctx context.Context, domain, operation, status string) {
-	// No-op
-}
-
-// RecordDuration does nothing when metrics are disabled.
-func (n *NoOpBusinessMetrics) RecordDuration(
-	ctx context.Context,
-	domain, operation string,
-	duration time.Duration,
-	status string,
-) {
-	// No-op
-}
-
 // Record calls RecordOperation and RecordDuration for a completed operation.
 // status is "success" when err is nil, "error" otherwise.
 // Callers capture time.Now() before the operation and pass it as start.
-// If m is nil, Record is a no-op.
 func Record(ctx context.Context, m BusinessMetrics, domain, op string, start time.Time, err error) {
-	if m == nil {
-		return
-	}
 	status := "success"
 	if err != nil {
 		status = "error"

--- a/internal/metrics/business_test.go
+++ b/internal/metrics/business_test.go
@@ -80,31 +80,6 @@ func TestBusinessMetrics_RecordDuration(t *testing.T) {
 	})
 }
 
-func TestNewNoOpBusinessMetrics(t *testing.T) {
-	noOpMetrics := NewNoOpBusinessMetrics()
-
-	assert.NotNil(t, noOpMetrics)
-	assert.IsType(t, &NoOpBusinessMetrics{}, noOpMetrics)
-
-	t.Run("NoOp_RecordOperationDoesNotPanic", func(t *testing.T) {
-		// Should not panic or do anything
-		noOpMetrics.RecordOperation(context.Background(), "auth", "create_client", "success")
-		noOpMetrics.RecordOperation(context.Background(), "secrets", "encrypt", "error")
-	})
-
-	t.Run("NoOp_RecordDurationDoesNotPanic", func(t *testing.T) {
-		// Should not panic or do anything
-		noOpMetrics.RecordDuration(
-			context.Background(),
-			"auth",
-			"create_client",
-			100*time.Millisecond,
-			"success",
-		)
-		noOpMetrics.RecordDuration(context.Background(), "secrets", "encrypt", 200*time.Millisecond, "error")
-	})
-}
-
 func TestBusinessMetrics_Integration(t *testing.T) {
 	provider, err := NewProvider("integration_test")
 	require.NoError(t, err)

--- a/internal/secrets/usecase/metrics_secret_usecase.go
+++ b/internal/secrets/usecase/metrics_secret_usecase.go
@@ -1,0 +1,83 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/allisson/secrets/internal/metrics"
+	secretsDomain "github.com/allisson/secrets/internal/secrets/domain"
+)
+
+type metricsSecretUseCase struct {
+	inner  SecretUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsSecretUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsSecretUseCase(inner SecretUseCase, bm metrics.BusinessMetrics, domain string) SecretUseCase {
+	return &metricsSecretUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsSecretUseCase) CreateOrUpdate(
+	ctx context.Context,
+	path string,
+	value []byte,
+) (result *secretsDomain.Secret, err error) {
+	start := time.Now()
+	result, err = m.inner.CreateOrUpdate(ctx, path, value)
+	metrics.Record(ctx, m.bm, m.domain, "secret_create_or_update", start, err)
+	return
+}
+
+func (m *metricsSecretUseCase) Get(
+	ctx context.Context,
+	path string,
+) (result *secretsDomain.Secret, err error) {
+	start := time.Now()
+	result, err = m.inner.Get(ctx, path)
+	metrics.Record(ctx, m.bm, m.domain, "secret_get", start, err)
+	return
+}
+
+func (m *metricsSecretUseCase) GetByVersion(
+	ctx context.Context,
+	path string,
+	version uint,
+) (result *secretsDomain.Secret, err error) {
+	start := time.Now()
+	result, err = m.inner.GetByVersion(ctx, path, version)
+	metrics.Record(ctx, m.bm, m.domain, "secret_get_by_version", start, err)
+	return
+}
+
+func (m *metricsSecretUseCase) Delete(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	err = m.inner.Delete(ctx, path)
+	metrics.Record(ctx, m.bm, m.domain, "secret_delete", start, err)
+	return
+}
+
+func (m *metricsSecretUseCase) ListCursor(
+	ctx context.Context,
+	afterPath *string,
+	limit int,
+) (result []*secretsDomain.Secret, err error) {
+	start := time.Now()
+	result, err = m.inner.ListCursor(ctx, afterPath, limit)
+	metrics.Record(ctx, m.bm, m.domain, "secret_list", start, err)
+	return
+}
+
+func (m *metricsSecretUseCase) PurgeDeleted(
+	ctx context.Context,
+	olderThanDays int,
+	dryRun bool,
+) (count int64, err error) {
+	start := time.Now()
+	count, err = m.inner.PurgeDeleted(ctx, olderThanDays, dryRun)
+	metrics.Record(ctx, m.bm, m.domain, "secret_purge_deleted", start, err)
+	return
+}
+
+var _ SecretUseCase = (*metricsSecretUseCase)(nil)

--- a/internal/secrets/usecase/secret_usecase.go
+++ b/internal/secrets/usecase/secret_usecase.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/allisson/secrets/internal/database"
 	"github.com/allisson/secrets/internal/keyring"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 	secretsDomain "github.com/allisson/secrets/internal/secrets/domain"
 )
 
@@ -20,7 +19,6 @@ type secretUseCase struct {
 	keyring              keyring.Keyring
 	secretRepo           SecretRepository
 	secretValueSizeLimit int
-	metrics              metricsLib.BusinessMetrics
 }
 
 // CreateOrUpdate creates a new secret or creates a new version of an existing secret.
@@ -29,9 +27,6 @@ func (s *secretUseCase) CreateOrUpdate(
 	path string,
 	value []byte,
 ) (result *secretsDomain.Secret, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, s.metrics, "secrets", "secret_create_or_update", start, err) }()
-
 	if err = validateSecretPath(path); err != nil {
 		return nil, err
 	}
@@ -77,9 +72,6 @@ func (s *secretUseCase) CreateOrUpdate(
 
 // Get retrieves and decrypts a secret by its path (latest version).
 func (s *secretUseCase) Get(ctx context.Context, path string) (result *secretsDomain.Secret, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, s.metrics, "secrets", "secret_get", start, err) }()
-
 	var secret *secretsDomain.Secret
 	secret, err = s.secretRepo.GetByPath(ctx, path)
 	if err != nil {
@@ -95,9 +87,6 @@ func (s *secretUseCase) GetByVersion(
 	path string,
 	version uint,
 ) (result *secretsDomain.Secret, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, s.metrics, "secrets", "secret_get_by_version", start, err) }()
-
 	var secret *secretsDomain.Secret
 	secret, err = s.secretRepo.GetByPathAndVersion(ctx, path, version)
 	if err != nil {
@@ -126,8 +115,6 @@ func (s *secretUseCase) decryptSecret(
 
 // Delete performs a soft delete on all versions of a secret by its path.
 func (s *secretUseCase) Delete(ctx context.Context, path string) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, s.metrics, "secrets", "secret_delete", start, err) }()
 	err = s.secretRepo.Delete(ctx, path)
 	return
 }
@@ -138,8 +125,6 @@ func (s *secretUseCase) ListCursor(
 	afterPath *string,
 	limit int,
 ) (result []*secretsDomain.Secret, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, s.metrics, "secrets", "secret_list", start, err) }()
 	result, err = s.secretRepo.ListCursor(ctx, afterPath, limit)
 	return
 }
@@ -150,9 +135,6 @@ func (s *secretUseCase) PurgeDeleted(
 	olderThanDays int,
 	dryRun bool,
 ) (count int64, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, s.metrics, "secrets", "secret_purge_deleted", start, err) }()
-
 	if olderThanDays < 0 {
 		return 0, errors.New("olderThanDays must be non-negative")
 	}
@@ -168,13 +150,11 @@ func NewSecretUseCase(
 	kr keyring.Keyring,
 	secretRepo SecretRepository,
 	secretValueSizeLimit int,
-	bm metricsLib.BusinessMetrics,
 ) SecretUseCase {
 	return &secretUseCase{
 		txManager:            txManager,
 		keyring:              kr,
 		secretRepo:           secretRepo,
 		secretValueSizeLimit: secretValueSizeLimit,
-		metrics:              bm,
 	}
 }

--- a/internal/secrets/usecase/secret_usecase_test.go
+++ b/internal/secrets/usecase/secret_usecase_test.go
@@ -36,7 +36,7 @@ func newSecretUseCase(
 	t.Helper()
 	fake := keyring.NewFake()
 	repo := mocks.NewMockSecretRepository(t)
-	uc := usecase.NewSecretUseCase(noopTxManager{}, fake, repo, sizeLimit, nil)
+	uc := usecase.NewSecretUseCase(noopTxManager{}, fake, repo, sizeLimit)
 	return uc, fake, repo
 }
 

--- a/internal/tokenization/usecase/metrics_tokenization_key_usecase.go
+++ b/internal/tokenization/usecase/metrics_tokenization_key_usecase.go
@@ -1,0 +1,92 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/allisson/secrets/internal/keyring"
+	"github.com/allisson/secrets/internal/metrics"
+	tokenizationDomain "github.com/allisson/secrets/internal/tokenization/domain"
+)
+
+type metricsTokenizationKeyUseCase struct {
+	inner  TokenizationKeyUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsTokenizationKeyUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsTokenizationKeyUseCase(
+	inner TokenizationKeyUseCase,
+	bm metrics.BusinessMetrics,
+	domain string,
+) TokenizationKeyUseCase {
+	return &metricsTokenizationKeyUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsTokenizationKeyUseCase) Create(
+	ctx context.Context,
+	name string,
+	formatType tokenizationDomain.FormatType,
+	isDeterministic bool,
+	alg keyring.Algorithm,
+) (result *tokenizationDomain.TokenizationKey, err error) {
+	start := time.Now()
+	result, err = m.inner.Create(ctx, name, formatType, isDeterministic, alg)
+	metrics.Record(ctx, m.bm, m.domain, "tokenization_key_create", start, err)
+	return
+}
+
+func (m *metricsTokenizationKeyUseCase) Rotate(
+	ctx context.Context,
+	name string,
+	formatType tokenizationDomain.FormatType,
+	isDeterministic bool,
+	alg keyring.Algorithm,
+) (result *tokenizationDomain.TokenizationKey, err error) {
+	start := time.Now()
+	result, err = m.inner.Rotate(ctx, name, formatType, isDeterministic, alg)
+	metrics.Record(ctx, m.bm, m.domain, "tokenization_key_rotate", start, err)
+	return
+}
+
+func (m *metricsTokenizationKeyUseCase) Delete(ctx context.Context, name string) (err error) {
+	start := time.Now()
+	err = m.inner.Delete(ctx, name)
+	metrics.Record(ctx, m.bm, m.domain, "tokenization_key_delete", start, err)
+	return
+}
+
+func (m *metricsTokenizationKeyUseCase) GetByName(
+	ctx context.Context,
+	name string,
+) (result *tokenizationDomain.TokenizationKey, err error) {
+	start := time.Now()
+	result, err = m.inner.GetByName(ctx, name)
+	metrics.Record(ctx, m.bm, m.domain, "tokenization_key_get", start, err)
+	return
+}
+
+func (m *metricsTokenizationKeyUseCase) ListCursor(
+	ctx context.Context,
+	afterName *string,
+	limit int,
+) (result []*tokenizationDomain.TokenizationKey, err error) {
+	start := time.Now()
+	result, err = m.inner.ListCursor(ctx, afterName, limit)
+	metrics.Record(ctx, m.bm, m.domain, "tokenization_key_list", start, err)
+	return
+}
+
+func (m *metricsTokenizationKeyUseCase) PurgeDeleted(
+	ctx context.Context,
+	olderThanDays int,
+	dryRun bool,
+) (count int64, err error) {
+	start := time.Now()
+	count, err = m.inner.PurgeDeleted(ctx, olderThanDays, dryRun)
+	metrics.Record(ctx, m.bm, m.domain, "tokenization_key_purge_deleted", start, err)
+	return
+}
+
+var _ TokenizationKeyUseCase = (*metricsTokenizationKeyUseCase)(nil)

--- a/internal/tokenization/usecase/metrics_tokenization_usecase.go
+++ b/internal/tokenization/usecase/metrics_tokenization_usecase.go
@@ -1,0 +1,100 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/allisson/secrets/internal/metrics"
+	tokenizationDomain "github.com/allisson/secrets/internal/tokenization/domain"
+)
+
+type metricsTokenizationUseCase struct {
+	inner  TokenizationUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsTokenizationUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsTokenizationUseCase(
+	inner TokenizationUseCase,
+	bm metrics.BusinessMetrics,
+	domain string,
+) TokenizationUseCase {
+	return &metricsTokenizationUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsTokenizationUseCase) Tokenize(
+	ctx context.Context,
+	keyName string,
+	plaintext []byte,
+	metadata map[string]any,
+	expiresAt *time.Time,
+) (result *tokenizationDomain.Token, err error) {
+	start := time.Now()
+	result, err = m.inner.Tokenize(ctx, keyName, plaintext, metadata, expiresAt)
+	metrics.Record(ctx, m.bm, m.domain, "tokenize", start, err)
+	return
+}
+
+func (m *metricsTokenizationUseCase) TokenizeBatch(
+	ctx context.Context,
+	keyName string,
+	plaintexts [][]byte,
+	metadatas []map[string]any,
+	expiresAt *time.Time,
+) (result []*tokenizationDomain.Token, err error) {
+	start := time.Now()
+	result, err = m.inner.TokenizeBatch(ctx, keyName, plaintexts, metadatas, expiresAt)
+	metrics.Record(ctx, m.bm, m.domain, "tokenize_batch", start, err)
+	return
+}
+
+func (m *metricsTokenizationUseCase) Detokenize(
+	ctx context.Context,
+	token string,
+) (plaintext []byte, metadata map[string]any, err error) {
+	start := time.Now()
+	plaintext, metadata, err = m.inner.Detokenize(ctx, token)
+	metrics.Record(ctx, m.bm, m.domain, "detokenize", start, err)
+	return
+}
+
+func (m *metricsTokenizationUseCase) DetokenizeBatch(
+	ctx context.Context,
+	tokens []string,
+) (plaintexts [][]byte, metadatas []map[string]any, err error) {
+	start := time.Now()
+	plaintexts, metadatas, err = m.inner.DetokenizeBatch(ctx, tokens)
+	metrics.Record(ctx, m.bm, m.domain, "detokenize_batch", start, err)
+	return
+}
+
+func (m *metricsTokenizationUseCase) Validate(
+	ctx context.Context,
+	token string,
+) (valid bool, err error) {
+	start := time.Now()
+	valid, err = m.inner.Validate(ctx, token)
+	metrics.Record(ctx, m.bm, m.domain, "tokenize_validate", start, err)
+	return
+}
+
+func (m *metricsTokenizationUseCase) Revoke(ctx context.Context, token string) (err error) {
+	start := time.Now()
+	err = m.inner.Revoke(ctx, token)
+	metrics.Record(ctx, m.bm, m.domain, "tokenize_revoke", start, err)
+	return
+}
+
+func (m *metricsTokenizationUseCase) CleanupExpired(
+	ctx context.Context,
+	days int,
+	dryRun bool,
+) (count int64, err error) {
+	start := time.Now()
+	count, err = m.inner.CleanupExpired(ctx, days, dryRun)
+	metrics.Record(ctx, m.bm, m.domain, "tokenize_cleanup_expired", start, err)
+	return
+}
+
+var _ TokenizationUseCase = (*metricsTokenizationUseCase)(nil)

--- a/internal/tokenization/usecase/tokenization_key_usecase.go
+++ b/internal/tokenization/usecase/tokenization_key_usecase.go
@@ -10,7 +10,6 @@ import (
 	"github.com/allisson/secrets/internal/database"
 	apperrors "github.com/allisson/secrets/internal/errors"
 	"github.com/allisson/secrets/internal/keyring"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 	tokenizationDomain "github.com/allisson/secrets/internal/tokenization/domain"
 )
 
@@ -19,7 +18,6 @@ type tokenizationKeyUseCase struct {
 	txManager           database.TxManager
 	tokenizationKeyRepo TokenizationKeyRepository
 	keyring             keyring.Keyring
-	metrics             metricsLib.BusinessMetrics
 }
 
 // createTokenizationKey is a helper that creates a tokenization key within an existing
@@ -77,11 +75,6 @@ func (t *tokenizationKeyUseCase) Create(
 	isDeterministic bool,
 	alg keyring.Algorithm,
 ) (result *tokenizationDomain.TokenizationKey, err error) {
-	start := time.Now()
-	defer func() {
-		metricsLib.Record(ctx, t.metrics, "tokenization", "tokenization_key_create", start, err)
-	}()
-
 	if err = formatType.Validate(); err != nil {
 		return nil, tokenizationDomain.ErrInvalidFormatType
 	}
@@ -115,11 +108,6 @@ func (t *tokenizationKeyUseCase) Rotate(
 	isDeterministic bool,
 	alg keyring.Algorithm,
 ) (result *tokenizationDomain.TokenizationKey, err error) {
-	start := time.Now()
-	defer func() {
-		metricsLib.Record(ctx, t.metrics, "tokenization", "tokenization_key_rotate", start, err)
-	}()
-
 	if err = formatType.Validate(); err != nil {
 		return nil, tokenizationDomain.ErrInvalidFormatType
 	}
@@ -153,11 +141,6 @@ func (t *tokenizationKeyUseCase) Rotate(
 
 // Delete soft deletes a tokenization key and all its versions by name.
 func (t *tokenizationKeyUseCase) Delete(ctx context.Context, name string) (err error) {
-	start := time.Now()
-	defer func() {
-		metricsLib.Record(ctx, t.metrics, "tokenization", "tokenization_key_delete", start, err)
-	}()
-
 	if err = t.tokenizationKeyRepo.Delete(ctx, name); err != nil {
 		return apperrors.Wrap(err, "failed to delete tokenization key")
 	}
@@ -169,11 +152,6 @@ func (t *tokenizationKeyUseCase) GetByName(
 	ctx context.Context,
 	name string,
 ) (result *tokenizationDomain.TokenizationKey, err error) {
-	start := time.Now()
-	defer func() {
-		metricsLib.Record(ctx, t.metrics, "tokenization", "tokenization_key_get", start, err)
-	}()
-
 	key, err := t.tokenizationKeyRepo.GetByName(ctx, name)
 	if err != nil {
 		if apperrors.Is(err, tokenizationDomain.ErrTokenizationKeyNotFound) {
@@ -190,11 +168,6 @@ func (t *tokenizationKeyUseCase) ListCursor(
 	afterName *string,
 	limit int,
 ) (result []*tokenizationDomain.TokenizationKey, err error) {
-	start := time.Now()
-	defer func() {
-		metricsLib.Record(ctx, t.metrics, "tokenization", "tokenization_key_list", start, err)
-	}()
-
 	keys, err := t.tokenizationKeyRepo.ListCursor(ctx, afterName, limit)
 	if err != nil {
 		return nil, apperrors.Wrap(err, "failed to list tokenization keys")
@@ -208,11 +181,6 @@ func (t *tokenizationKeyUseCase) PurgeDeleted(
 	olderThanDays int,
 	dryRun bool,
 ) (count int64, err error) {
-	start := time.Now()
-	defer func() {
-		metricsLib.Record(ctx, t.metrics, "tokenization", "tokenization_key_purge_deleted", start, err)
-	}()
-
 	if olderThanDays < 0 {
 		return 0, apperrors.New("olderThanDays must be a positive number")
 	}
@@ -227,12 +195,10 @@ func NewTokenizationKeyUseCase(
 	txManager database.TxManager,
 	tokenizationKeyRepo TokenizationKeyRepository,
 	kr keyring.Keyring,
-	bm metricsLib.BusinessMetrics,
 ) TokenizationKeyUseCase {
 	return &tokenizationKeyUseCase{
 		txManager:           txManager,
 		tokenizationKeyRepo: tokenizationKeyRepo,
 		keyring:             kr,
-		metrics:             bm,
 	}
 }

--- a/internal/tokenization/usecase/tokenization_key_usecase_test.go
+++ b/internal/tokenization/usecase/tokenization_key_usecase_test.go
@@ -29,7 +29,7 @@ func newTokenizationKeyUseCase(
 	t.Helper()
 	fake := keyring.NewFake()
 	repo := mocks.NewMockTokenizationKeyRepository(t)
-	uc := usecase.NewTokenizationKeyUseCase(noopTxManager{}, repo, fake, nil)
+	uc := usecase.NewTokenizationKeyUseCase(noopTxManager{}, repo, fake)
 	return uc, fake, repo
 }
 

--- a/internal/tokenization/usecase/tokenization_usecase.go
+++ b/internal/tokenization/usecase/tokenization_usecase.go
@@ -14,7 +14,6 @@ import (
 	"github.com/allisson/secrets/internal/database"
 	apperrors "github.com/allisson/secrets/internal/errors"
 	"github.com/allisson/secrets/internal/keyring"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 	tokenizationDomain "github.com/allisson/secrets/internal/tokenization/domain"
 	tokenizationService "github.com/allisson/secrets/internal/tokenization/service"
 )
@@ -44,7 +43,6 @@ type tokenizationUseCase struct {
 	tokenRepo        TokenRepository
 	hashService      HashService
 	keyring          keyring.Keyring
-	metrics          metricsLib.BusinessMetrics
 }
 
 // Tokenize generates a token for the given plaintext value using the latest version of the named key.
@@ -55,9 +53,6 @@ func (t *tokenizationUseCase) Tokenize(
 	metadata map[string]any,
 	expiresAt *time.Time,
 ) (result *tokenizationDomain.Token, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "tokenize", start, err) }()
-
 	if len(plaintext) == 0 {
 		return nil, tokenizationDomain.ErrPlaintextEmpty
 	}
@@ -154,9 +149,6 @@ func (t *tokenizationUseCase) TokenizeBatch(
 	metadatas []map[string]any,
 	expiresAt *time.Time,
 ) (result []*tokenizationDomain.Token, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "tokenize_batch", start, err) }()
-
 	var tokens []*tokenizationDomain.Token
 	err = t.txManager.WithTx(ctx, func(ctx context.Context) error {
 		for i, plaintext := range plaintexts {
@@ -184,9 +176,6 @@ func (t *tokenizationUseCase) Detokenize(
 	ctx context.Context,
 	token string,
 ) (plaintext []byte, metadata map[string]any, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "detokenize", start, err) }()
-
 	tokenRecord, err := t.tokenRepo.GetByToken(ctx, token)
 	if err != nil {
 		return nil, nil, apperrors.Wrap(err, "failed to get token")
@@ -221,9 +210,6 @@ func (t *tokenizationUseCase) DetokenizeBatch(
 	ctx context.Context,
 	tokens []string,
 ) (plaintexts [][]byte, metadatas []map[string]any, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "detokenize_batch", start, err) }()
-
 	err = t.txManager.WithTx(ctx, func(ctx context.Context) error {
 		for _, token := range tokens {
 			plaintext, metadata, err := t.Detokenize(ctx, token)
@@ -243,13 +229,9 @@ func (t *tokenizationUseCase) DetokenizeBatch(
 
 // Validate checks if a token exists and is valid (not expired or revoked).
 func (t *tokenizationUseCase) Validate(ctx context.Context, token string) (valid bool, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "tokenize_validate", start, err) }()
-
 	tokenRecord, err := t.tokenRepo.GetByToken(ctx, token)
 	if err != nil {
 		if apperrors.Is(err, tokenizationDomain.ErrTokenNotFound) {
-			err = nil
 			return false, nil
 		}
 		return false, apperrors.Wrap(err, "failed to validate token")
@@ -259,9 +241,6 @@ func (t *tokenizationUseCase) Validate(ctx context.Context, token string) (valid
 
 // Revoke marks a token as revoked, preventing further detokenization.
 func (t *tokenizationUseCase) Revoke(ctx context.Context, token string) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "tokenize_revoke", start, err) }()
-
 	if _, err = t.tokenRepo.GetByToken(ctx, token); err != nil {
 		return apperrors.Wrap(err, "failed to get token for revocation")
 	}
@@ -277,9 +256,6 @@ func (t *tokenizationUseCase) CleanupExpired(
 	days int,
 	dryRun bool,
 ) (count int64, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "tokenization", "tokenize_cleanup_expired", start, err) }()
-
 	if days < 0 {
 		return 0, apperrors.New("days must be non-negative")
 	}
@@ -300,7 +276,6 @@ func NewTokenizationUseCase(
 	tokenRepo TokenRepository,
 	hashService HashService,
 	kr keyring.Keyring,
-	bm metricsLib.BusinessMetrics,
 ) TokenizationUseCase {
 	return &tokenizationUseCase{
 		txManager:        txManager,
@@ -308,6 +283,5 @@ func NewTokenizationUseCase(
 		tokenRepo:        tokenRepo,
 		hashService:      hashService,
 		keyring:          kr,
-		metrics:          bm,
 	}
 }

--- a/internal/tokenization/usecase/tokenization_usecase_test.go
+++ b/internal/tokenization/usecase/tokenization_usecase_test.go
@@ -32,7 +32,7 @@ func newTokenizationUseCase(
 	keyRepo := mocks.NewMockTokenizationKeyRepository(t)
 	tokenRepo := mocks.NewMockTokenRepository(t)
 	hashSvc := mocks.NewMockHashService(t)
-	uc := usecase.NewTokenizationUseCase(noopTxManager{}, keyRepo, tokenRepo, hashSvc, fake, nil)
+	uc := usecase.NewTokenizationUseCase(noopTxManager{}, keyRepo, tokenRepo, hashSvc, fake)
 	return uc, fake, keyRepo, tokenRepo, hashSvc
 }
 

--- a/internal/transit/usecase/metrics_transit_key_usecase.go
+++ b/internal/transit/usecase/metrics_transit_key_usecase.go
@@ -1,0 +1,112 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/allisson/secrets/internal/keyring"
+	"github.com/allisson/secrets/internal/metrics"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
+)
+
+type metricsTransitKeyUseCase struct {
+	inner  TransitKeyUseCase
+	bm     metrics.BusinessMetrics
+	domain string
+}
+
+// NewMetricsTransitKeyUseCase wraps inner with per-method timing and operation recording.
+func NewMetricsTransitKeyUseCase(
+	inner TransitKeyUseCase,
+	bm metrics.BusinessMetrics,
+	domain string,
+) TransitKeyUseCase {
+	return &metricsTransitKeyUseCase{inner: inner, bm: bm, domain: domain}
+}
+
+func (m *metricsTransitKeyUseCase) Create(
+	ctx context.Context,
+	name string,
+	alg keyring.Algorithm,
+) (result *transitDomain.TransitKey, err error) {
+	start := time.Now()
+	result, err = m.inner.Create(ctx, name, alg)
+	metrics.Record(ctx, m.bm, m.domain, "transit_key_create", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) Rotate(
+	ctx context.Context,
+	name string,
+	alg keyring.Algorithm,
+) (result *transitDomain.TransitKey, err error) {
+	start := time.Now()
+	result, err = m.inner.Rotate(ctx, name, alg)
+	metrics.Record(ctx, m.bm, m.domain, "transit_key_rotate", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) Get(
+	ctx context.Context,
+	name string,
+	version uint,
+) (key *transitDomain.TransitKey, alg keyring.Algorithm, err error) {
+	start := time.Now()
+	key, alg, err = m.inner.Get(ctx, name, version)
+	metrics.Record(ctx, m.bm, m.domain, "transit_key_get", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) Delete(ctx context.Context, name string) (err error) {
+	start := time.Now()
+	err = m.inner.Delete(ctx, name)
+	metrics.Record(ctx, m.bm, m.domain, "transit_key_delete", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) Encrypt(
+	ctx context.Context,
+	name string,
+	plaintext, aad []byte,
+) (result *transitDomain.EncryptedBlob, err error) {
+	start := time.Now()
+	result, err = m.inner.Encrypt(ctx, name, plaintext, aad)
+	metrics.Record(ctx, m.bm, m.domain, "transit_encrypt", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) Decrypt(
+	ctx context.Context,
+	name string,
+	ciphertext string,
+	aad []byte,
+) (result *transitDomain.EncryptedBlob, err error) {
+	start := time.Now()
+	result, err = m.inner.Decrypt(ctx, name, ciphertext, aad)
+	metrics.Record(ctx, m.bm, m.domain, "transit_decrypt", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) ListCursor(
+	ctx context.Context,
+	afterName *string,
+	limit int,
+) (result []*transitDomain.TransitKey, err error) {
+	start := time.Now()
+	result, err = m.inner.ListCursor(ctx, afterName, limit)
+	metrics.Record(ctx, m.bm, m.domain, "transit_key_list", start, err)
+	return
+}
+
+func (m *metricsTransitKeyUseCase) PurgeDeleted(
+	ctx context.Context,
+	olderThanDays int,
+	dryRun bool,
+) (count int64, err error) {
+	start := time.Now()
+	count, err = m.inner.PurgeDeleted(ctx, olderThanDays, dryRun)
+	metrics.Record(ctx, m.bm, m.domain, "transit_key_purge_deleted", start, err)
+	return
+}
+
+var _ TransitKeyUseCase = (*metricsTransitKeyUseCase)(nil)

--- a/internal/transit/usecase/transit_key_usecase.go
+++ b/internal/transit/usecase/transit_key_usecase.go
@@ -13,7 +13,6 @@ import (
 	"github.com/allisson/secrets/internal/database"
 	apperrors "github.com/allisson/secrets/internal/errors"
 	"github.com/allisson/secrets/internal/keyring"
-	metricsLib "github.com/allisson/secrets/internal/metrics"
 	transitDomain "github.com/allisson/secrets/internal/transit/domain"
 )
 
@@ -22,7 +21,6 @@ type transitKeyUseCase struct {
 	txManager   database.TxManager
 	transitRepo TransitKeyRepository
 	keyring     keyring.Keyring
-	metrics     metricsLib.BusinessMetrics
 }
 
 // Create generates and persists a new transit key with version 1.
@@ -31,9 +29,6 @@ func (t *transitKeyUseCase) Create(
 	name string,
 	alg keyring.Algorithm,
 ) (result *transitDomain.TransitKey, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_key_create", start, err) }()
-
 	var transitKey *transitDomain.TransitKey
 
 	err = t.txManager.WithTx(ctx, func(txCtx context.Context) error {
@@ -72,9 +67,6 @@ func (t *transitKeyUseCase) Rotate(
 	name string,
 	alg keyring.Algorithm,
 ) (result *transitDomain.TransitKey, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_key_rotate", start, err) }()
-
 	var newTransitKey *transitDomain.TransitKey
 
 	err = t.txManager.WithTx(ctx, func(txCtx context.Context) error {
@@ -114,16 +106,12 @@ func (t *transitKeyUseCase) Get(
 	name string,
 	version uint,
 ) (key *transitDomain.TransitKey, alg keyring.Algorithm, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_key_get", start, err) }()
 	key, alg, err = t.transitRepo.GetTransitKey(ctx, name, version)
 	return
 }
 
 // Delete soft-deletes all versions of a transit key by name.
 func (t *transitKeyUseCase) Delete(ctx context.Context, name string) (err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_key_delete", start, err) }()
 	err = t.transitRepo.Delete(ctx, name)
 	return
 }
@@ -137,9 +125,6 @@ func (t *transitKeyUseCase) Encrypt(
 	name string,
 	plaintext, context []byte,
 ) (result *transitDomain.EncryptedBlob, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_encrypt", start, err) }()
-
 	transitKey, err := t.transitRepo.GetByName(ctx, name)
 	if err != nil {
 		return nil, err
@@ -162,9 +147,6 @@ func (t *transitKeyUseCase) Decrypt(
 	ciphertext string,
 	context []byte,
 ) (result *transitDomain.EncryptedBlob, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_decrypt", start, err) }()
-
 	blob, err := transitDomain.NewEncryptedBlob(ciphertext)
 	if err != nil {
 		return nil, err
@@ -198,8 +180,6 @@ func (t *transitKeyUseCase) ListCursor(
 	afterName *string,
 	limit int,
 ) (result []*transitDomain.TransitKey, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_key_list", start, err) }()
 	result, err = t.transitRepo.ListCursor(ctx, afterName, limit)
 	return
 }
@@ -210,9 +190,6 @@ func (t *transitKeyUseCase) PurgeDeleted(
 	olderThanDays int,
 	dryRun bool,
 ) (count int64, err error) {
-	start := time.Now()
-	defer func() { metricsLib.Record(ctx, t.metrics, "transit", "transit_key_purge_deleted", start, err) }()
-
 	if olderThanDays < 0 {
 		return 0, apperrors.New("olderThanDays must be a positive number")
 	}
@@ -227,12 +204,10 @@ func NewTransitKeyUseCase(
 	txManager database.TxManager,
 	transitRepo TransitKeyRepository,
 	kr keyring.Keyring,
-	bm metricsLib.BusinessMetrics,
 ) TransitKeyUseCase {
 	return &transitKeyUseCase{
 		txManager:   txManager,
 		transitRepo: transitRepo,
 		keyring:     kr,
-		metrics:     bm,
 	}
 }

--- a/internal/transit/usecase/transit_key_usecase_test.go
+++ b/internal/transit/usecase/transit_key_usecase_test.go
@@ -31,7 +31,7 @@ func newTransitKeyUseCase(
 	t.Helper()
 	fake := keyring.NewFake()
 	repo := mocks.NewMockTransitKeyRepository(t)
-	uc := usecase.NewTransitKeyUseCase(noopTxManager{}, repo, fake, nil)
+	uc := usecase.NewTransitKeyUseCase(noopTxManager{}, repo, fake)
 	return uc, fake, repo
 }
 

--- a/test/integration/audit_log_signature_test.go
+++ b/test/integration/audit_log_signature_test.go
@@ -45,7 +45,7 @@ func TestAuditLogSignature_EndToEnd(t *testing.T) {
 	require.NoError(t, err, "failed to get audit log repository")
 
 	// Create use case with signing enabled
-	auditLogUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, keySigner, nil)
+	auditLogUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, keySigner)
 
 	t.Run("CreateSignedAuditLog", func(t *testing.T) {
 		// Create a signed audit log
@@ -247,7 +247,7 @@ func TestAuditLogSignature_EndToEnd(t *testing.T) {
 
 	t.Run("LegacyUnsignedLogs", func(t *testing.T) {
 		// Create an unsigned legacy audit log (no signer)
-		legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil, nil)
+		legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil)
 
 		requestID := uuid.Must(uuid.NewV7())
 		clientID := testCtx.rootClient.ID
@@ -285,7 +285,7 @@ func TestAuditLogSignature_EndToEnd(t *testing.T) {
 		clientID := testCtx.rootClient.ID
 
 		// Create 2 signed logs
-		signedUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, keySigner, nil)
+		signedUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, keySigner)
 		for i := 0; i < 2; i++ {
 			requestID := uuid.Must(uuid.NewV7())
 			err := signedUseCase.Create(
@@ -301,7 +301,7 @@ func TestAuditLogSignature_EndToEnd(t *testing.T) {
 		}
 
 		// Create 2 unsigned legacy logs
-		legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil, nil)
+		legacyUseCase := authUseCase.NewAuditLogUseCase(auditLogRepo, nil)
 		for i := 0; i < 2; i++ {
 			requestID := uuid.Must(uuid.NewV7())
 			err := legacyUseCase.Create(


### PR DESCRIPTION
## Summary

- Extract `BusinessMetrics` recording out of 7 usecase implementations (44 scattered method-body calls) into thin decorator structs — one per usecase interface — applied only at DI wiring time when metrics are enabled
- Delete `NoOpBusinessMetrics` and the nil-guard in `metrics.Record`; a nil `BusinessMetrics` is now architecturally impossible because decorators are simply not wired when `MetricsEnabled=false`
- Every usecase constructor drops its `BusinessMetrics` parameter, making tests simpler and constructors honest about their actual dependencies

## Test plan

- [ ] `make test` — all unit tests pass
- [ ] `make test-all` — integration tests pass
- [ ] `make lint` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)