### PR TITLE
refactor: unify rate limiter stores behind a generic seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Absorbed `TokenService.HashToken` into `TokenUseCase`: raw bearer tokens flow directly to `Authenticate` and `Revoke`; SHA-256 hashing is now an internal detail. `TokenHandler` and the authentication middleware no longer hold a `TokenService` reference. No behavior change.
 - Removed unused `auditLogUseCase` dependency from `ClientHandler`. No behavior change.
 - Inlined `BusinessMetrics` into all use case structs via a named-return defer pattern and deleted the five metrics decorator layers. No behavior change.
+- Unified the two rate limiter store implementations (`rateLimiterStore` / `tokenRateLimiterStore`) behind a single generic `rateLimiterStore[K comparable]`; `RateLimitMiddleware` and `TokenRateLimitMiddleware` are now thin adapters over a shared factory. No behavior change.
 
 ## [0.28.0] - 2026-03-23
 

--- a/internal/auth/http/rate_limit_middleware.go
+++ b/internal/auth/http/rate_limit_middleware.go
@@ -3,33 +3,14 @@ package http
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"net/http"
-	"sync"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"golang.org/x/time/rate"
 
 	apperrors "github.com/allisson/secrets/internal/errors"
 	"github.com/allisson/secrets/internal/httputil"
 )
-
-// rateLimiterStore holds per-client rate limiters with automatic cleanup.
-type rateLimiterStore struct {
-	limiters sync.Map // map[uuid.UUID]*rateLimiterEntry
-	rps      float64
-	burst    int
-}
-
-// rateLimiterEntry holds a rate limiter and last access time for cleanup.
-type rateLimiterEntry struct {
-	limiter    *rate.Limiter
-	lastAccess time.Time
-	mu         sync.Mutex
-}
 
 // RateLimitMiddleware enforces per-client rate limiting on authenticated requests.
 //
@@ -46,100 +27,19 @@ type rateLimiterEntry struct {
 //   - 429 Too Many Requests: Rate limit exceeded (includes Retry-After header)
 //   - Continues: Request allowed within rate limit
 func RateLimitMiddleware(ctx context.Context, rps float64, burst int, logger *slog.Logger) gin.HandlerFunc {
-	store := &rateLimiterStore{
-		rps:   rps,
-		burst: burst,
-	}
-
-	// Start cleanup goroutine for stale limiters (every 5 minutes)
-	go store.cleanupStale(ctx, 5*time.Minute)
-
-	return func(c *gin.Context) {
-		// Get authenticated client from context
-		client, ok := GetClient(c.Request.Context())
-		if !ok || client == nil {
-			// Should never happen - authentication middleware should have caught this
-			logger.Error("rate limit middleware: no authenticated client in context")
-			httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
-			c.Abort()
-			return
-		}
-
-		// Get or create rate limiter for this client
-		limiter := store.getLimiter(client.ID)
-
-		// Check if request is allowed
-		if !limiter.Allow() {
-			// Calculate retry-after delay
-			reservation := limiter.Reserve()
-			retryAfter := int(reservation.Delay().Seconds())
-			reservation.Cancel() // Cancel the reservation
-
-			logger.Debug("rate limit exceeded",
-				slog.String("client_id", client.ID.String()),
-				slog.Int("retry_after", retryAfter))
-
-			c.Header("Retry-After", fmt.Sprintf("%d", retryAfter))
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error":   "rate_limit_exceeded",
-				"message": "Too many requests. Please retry after the specified delay.",
-			})
-			c.Abort()
-			return
-		}
-
-		// Request allowed, continue
-		c.Next()
-	}
-}
-
-// getLimiter retrieves or creates a rate limiter for a client.
-func (s *rateLimiterStore) getLimiter(clientID uuid.UUID) *rate.Limiter {
-	// Try to load existing limiter
-	if val, ok := s.limiters.Load(clientID); ok {
-		entry := val.(*rateLimiterEntry)
-		entry.mu.Lock()
-		entry.lastAccess = time.Now()
-		entry.mu.Unlock()
-		return entry.limiter
-	}
-
-	// Create new limiter
-	limiter := rate.NewLimiter(rate.Limit(s.rps), s.burst)
-	entry := &rateLimiterEntry{
-		limiter:    limiter,
-		lastAccess: time.Now(),
-	}
-
-	// Store and return
-	s.limiters.Store(clientID, entry)
-	return limiter
-}
-
-// cleanupStale removes rate limiters that haven't been accessed recently.
-// Runs periodically to prevent unbounded memory growth.
-func (s *rateLimiterStore) cleanupStale(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			// Remove limiters not accessed in last hour
-			threshold := time.Now().Add(-1 * time.Hour)
-			s.limiters.Range(func(key, value interface{}) bool {
-				entry := value.(*rateLimiterEntry)
-				entry.mu.Lock()
-				shouldDelete := entry.lastAccess.Before(threshold)
-				entry.mu.Unlock()
-
-				if shouldDelete {
-					s.limiters.Delete(key)
-				}
-				return true
-			})
-		}
-	}
+	return newRateLimitMiddleware(ctx, rps, burst, logger,
+		func(c *gin.Context) (uuid.UUID, bool) {
+			client, ok := GetClient(c.Request.Context())
+			if !ok || client == nil {
+				logger.Error("rate limit middleware: no authenticated client in context")
+				httputil.HandleErrorGin(c, apperrors.ErrUnauthorized, logger)
+				c.Abort()
+				return uuid.UUID{}, false
+			}
+			return client.ID, true
+		},
+		func(id uuid.UUID) slog.Attr { return slog.String("client_id", id.String()) },
+		"rate limit exceeded",
+		"Too many requests. Please retry after the specified delay.",
+	)
 }

--- a/internal/auth/http/rate_limit_middleware_test.go
+++ b/internal/auth/http/rate_limit_middleware_test.go
@@ -237,7 +237,7 @@ func TestRateLimitMiddleware_RequiresAuthentication(t *testing.T) {
 }
 
 func TestRateLimiterStore_CleanupStaleEntries(t *testing.T) {
-	store := &rateLimiterStore{
+	store := &rateLimiterStore[uuid.UUID]{
 		rps:   10.0,
 		burst: 20,
 	}

--- a/internal/auth/http/rate_limiter.go
+++ b/internal/auth/http/rate_limiter.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// rateLimiterEntry holds a rate limiter and last access time for cleanup.
+type rateLimiterEntry struct {
+	limiter    *rate.Limiter
+	lastAccess time.Time
+	mu         sync.Mutex
+}
+
+// rateLimiterStore holds per-key rate limiters with automatic cleanup.
+type rateLimiterStore[K comparable] struct {
+	limiters sync.Map
+	rps      float64
+	burst    int
+}
+
+func (s *rateLimiterStore[K]) getLimiter(key K) *rate.Limiter {
+	if val, ok := s.limiters.Load(key); ok {
+		entry := val.(*rateLimiterEntry)
+		entry.mu.Lock()
+		entry.lastAccess = time.Now()
+		entry.mu.Unlock()
+		return entry.limiter
+	}
+
+	limiter := rate.NewLimiter(rate.Limit(s.rps), s.burst)
+	entry := &rateLimiterEntry{
+		limiter:    limiter,
+		lastAccess: time.Now(),
+	}
+	s.limiters.Store(key, entry)
+	return limiter
+}
+
+func (s *rateLimiterStore[K]) cleanupStale(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			threshold := time.Now().Add(-1 * time.Hour)
+			s.limiters.Range(func(key, value interface{}) bool {
+				entry := value.(*rateLimiterEntry)
+				entry.mu.Lock()
+				shouldDelete := entry.lastAccess.Before(threshold)
+				entry.mu.Unlock()
+				if shouldDelete {
+					s.limiters.Delete(key)
+				}
+				return true
+			})
+		}
+	}
+}
+
+// newRateLimitMiddleware builds a gin.HandlerFunc that rate-limits by an
+// arbitrary key K extracted from the request.
+//
+// keyFn returns (key, true) on success; on failure it must write the error
+// response and call c.Abort() itself, then return (zero, false).
+// logAttr converts the key into a slog.Attr for the "rate limit exceeded" log line.
+// logMsg and errMsg customise the debug log and the JSON error body respectively.
+func newRateLimitMiddleware[K comparable](
+	ctx context.Context,
+	rps float64,
+	burst int,
+	logger *slog.Logger,
+	keyFn func(*gin.Context) (K, bool),
+	logAttr func(K) slog.Attr,
+	logMsg string,
+	errMsg string,
+) gin.HandlerFunc {
+	store := &rateLimiterStore[K]{rps: rps, burst: burst}
+	go store.cleanupStale(ctx, 5*time.Minute)
+
+	return func(c *gin.Context) {
+		key, ok := keyFn(c)
+		if !ok {
+			return
+		}
+
+		limiter := store.getLimiter(key)
+		if !limiter.Allow() {
+			reservation := limiter.Reserve()
+			retryAfter := int(reservation.Delay().Seconds())
+			reservation.Cancel()
+
+			logger.Debug(logMsg, logAttr(key), slog.Int("retry_after", retryAfter))
+			c.Header("Retry-After", fmt.Sprintf("%d", retryAfter))
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error":   "rate_limit_exceeded",
+				"message": errMsg,
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/auth/http/token_rate_limit_middleware.go
+++ b/internal/auth/http/token_rate_limit_middleware.go
@@ -3,29 +3,10 @@ package http
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"net/http"
-	"sync"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/time/rate"
 )
-
-// tokenRateLimiterStore holds per-IP rate limiters with automatic cleanup.
-type tokenRateLimiterStore struct {
-	limiters sync.Map // map[string]*tokenRateLimiterEntry (IP -> limiter)
-	rps      float64
-	burst    int
-}
-
-// tokenRateLimiterEntry holds a rate limiter and last access time for cleanup.
-type tokenRateLimiterEntry struct {
-	limiter    *rate.Limiter
-	lastAccess time.Time
-	mu         sync.Mutex
-}
 
 // TokenRateLimitMiddleware enforces per-IP rate limiting on token issuance endpoint.
 //
@@ -52,93 +33,10 @@ func TokenRateLimitMiddleware(
 	burst int,
 	logger *slog.Logger,
 ) gin.HandlerFunc {
-	store := &tokenRateLimiterStore{
-		rps:   rps,
-		burst: burst,
-	}
-
-	// Start cleanup goroutine for stale limiters (every 5 minutes)
-	go store.cleanupStale(ctx, 5*time.Minute)
-
-	return func(c *gin.Context) {
-		// Get client IP address
-		clientIP := c.ClientIP()
-
-		// Get or create rate limiter for this IP
-		limiter := store.getLimiter(clientIP)
-
-		// Check if request is allowed
-		if !limiter.Allow() {
-			// Calculate retry-after delay
-			reservation := limiter.Reserve()
-			retryAfter := int(reservation.Delay().Seconds())
-			reservation.Cancel() // Cancel the reservation
-
-			logger.Debug("token rate limit exceeded",
-				slog.String("client_ip", clientIP),
-				slog.Int("retry_after", retryAfter))
-
-			c.Header("Retry-After", fmt.Sprintf("%d", retryAfter))
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error":   "rate_limit_exceeded",
-				"message": "Too many token requests from this IP. Please retry after the specified delay.",
-			})
-			c.Abort()
-			return
-		}
-
-		// Request allowed, continue
-		c.Next()
-	}
-}
-
-// getLimiter retrieves or creates a rate limiter for an IP address.
-func (s *tokenRateLimiterStore) getLimiter(ip string) *rate.Limiter {
-	// Try to load existing limiter
-	if val, ok := s.limiters.Load(ip); ok {
-		entry := val.(*tokenRateLimiterEntry)
-		entry.mu.Lock()
-		entry.lastAccess = time.Now()
-		entry.mu.Unlock()
-		return entry.limiter
-	}
-
-	// Create new limiter
-	limiter := rate.NewLimiter(rate.Limit(s.rps), s.burst)
-	entry := &tokenRateLimiterEntry{
-		limiter:    limiter,
-		lastAccess: time.Now(),
-	}
-
-	// Store and return
-	s.limiters.Store(ip, entry)
-	return limiter
-}
-
-// cleanupStale removes rate limiters that haven't been accessed recently.
-// Runs periodically to prevent unbounded memory growth from IP address churn.
-func (s *tokenRateLimiterStore) cleanupStale(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			// Remove limiters not accessed in last hour
-			threshold := time.Now().Add(-1 * time.Hour)
-			s.limiters.Range(func(key, value interface{}) bool {
-				entry := value.(*tokenRateLimiterEntry)
-				entry.mu.Lock()
-				shouldDelete := entry.lastAccess.Before(threshold)
-				entry.mu.Unlock()
-
-				if shouldDelete {
-					s.limiters.Delete(key)
-				}
-				return true
-			})
-		}
-	}
+	return newRateLimitMiddleware(ctx, rps, burst, logger,
+		func(c *gin.Context) (string, bool) { return c.ClientIP(), true },
+		func(ip string) slog.Attr { return slog.String("client_ip", ip) },
+		"token rate limit exceeded",
+		"Too many token requests from this IP. Please retry after the specified delay.",
+	)
 }

--- a/internal/auth/http/token_rate_limit_middleware_test.go
+++ b/internal/auth/http/token_rate_limit_middleware_test.go
@@ -182,7 +182,7 @@ func TestTokenRateLimitMiddleware_NoAuthenticationRequired(t *testing.T) {
 }
 
 func TestTokenRateLimiterStore_CleanupStaleEntries(t *testing.T) {
-	store := &tokenRateLimiterStore{
+	store := &rateLimiterStore[string]{
 		rps:   10.0,
 		burst: 20,
 	}
@@ -198,7 +198,7 @@ func TestTokenRateLimiterStore_CleanupStaleEntries(t *testing.T) {
 
 	// Manually set last access to old time
 	if val, ok := store.limiters.Load(ip1); ok {
-		entry := val.(*tokenRateLimiterEntry)
+		entry := val.(*rateLimiterEntry)
 		entry.mu.Lock()
 		entry.lastAccess = time.Now().Add(-2 * time.Hour)
 		entry.mu.Unlock()
@@ -207,7 +207,7 @@ func TestTokenRateLimiterStore_CleanupStaleEntries(t *testing.T) {
 	// Run cleanup manually
 	threshold := time.Now().Add(-1 * time.Hour)
 	store.limiters.Range(func(key, value interface{}) bool {
-		entry := value.(*tokenRateLimiterEntry)
+		entry := value.(*rateLimiterEntry)
 		entry.mu.Lock()
 		shouldDelete := entry.lastAccess.Before(threshold)
 		entry.mu.Unlock()


### PR DESCRIPTION
## Summary

- Replace two structurally identical token-bucket store implementations (`rateLimiterStore` keyed by `uuid.UUID` and `tokenRateLimiterStore` keyed by `string`) with a single generic `rateLimiterStore[K comparable]` in a new `rate_limiter.go` file
- The shared `getLimiter`, `cleanupStale`, and `newRateLimitMiddleware` factory live once; `RateLimitMiddleware` and `TokenRateLimitMiddleware` become thin adapters (each ~10 lines) that supply a key extractor, log attribute, and message strings
- Any future bug in the store logic (cleanup goroutine, limiter lifecycle) is fixed in one place

## Test plan

- [ ] `make test` — all unit tests pass (147 in the auth/http package)
- [ ] `make lint` — no issues
- [ ] Goroutine leak tests still pass for both middleware functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)