### PR TITLE
refactor: fold Algorithm into TransitKey and unify Algorithm type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused `auditLogUseCase` dependency from `ClientHandler`. No behavior change.
 - Inlined `BusinessMetrics` into all use case structs via a named-return defer pattern and deleted the five metrics decorator layers. No behavior change.
 - Unified the two rate limiter store implementations (`rateLimiterStore` / `tokenRateLimiterStore`) behind a single generic `rateLimiterStore[K comparable]`; `RateLimitMiddleware` and `TokenRateLimitMiddleware` are now thin adapters over a shared factory. No behavior change.
+- Folded the `Algorithm` return value into `TransitKey.Algorithm` so `GetTransitKey` and `Get` return `(*TransitKey, error)` instead of a three-value tuple; replaced `crypto/domain.Algorithm` with `keyring.Algorithm` across transit and tokenization layers. No behavior change.
 
 ## [0.28.0] - 2026-03-23
 

--- a/internal/auth/service/mocks/mocks.go
+++ b/internal/auth/service/mocks/mocks.go
@@ -296,4 +296,3 @@ func (_c *MockTokenService_GenerateToken_Call) RunAndReturn(run func() (string, 
 	_c.Call.Return(run)
 	return _c
 }
-

--- a/internal/tokenization/usecase/mocks/mocks.go
+++ b/internal/tokenization/usecase/mocks/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"time"
 
-	domain0 "github.com/allisson/secrets/internal/crypto/domain"
+	"github.com/allisson/secrets/internal/keyring"
 	"github.com/allisson/secrets/internal/tokenization/domain"
 	"github.com/google/uuid"
 	mock "github.com/stretchr/testify/mock"
@@ -1163,7 +1163,7 @@ func (_m *MockTokenizationKeyUseCase) EXPECT() *MockTokenizationKeyUseCase_Expec
 }
 
 // Create provides a mock function for the type MockTokenizationKeyUseCase
-func (_mock *MockTokenizationKeyUseCase) Create(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg domain0.Algorithm) (*domain.TokenizationKey, error) {
+func (_mock *MockTokenizationKeyUseCase) Create(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg keyring.Algorithm) (*domain.TokenizationKey, error) {
 	ret := _mock.Called(ctx, name, formatType, isDeterministic, alg)
 
 	if len(ret) == 0 {
@@ -1172,17 +1172,17 @@ func (_mock *MockTokenizationKeyUseCase) Create(ctx context.Context, name string
 
 	var r0 *domain.TokenizationKey
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, domain0.Algorithm) (*domain.TokenizationKey, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, keyring.Algorithm) (*domain.TokenizationKey, error)); ok {
 		return returnFunc(ctx, name, formatType, isDeterministic, alg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, domain0.Algorithm) *domain.TokenizationKey); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, keyring.Algorithm) *domain.TokenizationKey); ok {
 		r0 = returnFunc(ctx, name, formatType, isDeterministic, alg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain.TokenizationKey)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, domain.FormatType, bool, domain0.Algorithm) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, domain.FormatType, bool, keyring.Algorithm) error); ok {
 		r1 = returnFunc(ctx, name, formatType, isDeterministic, alg)
 	} else {
 		r1 = ret.Error(1)
@@ -1200,12 +1200,12 @@ type MockTokenizationKeyUseCase_Create_Call struct {
 //   - name string
 //   - formatType domain.FormatType
 //   - isDeterministic bool
-//   - alg domain0.Algorithm
+//   - alg keyring.Algorithm
 func (_e *MockTokenizationKeyUseCase_Expecter) Create(ctx interface{}, name interface{}, formatType interface{}, isDeterministic interface{}, alg interface{}) *MockTokenizationKeyUseCase_Create_Call {
 	return &MockTokenizationKeyUseCase_Create_Call{Call: _e.mock.On("Create", ctx, name, formatType, isDeterministic, alg)}
 }
 
-func (_c *MockTokenizationKeyUseCase_Create_Call) Run(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg domain0.Algorithm)) *MockTokenizationKeyUseCase_Create_Call {
+func (_c *MockTokenizationKeyUseCase_Create_Call) Run(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg keyring.Algorithm)) *MockTokenizationKeyUseCase_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1223,9 +1223,9 @@ func (_c *MockTokenizationKeyUseCase_Create_Call) Run(run func(ctx context.Conte
 		if args[3] != nil {
 			arg3 = args[3].(bool)
 		}
-		var arg4 domain0.Algorithm
+		var arg4 keyring.Algorithm
 		if args[4] != nil {
-			arg4 = args[4].(domain0.Algorithm)
+			arg4 = args[4].(keyring.Algorithm)
 		}
 		run(
 			arg0,
@@ -1243,7 +1243,7 @@ func (_c *MockTokenizationKeyUseCase_Create_Call) Return(tokenizationKey *domain
 	return _c
 }
 
-func (_c *MockTokenizationKeyUseCase_Create_Call) RunAndReturn(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg domain0.Algorithm) (*domain.TokenizationKey, error)) *MockTokenizationKeyUseCase_Create_Call {
+func (_c *MockTokenizationKeyUseCase_Create_Call) RunAndReturn(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg keyring.Algorithm) (*domain.TokenizationKey, error)) *MockTokenizationKeyUseCase_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1520,7 +1520,7 @@ func (_c *MockTokenizationKeyUseCase_PurgeDeleted_Call) RunAndReturn(run func(ct
 }
 
 // Rotate provides a mock function for the type MockTokenizationKeyUseCase
-func (_mock *MockTokenizationKeyUseCase) Rotate(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg domain0.Algorithm) (*domain.TokenizationKey, error) {
+func (_mock *MockTokenizationKeyUseCase) Rotate(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg keyring.Algorithm) (*domain.TokenizationKey, error) {
 	ret := _mock.Called(ctx, name, formatType, isDeterministic, alg)
 
 	if len(ret) == 0 {
@@ -1529,17 +1529,17 @@ func (_mock *MockTokenizationKeyUseCase) Rotate(ctx context.Context, name string
 
 	var r0 *domain.TokenizationKey
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, domain0.Algorithm) (*domain.TokenizationKey, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, keyring.Algorithm) (*domain.TokenizationKey, error)); ok {
 		return returnFunc(ctx, name, formatType, isDeterministic, alg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, domain0.Algorithm) *domain.TokenizationKey); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.FormatType, bool, keyring.Algorithm) *domain.TokenizationKey); ok {
 		r0 = returnFunc(ctx, name, formatType, isDeterministic, alg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain.TokenizationKey)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, domain.FormatType, bool, domain0.Algorithm) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, domain.FormatType, bool, keyring.Algorithm) error); ok {
 		r1 = returnFunc(ctx, name, formatType, isDeterministic, alg)
 	} else {
 		r1 = ret.Error(1)
@@ -1557,12 +1557,12 @@ type MockTokenizationKeyUseCase_Rotate_Call struct {
 //   - name string
 //   - formatType domain.FormatType
 //   - isDeterministic bool
-//   - alg domain0.Algorithm
+//   - alg keyring.Algorithm
 func (_e *MockTokenizationKeyUseCase_Expecter) Rotate(ctx interface{}, name interface{}, formatType interface{}, isDeterministic interface{}, alg interface{}) *MockTokenizationKeyUseCase_Rotate_Call {
 	return &MockTokenizationKeyUseCase_Rotate_Call{Call: _e.mock.On("Rotate", ctx, name, formatType, isDeterministic, alg)}
 }
 
-func (_c *MockTokenizationKeyUseCase_Rotate_Call) Run(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg domain0.Algorithm)) *MockTokenizationKeyUseCase_Rotate_Call {
+func (_c *MockTokenizationKeyUseCase_Rotate_Call) Run(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg keyring.Algorithm)) *MockTokenizationKeyUseCase_Rotate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1580,9 +1580,9 @@ func (_c *MockTokenizationKeyUseCase_Rotate_Call) Run(run func(ctx context.Conte
 		if args[3] != nil {
 			arg3 = args[3].(bool)
 		}
-		var arg4 domain0.Algorithm
+		var arg4 keyring.Algorithm
 		if args[4] != nil {
-			arg4 = args[4].(domain0.Algorithm)
+			arg4 = args[4].(keyring.Algorithm)
 		}
 		run(
 			arg0,
@@ -1600,7 +1600,7 @@ func (_c *MockTokenizationKeyUseCase_Rotate_Call) Return(tokenizationKey *domain
 	return _c
 }
 
-func (_c *MockTokenizationKeyUseCase_Rotate_Call) RunAndReturn(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg domain0.Algorithm) (*domain.TokenizationKey, error)) *MockTokenizationKeyUseCase_Rotate_Call {
+func (_c *MockTokenizationKeyUseCase_Rotate_Call) RunAndReturn(run func(ctx context.Context, name string, formatType domain.FormatType, isDeterministic bool, alg keyring.Algorithm) (*domain.TokenizationKey, error)) *MockTokenizationKeyUseCase_Rotate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/transit/domain/repository.go
+++ b/internal/transit/domain/repository.go
@@ -3,8 +3,6 @@ package domain
 import (
 	"context"
 	"time"
-
-	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
 )
 
 // TransitKeyRepository defines the interface for transit key persistence.
@@ -22,8 +20,9 @@ type TransitKeyRepository interface {
 	GetByNameAndVersion(ctx context.Context, name string, version uint) (*TransitKey, error)
 
 	// GetTransitKey retrieves a transit key version by name and optional version (0 for latest),
-	// including its associated encryption algorithm. Returns ErrTransitKeyNotFound if not found.
-	GetTransitKey(ctx context.Context, name string, version uint) (*TransitKey, cryptoDomain.Algorithm, error)
+	// including its associated encryption algorithm (populated in TransitKey.Algorithm).
+	// Returns ErrTransitKeyNotFound if not found.
+	GetTransitKey(ctx context.Context, name string, version uint) (*TransitKey, error)
 
 	// ListCursor retrieves transit keys ordered by name ascending with cursor-based pagination.
 	// If afterName is provided, returns keys with name greater than afterName (ASC order).

--- a/internal/transit/domain/transit_key.go
+++ b/internal/transit/domain/transit_key.go
@@ -17,6 +17,7 @@ type TransitKey struct {
 	Name      string     // Human-readable name (shared across all versions of this key)
 	Version   uint       // Key version number (increments with rotation, starts at 1)
 	DekID     uuid.UUID  // Reference to the Data Encryption Key used to encrypt this transit key
+	Algorithm string     // AEAD algorithm name (populated on read; empty when creating)
 	CreatedAt time.Time  // Timestamp when this key version was created (UTC)
 	DeletedAt *time.Time // Soft deletion timestamp (nil if active, set when deleted)
 }

--- a/internal/transit/http/dto/request_test.go
+++ b/internal/transit/http/dto/request_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
+	"github.com/allisson/secrets/internal/keyring"
 )
 
 func TestCreateTransitKeyRequest_Validate(t *testing.T) {
@@ -195,13 +195,13 @@ func TestParseAlgorithm(t *testing.T) {
 	t.Run("Success_AESGCM", func(t *testing.T) {
 		alg, err := ParseAlgorithm("aes-gcm")
 		assert.NoError(t, err)
-		assert.Equal(t, cryptoDomain.AESGCM, alg)
+		assert.Equal(t, keyring.AESGCM, alg)
 	})
 
 	t.Run("Success_ChaCha20", func(t *testing.T) {
 		alg, err := ParseAlgorithm("chacha20-poly1305")
 		assert.NoError(t, err)
-		assert.Equal(t, cryptoDomain.ChaCha20, alg)
+		assert.Equal(t, keyring.ChaCha20, alg)
 	})
 
 	t.Run("Error_InvalidAlgorithm", func(t *testing.T) {

--- a/internal/transit/http/transit_key_handler.go
+++ b/internal/transit/http/transit_key_handler.go
@@ -208,13 +208,13 @@ func (h *TransitKeyHandler) GetHandler(c *gin.Context) {
 	}
 
 	// Call use case
-	transitKey, alg, err := h.transitKeyUseCase.Get(c.Request.Context(), name, version)
+	transitKey, err := h.transitKeyUseCase.Get(c.Request.Context(), name, version)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return
 	}
 
 	// Map to response
-	response := dto.MapTransitKeyToMetadataResponse(transitKey, string(alg))
+	response := dto.MapTransitKeyToMetadataResponse(transitKey, transitKey.Algorithm)
 	c.JSON(http.StatusOK, response)
 }

--- a/internal/transit/http/transit_key_handler_test.go
+++ b/internal/transit/http/transit_key_handler_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
 	apperrors "github.com/allisson/secrets/internal/errors"
+	"github.com/allisson/secrets/internal/keyring"
 	transitDomain "github.com/allisson/secrets/internal/transit/domain"
 	"github.com/allisson/secrets/internal/transit/http/dto"
 	"github.com/allisson/secrets/internal/transit/usecase/mocks"
@@ -58,7 +58,7 @@ func TestTransitKeyHandler_CreateHandler(t *testing.T) {
 		}
 
 		mockUseCase.EXPECT().
-			Create(mock.Anything, "test-key", cryptoDomain.AESGCM).
+			Create(mock.Anything, "test-key", keyring.AESGCM).
 			Return(expectedTransitKey, nil).
 			Once()
 
@@ -98,7 +98,7 @@ func TestTransitKeyHandler_CreateHandler(t *testing.T) {
 		}
 
 		mockUseCase.EXPECT().
-			Create(mock.Anything, "test-key-chacha", cryptoDomain.ChaCha20).
+			Create(mock.Anything, "test-key-chacha", keyring.ChaCha20).
 			Return(expectedTransitKey, nil).
 			Once()
 
@@ -180,7 +180,7 @@ func TestTransitKeyHandler_CreateHandler(t *testing.T) {
 		}
 
 		mockUseCase.EXPECT().
-			Create(mock.Anything, "test-key", cryptoDomain.AESGCM).
+			Create(mock.Anything, "test-key", keyring.AESGCM).
 			Return(nil, apperrors.ErrConflict).
 			Once()
 
@@ -213,7 +213,7 @@ func TestTransitKeyHandler_RotateHandler(t *testing.T) {
 		}
 
 		mockUseCase.EXPECT().
-			Rotate(mock.Anything, "test-key", cryptoDomain.AESGCM).
+			Rotate(mock.Anything, "test-key", keyring.AESGCM).
 			Return(expectedTransitKey, nil).
 			Once()
 
@@ -297,7 +297,7 @@ func TestTransitKeyHandler_RotateHandler(t *testing.T) {
 		}
 
 		mockUseCase.EXPECT().
-			Rotate(mock.Anything, "nonexistent-key", cryptoDomain.AESGCM).
+			Rotate(mock.Anything, "nonexistent-key", keyring.AESGCM).
 			Return(nil, transitDomain.ErrTransitKeyNotFound).
 			Once()
 
@@ -408,13 +408,13 @@ func TestTransitKeyHandler_GetHandler(t *testing.T) {
 			Name:      "test-key",
 			Version:   1,
 			DekID:     uuid.Must(uuid.NewV7()),
+			Algorithm: string(keyring.AESGCM),
 			CreatedAt: now,
 		}
-		expectedAlg := cryptoDomain.AESGCM
 
 		mockUseCase.EXPECT().
 			Get(mock.Anything, "test-key", uint(0)).
-			Return(expectedKey, expectedAlg, nil).
+			Return(expectedKey, nil).
 			Once()
 
 		c, w := createTestContext(http.MethodGet, "/v1/transit/keys/test-key", nil)
@@ -441,13 +441,13 @@ func TestTransitKeyHandler_GetHandler(t *testing.T) {
 			Name:      "test-key",
 			Version:   2,
 			DekID:     uuid.Must(uuid.NewV7()),
+			Algorithm: string(keyring.ChaCha20),
 			CreatedAt: now,
 		}
-		expectedAlg := cryptoDomain.ChaCha20
 
 		mockUseCase.EXPECT().
 			Get(mock.Anything, "test-key", uint(2)).
-			Return(expectedKey, expectedAlg, nil).
+			Return(expectedKey, nil).
 			Once()
 
 		c, w := createTestContext(http.MethodGet, "/v1/transit/keys/test-key?version=2", nil)
@@ -492,7 +492,7 @@ func TestTransitKeyHandler_GetHandler(t *testing.T) {
 
 		mockUseCase.EXPECT().
 			Get(mock.Anything, "nonexistent", uint(0)).
-			Return(nil, cryptoDomain.Algorithm(""), transitDomain.ErrTransitKeyNotFound).
+			Return(nil, transitDomain.ErrTransitKeyNotFound).
 			Once()
 
 		c, w := createTestContext(http.MethodGet, "/v1/transit/keys/nonexistent", nil)

--- a/internal/transit/repository/transit_key_repository.go
+++ b/internal/transit/repository/transit_key_repository.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"time"
 
-	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
 	"github.com/allisson/secrets/internal/database"
 	apperrors "github.com/allisson/secrets/internal/errors"
 	transitDomain "github.com/allisson/secrets/internal/transit/domain"
@@ -123,27 +122,28 @@ func (p *TransitKeyRepository) GetByNameAndVersion(
 }
 
 // GetTransitKey retrieves a transit key version by name and optional version (0 for latest),
-// including its associated encryption algorithm. Returns ErrTransitKeyNotFound if not found.
+// including its associated encryption algorithm (populated in TransitKey.Algorithm).
+// Returns ErrTransitKeyNotFound if not found.
 func (p *TransitKeyRepository) GetTransitKey(
 	ctx context.Context,
 	name string,
 	version uint,
-) (*transitDomain.TransitKey, cryptoDomain.Algorithm, error) {
+) (*transitDomain.TransitKey, error) {
 	querier := database.GetTx(ctx, p.db)
 
 	var query string
 	var args []interface{}
 
 	if version == 0 {
-		query = `SELECT tk.id, tk.name, tk.version, tk.dek_id, tk.created_at, tk.deleted_at, d.algorithm 
+		query = `SELECT tk.id, tk.name, tk.version, tk.dek_id, tk.created_at, tk.deleted_at, d.algorithm
 				  FROM transit_keys tk
 				  JOIN deks d ON tk.dek_id = d.id
-				  WHERE tk.name = $1 AND tk.deleted_at IS NULL 
-				  ORDER BY tk.version DESC 
+				  WHERE tk.name = $1 AND tk.deleted_at IS NULL
+				  ORDER BY tk.version DESC
 				  LIMIT 1`
 		args = []interface{}{name}
 	} else {
-		query = `SELECT tk.id, tk.name, tk.version, tk.dek_id, tk.created_at, tk.deleted_at, d.algorithm 
+		query = `SELECT tk.id, tk.name, tk.version, tk.dek_id, tk.created_at, tk.deleted_at, d.algorithm
 				  FROM transit_keys tk
 				  JOIN deks d ON tk.dek_id = d.id
 				  WHERE tk.name = $1 AND tk.version = $2 AND tk.deleted_at IS NULL`
@@ -151,7 +151,6 @@ func (p *TransitKeyRepository) GetTransitKey(
 	}
 
 	var transitKey transitDomain.TransitKey
-	var algorithm cryptoDomain.Algorithm
 	err := querier.QueryRowContext(ctx, query, args...).Scan(
 		&transitKey.ID,
 		&transitKey.Name,
@@ -159,16 +158,16 @@ func (p *TransitKeyRepository) GetTransitKey(
 		&transitKey.DekID,
 		&transitKey.CreatedAt,
 		&transitKey.DeletedAt,
-		&algorithm,
+		&transitKey.Algorithm,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, "", transitDomain.ErrTransitKeyNotFound
+			return nil, transitDomain.ErrTransitKeyNotFound
 		}
-		return nil, "", apperrors.Wrap(err, "failed to get transit key")
+		return nil, apperrors.Wrap(err, "failed to get transit key")
 	}
 
-	return &transitKey, algorithm, nil
+	return &transitKey, nil
 }
 
 // ListCursor retrieves transit keys ordered by name ascending using cursor-based pagination.

--- a/internal/transit/repository/transit_key_repository_test.go
+++ b/internal/transit/repository/transit_key_repository_test.go
@@ -847,35 +847,33 @@ func TestTransitKeyRepository_GetTransitKey(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Get latest version", func(t *testing.T) {
-		tk, alg, err := repo.GetTransitKey(ctx, name, 0)
+		tk, err := repo.GetTransitKey(ctx, name, 0)
 		require.NoError(t, err)
 		assert.Equal(t, key2.ID, tk.ID)
 		assert.Equal(t, name, tk.Name)
 		assert.Equal(t, uint(2), tk.Version)
-		assert.Equal(t, algorithm, alg)
+		assert.Equal(t, string(algorithm), tk.Algorithm)
 	})
 
 	t.Run("Get specific version", func(t *testing.T) {
-		tk, alg, err := repo.GetTransitKey(ctx, name, 1)
+		tk, err := repo.GetTransitKey(ctx, name, 1)
 		require.NoError(t, err)
 		assert.Equal(t, key1.ID, tk.ID)
 		assert.Equal(t, name, tk.Name)
 		assert.Equal(t, uint(1), tk.Version)
-		assert.Equal(t, algorithm, alg)
+		assert.Equal(t, string(algorithm), tk.Algorithm)
 	})
 
 	t.Run("Key not found", func(t *testing.T) {
-		tk, alg, err := repo.GetTransitKey(ctx, "non-existent", 0)
+		tk, err := repo.GetTransitKey(ctx, "non-existent", 0)
 		assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
 		assert.Nil(t, tk)
-		assert.Empty(t, alg)
 	})
 
 	t.Run("Version not found", func(t *testing.T) {
-		tk, alg, err := repo.GetTransitKey(ctx, name, 3)
+		tk, err := repo.GetTransitKey(ctx, name, 3)
 		assert.ErrorIs(t, err, transitDomain.ErrTransitKeyNotFound)
 		assert.Nil(t, tk)
-		assert.Empty(t, alg)
 	})
 }
 

--- a/internal/transit/usecase/interface.go
+++ b/internal/transit/usecase/interface.go
@@ -23,13 +23,14 @@ type TransitKeyUseCase interface {
 	// Generates a new DEK for the new version while preserving old versions for decryption.
 	Rotate(ctx context.Context, name string, alg keyring.Algorithm) (*transitDomain.TransitKey, error)
 
-	// Get retrieves transit key metadata (including its algorithm) by name and optional version.
+	// Get retrieves transit key metadata by name and optional version.
 	// If version is 0, the latest version is retrieved.
+	// The algorithm is available in the returned TransitKey.Algorithm field.
 	Get(
 		ctx context.Context,
 		name string,
 		version uint,
-	) (*transitDomain.TransitKey, keyring.Algorithm, error)
+	) (*transitDomain.TransitKey, error)
 
 	// Delete soft deletes a transit key and all its versions by name.
 	Delete(ctx context.Context, name string) error

--- a/internal/transit/usecase/metrics_transit_key_usecase.go
+++ b/internal/transit/usecase/metrics_transit_key_usecase.go
@@ -50,9 +50,9 @@ func (m *metricsTransitKeyUseCase) Get(
 	ctx context.Context,
 	name string,
 	version uint,
-) (key *transitDomain.TransitKey, alg keyring.Algorithm, err error) {
+) (key *transitDomain.TransitKey, err error) {
 	start := time.Now()
-	key, alg, err = m.inner.Get(ctx, name, version)
+	key, err = m.inner.Get(ctx, name, version)
 	metrics.Record(ctx, m.bm, m.domain, "transit_key_get", start, err)
 	return
 }

--- a/internal/transit/usecase/mocks/mocks.go
+++ b/internal/transit/usecase/mocks/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"time"
 
-	domain0 "github.com/allisson/secrets/internal/crypto/domain"
+	"github.com/allisson/secrets/internal/keyring"
 	"github.com/allisson/secrets/internal/transit/domain"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -297,7 +297,7 @@ func (_c *MockTransitKeyRepository_GetByNameAndVersion_Call) RunAndReturn(run fu
 }
 
 // GetTransitKey provides a mock function for the type MockTransitKeyRepository
-func (_mock *MockTransitKeyRepository) GetTransitKey(ctx context.Context, name string, version uint) (*domain.TransitKey, domain0.Algorithm, error) {
+func (_mock *MockTransitKeyRepository) GetTransitKey(ctx context.Context, name string, version uint) (*domain.TransitKey, error) {
 	ret := _mock.Called(ctx, name, version)
 
 	if len(ret) == 0 {
@@ -305,9 +305,8 @@ func (_mock *MockTransitKeyRepository) GetTransitKey(ctx context.Context, name s
 	}
 
 	var r0 *domain.TransitKey
-	var r1 domain0.Algorithm
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint) (*domain.TransitKey, domain0.Algorithm, error)); ok {
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint) (*domain.TransitKey, error)); ok {
 		return returnFunc(ctx, name, version)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint) *domain.TransitKey); ok {
@@ -317,17 +316,12 @@ func (_mock *MockTransitKeyRepository) GetTransitKey(ctx context.Context, name s
 			r0 = ret.Get(0).(*domain.TransitKey)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uint) domain0.Algorithm); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uint) error); ok {
 		r1 = returnFunc(ctx, name, version)
 	} else {
-		r1 = ret.Get(1).(domain0.Algorithm)
+		r1 = ret.Error(1)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, uint) error); ok {
-		r2 = returnFunc(ctx, name, version)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockTransitKeyRepository_GetTransitKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransitKey'
@@ -366,12 +360,12 @@ func (_c *MockTransitKeyRepository_GetTransitKey_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *MockTransitKeyRepository_GetTransitKey_Call) Return(transitKey *domain.TransitKey, algorithm domain0.Algorithm, err error) *MockTransitKeyRepository_GetTransitKey_Call {
-	_c.Call.Return(transitKey, algorithm, err)
+func (_c *MockTransitKeyRepository_GetTransitKey_Call) Return(transitKey *domain.TransitKey, err error) *MockTransitKeyRepository_GetTransitKey_Call {
+	_c.Call.Return(transitKey, err)
 	return _c
 }
 
-func (_c *MockTransitKeyRepository_GetTransitKey_Call) RunAndReturn(run func(ctx context.Context, name string, version uint) (*domain.TransitKey, domain0.Algorithm, error)) *MockTransitKeyRepository_GetTransitKey_Call {
+func (_c *MockTransitKeyRepository_GetTransitKey_Call) RunAndReturn(run func(ctx context.Context, name string, version uint) (*domain.TransitKey, error)) *MockTransitKeyRepository_GetTransitKey_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -550,7 +544,7 @@ func (_m *MockTransitKeyUseCase) EXPECT() *MockTransitKeyUseCase_Expecter {
 }
 
 // Create provides a mock function for the type MockTransitKeyUseCase
-func (_mock *MockTransitKeyUseCase) Create(ctx context.Context, name string, alg domain0.Algorithm) (*domain.TransitKey, error) {
+func (_mock *MockTransitKeyUseCase) Create(ctx context.Context, name string, alg keyring.Algorithm) (*domain.TransitKey, error) {
 	ret := _mock.Called(ctx, name, alg)
 
 	if len(ret) == 0 {
@@ -559,17 +553,17 @@ func (_mock *MockTransitKeyUseCase) Create(ctx context.Context, name string, alg
 
 	var r0 *domain.TransitKey
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain0.Algorithm) (*domain.TransitKey, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, keyring.Algorithm) (*domain.TransitKey, error)); ok {
 		return returnFunc(ctx, name, alg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain0.Algorithm) *domain.TransitKey); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, keyring.Algorithm) *domain.TransitKey); ok {
 		r0 = returnFunc(ctx, name, alg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain.TransitKey)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, domain0.Algorithm) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, keyring.Algorithm) error); ok {
 		r1 = returnFunc(ctx, name, alg)
 	} else {
 		r1 = ret.Error(1)
@@ -585,12 +579,12 @@ type MockTransitKeyUseCase_Create_Call struct {
 // Create is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-//   - alg domain0.Algorithm
+//   - alg keyring.Algorithm
 func (_e *MockTransitKeyUseCase_Expecter) Create(ctx interface{}, name interface{}, alg interface{}) *MockTransitKeyUseCase_Create_Call {
 	return &MockTransitKeyUseCase_Create_Call{Call: _e.mock.On("Create", ctx, name, alg)}
 }
 
-func (_c *MockTransitKeyUseCase_Create_Call) Run(run func(ctx context.Context, name string, alg domain0.Algorithm)) *MockTransitKeyUseCase_Create_Call {
+func (_c *MockTransitKeyUseCase_Create_Call) Run(run func(ctx context.Context, name string, alg keyring.Algorithm)) *MockTransitKeyUseCase_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -600,9 +594,9 @@ func (_c *MockTransitKeyUseCase_Create_Call) Run(run func(ctx context.Context, n
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 domain0.Algorithm
+		var arg2 keyring.Algorithm
 		if args[2] != nil {
-			arg2 = args[2].(domain0.Algorithm)
+			arg2 = args[2].(keyring.Algorithm)
 		}
 		run(
 			arg0,
@@ -618,7 +612,7 @@ func (_c *MockTransitKeyUseCase_Create_Call) Return(transitKey *domain.TransitKe
 	return _c
 }
 
-func (_c *MockTransitKeyUseCase_Create_Call) RunAndReturn(run func(ctx context.Context, name string, alg domain0.Algorithm) (*domain.TransitKey, error)) *MockTransitKeyUseCase_Create_Call {
+func (_c *MockTransitKeyUseCase_Create_Call) RunAndReturn(run func(ctx context.Context, name string, alg keyring.Algorithm) (*domain.TransitKey, error)) *MockTransitKeyUseCase_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -841,7 +835,7 @@ func (_c *MockTransitKeyUseCase_Encrypt_Call) RunAndReturn(run func(ctx context.
 }
 
 // Get provides a mock function for the type MockTransitKeyUseCase
-func (_mock *MockTransitKeyUseCase) Get(ctx context.Context, name string, version uint) (*domain.TransitKey, domain0.Algorithm, error) {
+func (_mock *MockTransitKeyUseCase) Get(ctx context.Context, name string, version uint) (*domain.TransitKey, error) {
 	ret := _mock.Called(ctx, name, version)
 
 	if len(ret) == 0 {
@@ -849,9 +843,8 @@ func (_mock *MockTransitKeyUseCase) Get(ctx context.Context, name string, versio
 	}
 
 	var r0 *domain.TransitKey
-	var r1 domain0.Algorithm
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint) (*domain.TransitKey, domain0.Algorithm, error)); ok {
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint) (*domain.TransitKey, error)); ok {
 		return returnFunc(ctx, name, version)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint) *domain.TransitKey); ok {
@@ -861,17 +854,12 @@ func (_mock *MockTransitKeyUseCase) Get(ctx context.Context, name string, versio
 			r0 = ret.Get(0).(*domain.TransitKey)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uint) domain0.Algorithm); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uint) error); ok {
 		r1 = returnFunc(ctx, name, version)
 	} else {
-		r1 = ret.Get(1).(domain0.Algorithm)
+		r1 = ret.Error(1)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, uint) error); ok {
-		r2 = returnFunc(ctx, name, version)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockTransitKeyUseCase_Get_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Get'
@@ -910,12 +898,12 @@ func (_c *MockTransitKeyUseCase_Get_Call) Run(run func(ctx context.Context, name
 	return _c
 }
 
-func (_c *MockTransitKeyUseCase_Get_Call) Return(transitKey *domain.TransitKey, algorithm domain0.Algorithm, err error) *MockTransitKeyUseCase_Get_Call {
-	_c.Call.Return(transitKey, algorithm, err)
+func (_c *MockTransitKeyUseCase_Get_Call) Return(transitKey *domain.TransitKey, err error) *MockTransitKeyUseCase_Get_Call {
+	_c.Call.Return(transitKey, err)
 	return _c
 }
 
-func (_c *MockTransitKeyUseCase_Get_Call) RunAndReturn(run func(ctx context.Context, name string, version uint) (*domain.TransitKey, domain0.Algorithm, error)) *MockTransitKeyUseCase_Get_Call {
+func (_c *MockTransitKeyUseCase_Get_Call) RunAndReturn(run func(ctx context.Context, name string, version uint) (*domain.TransitKey, error)) *MockTransitKeyUseCase_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1067,7 +1055,7 @@ func (_c *MockTransitKeyUseCase_PurgeDeleted_Call) RunAndReturn(run func(ctx con
 }
 
 // Rotate provides a mock function for the type MockTransitKeyUseCase
-func (_mock *MockTransitKeyUseCase) Rotate(ctx context.Context, name string, alg domain0.Algorithm) (*domain.TransitKey, error) {
+func (_mock *MockTransitKeyUseCase) Rotate(ctx context.Context, name string, alg keyring.Algorithm) (*domain.TransitKey, error) {
 	ret := _mock.Called(ctx, name, alg)
 
 	if len(ret) == 0 {
@@ -1076,17 +1064,17 @@ func (_mock *MockTransitKeyUseCase) Rotate(ctx context.Context, name string, alg
 
 	var r0 *domain.TransitKey
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain0.Algorithm) (*domain.TransitKey, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, keyring.Algorithm) (*domain.TransitKey, error)); ok {
 		return returnFunc(ctx, name, alg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain0.Algorithm) *domain.TransitKey); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, keyring.Algorithm) *domain.TransitKey); ok {
 		r0 = returnFunc(ctx, name, alg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain.TransitKey)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, domain0.Algorithm) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, keyring.Algorithm) error); ok {
 		r1 = returnFunc(ctx, name, alg)
 	} else {
 		r1 = ret.Error(1)
@@ -1102,12 +1090,12 @@ type MockTransitKeyUseCase_Rotate_Call struct {
 // Rotate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-//   - alg domain0.Algorithm
+//   - alg keyring.Algorithm
 func (_e *MockTransitKeyUseCase_Expecter) Rotate(ctx interface{}, name interface{}, alg interface{}) *MockTransitKeyUseCase_Rotate_Call {
 	return &MockTransitKeyUseCase_Rotate_Call{Call: _e.mock.On("Rotate", ctx, name, alg)}
 }
 
-func (_c *MockTransitKeyUseCase_Rotate_Call) Run(run func(ctx context.Context, name string, alg domain0.Algorithm)) *MockTransitKeyUseCase_Rotate_Call {
+func (_c *MockTransitKeyUseCase_Rotate_Call) Run(run func(ctx context.Context, name string, alg keyring.Algorithm)) *MockTransitKeyUseCase_Rotate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1117,9 +1105,9 @@ func (_c *MockTransitKeyUseCase_Rotate_Call) Run(run func(ctx context.Context, n
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 domain0.Algorithm
+		var arg2 keyring.Algorithm
 		if args[2] != nil {
-			arg2 = args[2].(domain0.Algorithm)
+			arg2 = args[2].(keyring.Algorithm)
 		}
 		run(
 			arg0,
@@ -1135,7 +1123,7 @@ func (_c *MockTransitKeyUseCase_Rotate_Call) Return(transitKey *domain.TransitKe
 	return _c
 }
 
-func (_c *MockTransitKeyUseCase_Rotate_Call) RunAndReturn(run func(ctx context.Context, name string, alg domain0.Algorithm) (*domain.TransitKey, error)) *MockTransitKeyUseCase_Rotate_Call {
+func (_c *MockTransitKeyUseCase_Rotate_Call) RunAndReturn(run func(ctx context.Context, name string, alg keyring.Algorithm) (*domain.TransitKey, error)) *MockTransitKeyUseCase_Rotate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/transit/usecase/transit_key_usecase.go
+++ b/internal/transit/usecase/transit_key_usecase.go
@@ -100,14 +100,14 @@ func (t *transitKeyUseCase) Rotate(
 	return newTransitKey, nil
 }
 
-// Get retrieves transit key metadata (including its algorithm) by name and optional version.
+// Get retrieves transit key metadata by name and optional version.
+// The algorithm is available in the returned TransitKey.Algorithm field.
 func (t *transitKeyUseCase) Get(
 	ctx context.Context,
 	name string,
 	version uint,
-) (key *transitDomain.TransitKey, alg keyring.Algorithm, err error) {
-	key, alg, err = t.transitRepo.GetTransitKey(ctx, name, version)
-	return
+) (*transitDomain.TransitKey, error) {
+	return t.transitRepo.GetTransitKey(ctx, name, version)
 }
 
 // Delete soft-deletes all versions of a transit key by name.

--- a/internal/transit/usecase/transit_key_usecase_test.go
+++ b/internal/transit/usecase/transit_key_usecase_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	cryptoDomain "github.com/allisson/secrets/internal/crypto/domain"
 	"github.com/allisson/secrets/internal/keyring"
 	transitDomain "github.com/allisson/secrets/internal/transit/domain"
 	"github.com/allisson/secrets/internal/transit/usecase"
@@ -59,7 +58,7 @@ func TestTransitKeyUseCase_Create(t *testing.T) {
 			})).
 			Return(nil)
 
-		key, err := uc.Create(ctx, "k", cryptoDomain.AESGCM)
+		key, err := uc.Create(ctx, "k", keyring.AESGCM)
 		require.NoError(t, err)
 		assert.Equal(t, "k", key.Name)
 		assert.EqualValues(t, 1, key.Version)
@@ -73,7 +72,7 @@ func TestTransitKeyUseCase_Create(t *testing.T) {
 			GetByNameAndVersion(ctx, "dup", uint(1)).
 			Return(&transitDomain.TransitKey{}, nil)
 
-		_, err := uc.Create(ctx, "dup", cryptoDomain.AESGCM)
+		_, err := uc.Create(ctx, "dup", keyring.AESGCM)
 		assert.ErrorIs(t, err, transitDomain.ErrTransitKeyAlreadyExists)
 	})
 }
@@ -95,7 +94,7 @@ func TestTransitKeyUseCase_Rotate(t *testing.T) {
 			})).
 			Return(nil)
 
-		key, err := uc.Rotate(ctx, "k", cryptoDomain.AESGCM)
+		key, err := uc.Rotate(ctx, "k", keyring.AESGCM)
 		require.NoError(t, err)
 		assert.EqualValues(t, 3, key.Version)
 	})
@@ -113,7 +112,7 @@ func TestTransitKeyUseCase_Rotate(t *testing.T) {
 			})).
 			Return(nil)
 
-		key, err := uc.Rotate(ctx, "new", cryptoDomain.AESGCM)
+		key, err := uc.Rotate(ctx, "new", keyring.AESGCM)
 		require.NoError(t, err)
 		assert.EqualValues(t, 1, key.Version)
 	})
@@ -171,7 +170,7 @@ func TestTransitKeyUseCase_Decrypt_CiphertextTooShort(t *testing.T) {
 	// 5 bytes < 12-byte nonce
 	wire := fmt.Sprintf("1:%s", base64.StdEncoding.EncodeToString([]byte{1, 2, 3, 4, 5}))
 	_, err := uc.Decrypt(ctx, "k", wire, nil)
-	assert.ErrorIs(t, err, cryptoDomain.ErrDecryptionFailed)
+	assert.ErrorIs(t, err, keyring.ErrDecryptionFailed)
 }
 
 func TestTransitKeyUseCase_Get(t *testing.T) {
@@ -179,13 +178,12 @@ func TestTransitKeyUseCase_Get(t *testing.T) {
 	ctx := context.Background()
 	uc, _, repo := newTransitKeyUseCase(t)
 
-	want := &transitDomain.TransitKey{Name: "k", Version: 1}
-	repo.EXPECT().GetTransitKey(ctx, "k", uint(0)).Return(want, cryptoDomain.AESGCM, nil)
+	want := &transitDomain.TransitKey{Name: "k", Version: 1, Algorithm: string(keyring.AESGCM)}
+	repo.EXPECT().GetTransitKey(ctx, "k", uint(0)).Return(want, nil)
 
-	got, alg, err := uc.Get(ctx, "k", 0)
+	got, err := uc.Get(ctx, "k", 0)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
-	assert.Equal(t, cryptoDomain.AESGCM, alg)
 }
 
 func TestTransitKeyUseCase_Delete(t *testing.T) {


### PR DESCRIPTION
## Summary

- Move `Algorithm` into the `TransitKey` struct so `GetTransitKey` and `Get` return `(*TransitKey, error)` instead of a three-value tuple, reducing call-site complexity
- Replace `cryptoDomain.Algorithm` with `keyring.Algorithm` across transit and tokenization layers, eliminating the `crypto/domain` import alias from all call sites
- Update repository, usecase, HTTP handler, tests, and generated mocks accordingly

## Test plan

- [ ] `make test` passes with race detector
- [ ] All transit key handler and repository tests updated to match new signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)