### PR TITLE
refactor: replace sync.Once+sync.Map boilerplate with generic once[T] helper

### DIFF
--- a/internal/app/di.go
+++ b/internal/app/di.go
@@ -27,99 +27,62 @@ import (
 
 // Container holds all application dependencies with lazy initialization.
 type Container struct {
-	// Configuration
 	config *config.Config
 
-	// Infrastructure
-	logger         *slog.Logger
-	db             *sql.DB
-	masterKeyChain *keyring.MasterKeyChain
+	// Infallible singletons — kept as plain sync.Once because they cannot fail.
+	logger            *slog.Logger
+	loggerInit        sync.Once
+	kmsService        keyring.KMSService
+	kmsServiceInit    sync.Once
+	secretService     authService.SecretService
+	secretServiceInit sync.Once
+	tokenService      authService.TokenService
+	tokenServiceInit  sync.Once
 
-	// Managers
-	txManager database.TxManager
+	// Infrastructure
+	db             once[*sql.DB]
+	masterKeyChain once[*keyring.MasterKeyChain]
+	txManager      once[database.TxManager]
 
 	// Metrics
-	metricsProvider *metrics.Provider
-	businessMetrics metrics.BusinessMetrics
-
-	// Services
-	kmsService    keyring.KMSService
-	secretService authService.SecretService
-	tokenService  authService.TokenService
+	metricsProvider once[*metrics.Provider]
+	businessMetrics once[metrics.BusinessMetrics]
 
 	// Keyring (envelope encryption)
-	keyring keyring.Keyring
+	keyring once[keyring.Keyring]
 
 	// Repositories
-	secretRepository            secretsUseCase.SecretRepository
-	clientRepository            authUseCase.ClientRepository
-	tokenRepository             authUseCase.TokenRepository
-	auditLogRepository          authUseCase.AuditLogRepository
-	transitKeyRepository        transitUseCase.TransitKeyRepository
-	tokenizationKeyRepository   tokenizationUseCase.TokenizationKeyRepository
-	tokenizationTokenRepository tokenizationUseCase.TokenRepository
+	secretRepository            once[secretsUseCase.SecretRepository]
+	clientRepository            once[authUseCase.ClientRepository]
+	tokenRepository             once[authUseCase.TokenRepository]
+	auditLogRepository          once[authUseCase.AuditLogRepository]
+	transitKeyRepository        once[transitUseCase.TransitKeyRepository]
+	tokenizationKeyRepository   once[tokenizationUseCase.TokenizationKeyRepository]
+	tokenizationTokenRepository once[tokenizationUseCase.TokenRepository]
 
 	// Use Cases
-	kekUseCase             keyring.KekUseCase
-	secretUseCase          secretsUseCase.SecretUseCase
-	clientUseCase          authUseCase.ClientUseCase
-	tokenUseCase           authUseCase.TokenUseCase
-	auditLogUseCase        authUseCase.AuditLogUseCase
-	transitKeyUseCase      transitUseCase.TransitKeyUseCase
-	tokenizationKeyUseCase tokenizationUseCase.TokenizationKeyUseCase
-	tokenizationUseCase    tokenizationUseCase.TokenizationUseCase
+	kekUseCase             once[keyring.KekUseCase]
+	secretUseCase          once[secretsUseCase.SecretUseCase]
+	clientUseCase          once[authUseCase.ClientUseCase]
+	tokenUseCase           once[authUseCase.TokenUseCase]
+	auditLogUseCase        once[authUseCase.AuditLogUseCase]
+	transitKeyUseCase      once[transitUseCase.TransitKeyUseCase]
+	tokenizationKeyUseCase once[tokenizationUseCase.TokenizationKeyUseCase]
+	tokenizationUseCase    once[tokenizationUseCase.TokenizationUseCase]
 
 	// HTTP Handlers
-	clientHandler          *authHTTP.ClientHandler
-	tokenHandler           *authHTTP.TokenHandler
-	auditLogHandler        *authHTTP.AuditLogHandler
-	secretHandler          *secretsHTTP.SecretHandler
-	transitKeyHandler      *transitHTTP.TransitKeyHandler
-	cryptoHandler          *transitHTTP.CryptoHandler
-	tokenizationKeyHandler *tokenizationHTTP.TokenizationKeyHandler
-	tokenizationHandler    *tokenizationHTTP.TokenizationHandler
+	clientHandler          once[*authHTTP.ClientHandler]
+	tokenHandler           once[*authHTTP.TokenHandler]
+	auditLogHandler        once[*authHTTP.AuditLogHandler]
+	secretHandler          once[*secretsHTTP.SecretHandler]
+	transitKeyHandler      once[*transitHTTP.TransitKeyHandler]
+	cryptoHandler          once[*transitHTTP.CryptoHandler]
+	tokenizationKeyHandler once[*tokenizationHTTP.TokenizationKeyHandler]
+	tokenizationHandler    once[*tokenizationHTTP.TokenizationHandler]
 
-	// Servers and Workers
-	httpServer    *http.Server
-	metricsServer *http.MetricsServer
-
-	// Initialization flags and sync.Once for thread-safety
-	loggerInit                      sync.Once
-	dbInit                          sync.Once
-	masterKeyChainInit              sync.Once
-	txManagerInit                   sync.Once
-	metricsProviderInit             sync.Once
-	businessMetricsInit             sync.Once
-	kmsServiceInit                  sync.Once
-	secretServiceInit               sync.Once
-	tokenServiceInit                sync.Once
-	keyringInit                     sync.Once
-	secretRepositoryInit            sync.Once
-	clientRepositoryInit            sync.Once
-	tokenRepositoryInit             sync.Once
-	auditLogRepositoryInit          sync.Once
-	transitKeyRepositoryInit        sync.Once
-	tokenizationKeyRepositoryInit   sync.Once
-	tokenizationTokenRepositoryInit sync.Once
-	kekUseCaseInit                  sync.Once
-	secretUseCaseInit               sync.Once
-	clientUseCaseInit               sync.Once
-	tokenUseCaseInit                sync.Once
-	auditLogUseCaseInit             sync.Once
-	transitKeyUseCaseInit           sync.Once
-	tokenizationKeyUseCaseInit      sync.Once
-	tokenizationUseCaseInit         sync.Once
-	clientHandlerInit               sync.Once
-	tokenHandlerInit                sync.Once
-	auditLogHandlerInit             sync.Once
-	secretHandlerInit               sync.Once
-	transitKeyHandlerInit           sync.Once
-	cryptoHandlerInit               sync.Once
-	tokenizationKeyHandlerInit      sync.Once
-	tokenizationHandlerInit         sync.Once
-	httpServerInit                  sync.Once
-	metricsServerInit               sync.Once
-	initErrors                      sync.Map
+	// Servers
+	httpServer    once[*http.Server]
+	metricsServer once[*http.MetricsServer]
 }
 
 // NewContainer creates a new dependency injection container with the provided configuration.
@@ -144,150 +107,78 @@ func (c *Container) Logger() *slog.Logger {
 
 // DB returns the database connection.
 func (c *Container) DB(ctx context.Context) (*sql.DB, error) {
-	var err error
-	c.dbInit.Do(func() {
-		c.db, err = c.initDB(ctx)
-		if err != nil {
-			c.initErrors.Store("db", err)
-		}
+	return c.db.get(func() (*sql.DB, error) {
+		return c.initDB(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("db"); ok {
-		return nil, val.(error)
-	}
-	return c.db, nil
 }
 
 // TxManager returns the transaction manager.
 func (c *Container) TxManager(ctx context.Context) (database.TxManager, error) {
-	var err error
-	c.txManagerInit.Do(func() {
-		c.txManager, err = c.initTxManager(ctx)
-		if err != nil {
-			c.initErrors.Store("txManager", err)
-		}
+	return c.txManager.get(func() (database.TxManager, error) {
+		return c.initTxManager(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("txManager"); ok {
-		return nil, val.(error)
-	}
-	return c.txManager, nil
 }
 
 // MetricsProvider returns the metrics provider for Prometheus export.
 func (c *Container) MetricsProvider(ctx context.Context) (*metrics.Provider, error) {
-	var err error
-	c.metricsProviderInit.Do(func() {
-		c.metricsProvider, err = c.initMetricsProvider(ctx)
-		if err != nil {
-			c.initErrors.Store("metricsProvider", err)
-		}
+	return c.metricsProvider.get(func() (*metrics.Provider, error) {
+		return c.initMetricsProvider(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("metricsProvider"); ok {
-		return nil, val.(error)
-	}
-	return c.metricsProvider, nil
 }
 
 // BusinessMetrics returns the business metrics recorder.
 func (c *Container) BusinessMetrics(ctx context.Context) (metrics.BusinessMetrics, error) {
-	var err error
-	c.businessMetricsInit.Do(func() {
-		c.businessMetrics, err = c.initBusinessMetrics(ctx)
-		if err != nil {
-			c.initErrors.Store("businessMetrics", err)
-		}
+	return c.businessMetrics.get(func() (metrics.BusinessMetrics, error) {
+		return c.initBusinessMetrics(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("businessMetrics"); ok {
-		return nil, val.(error)
-	}
-	return c.businessMetrics, nil
 }
 
 // HTTPServer returns the HTTP server instance.
 func (c *Container) HTTPServer(ctx context.Context) (*http.Server, error) {
-	var err error
-	c.httpServerInit.Do(func() {
-		c.httpServer, err = c.initHTTPServer(ctx)
-		if err != nil {
-			c.initErrors.Store("httpServer", err)
-		}
+	return c.httpServer.get(func() (*http.Server, error) {
+		return c.initHTTPServer(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("httpServer"); ok {
-		return nil, val.(error)
-	}
-	return c.httpServer, nil
 }
 
 // MetricsServer returns the Metrics server instance.
 func (c *Container) MetricsServer(ctx context.Context) (*http.MetricsServer, error) {
-	var err error
-	c.metricsServerInit.Do(func() {
-		c.metricsServer, err = c.initMetricsServer(ctx)
-		if err != nil {
-			c.initErrors.Store("metricsServer", err)
-		}
+	return c.metricsServer.get(func() (*http.MetricsServer, error) {
+		return c.initMetricsServer(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("metricsServer"); ok {
-		return nil, val.(error)
-	}
-	return c.metricsServer, nil
 }
 
 // Shutdown performs cleanup of all initialized resources.
 func (c *Container) Shutdown(ctx context.Context) error {
 	var shutdownErrors []error
 
-	// Shutdown HTTP server if initialized
-	if c.httpServer != nil {
-		if err := c.httpServer.Shutdown(ctx); err != nil {
+	if c.httpServer.val != nil {
+		if err := c.httpServer.val.Shutdown(ctx); err != nil {
 			shutdownErrors = append(shutdownErrors, fmt.Errorf("http server shutdown: %w", err))
 		}
 	}
 
-	// Shutdown metrics provider if initialized
-	if c.metricsProvider != nil {
-		if err := c.metricsProvider.Shutdown(ctx); err != nil {
+	if c.metricsProvider.val != nil {
+		if err := c.metricsProvider.val.Shutdown(ctx); err != nil {
 			shutdownErrors = append(shutdownErrors, fmt.Errorf("metrics provider shutdown: %w", err))
 		}
 	}
 
-	// Shutdown metrics server if initialized
-	if c.metricsServer != nil {
-		if err := c.metricsServer.Shutdown(ctx); err != nil {
+	if c.metricsServer.val != nil {
+		if err := c.metricsServer.val.Shutdown(ctx); err != nil {
 			shutdownErrors = append(shutdownErrors, fmt.Errorf("metrics server shutdown: %w", err))
 		}
 	}
 
-	// Close master key chain if initialized
-	if c.masterKeyChain != nil {
-		c.masterKeyChain.Close()
+	if c.masterKeyChain.val != nil {
+		c.masterKeyChain.val.Close()
 	}
 
-	// Close database connection if initialized
-	if c.db != nil {
-		if err := c.db.Close(); err != nil {
+	if c.db.val != nil {
+		if err := c.db.val.Close(); err != nil {
 			shutdownErrors = append(shutdownErrors, fmt.Errorf("database close: %w", err))
 		}
 	}
 
-	// Return combined errors if any occurred
 	if len(shutdownErrors) > 0 {
 		return fmt.Errorf("shutdown errors: %v", shutdownErrors)
 	}
@@ -356,7 +247,6 @@ func (c *Container) initMetricsProvider(ctx context.Context) (*metrics.Provider,
 }
 
 // initBusinessMetrics creates the business metrics recorder.
-// Only called when MetricsEnabled is true.
 func (c *Container) initBusinessMetrics(ctx context.Context) (metrics.BusinessMetrics, error) {
 	provider, err := c.MetricsProvider(ctx)
 	if err != nil {
@@ -391,7 +281,6 @@ func (c *Container) initHTTPServer(ctx context.Context) (*http.Server, error) {
 		logger,
 	)
 
-	// Get dependencies for routing
 	clientHandler, err := c.ClientHandler(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client handler: %w", err)
@@ -442,13 +331,11 @@ func (c *Container) initHTTPServer(ctx context.Context) (*http.Server, error) {
 		return nil, fmt.Errorf("failed to get audit log use case: %w", err)
 	}
 
-	// Get metrics provider (may be nil if metrics are disabled)
 	metricsProvider, err := c.MetricsProvider(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get metrics provider: %w", err)
 	}
 
-	// Setup router with dependencies
 	server.SetupRouter(ctx, c.config, http.RouterDeps{
 		ClientHandler:          clientHandler,
 		TokenHandler:           tokenHandler,
@@ -474,7 +361,6 @@ func (c *Container) initMetricsServer(ctx context.Context) (*http.MetricsServer,
 	}
 
 	logger := c.Logger()
-	// Get metrics provider using existing accessor
 	provider, err := c.MetricsProvider(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get metrics provider: %w", err)

--- a/internal/app/di_auth.go
+++ b/internal/app/di_auth.go
@@ -20,38 +20,16 @@ func (c *Container) SecretService() authService.SecretService {
 
 // ClientRepository returns the client repository.
 func (c *Container) ClientRepository(ctx context.Context) (authUseCase.ClientRepository, error) {
-	var err error
-	c.clientRepositoryInit.Do(func() {
-		c.clientRepository, err = c.initClientRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("clientRepository", err)
-		}
+	return c.clientRepository.get(func() (authUseCase.ClientRepository, error) {
+		return c.initClientRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("clientRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.clientRepository, nil
 }
 
 // ClientUseCase returns the client use case.
 func (c *Container) ClientUseCase(ctx context.Context) (authUseCase.ClientUseCase, error) {
-	var err error
-	c.clientUseCaseInit.Do(func() {
-		c.clientUseCase, err = c.initClientUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("clientUseCase", err)
-		}
+	return c.clientUseCase.get(func() (authUseCase.ClientUseCase, error) {
+		return c.initClientUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("clientUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.clientUseCase, nil
 }
 
 // TokenService returns the token service for authentication operations.
@@ -64,128 +42,51 @@ func (c *Container) TokenService() authService.TokenService {
 
 // TokenRepository returns the token repository.
 func (c *Container) TokenRepository(ctx context.Context) (authUseCase.TokenRepository, error) {
-	var err error
-	c.tokenRepositoryInit.Do(func() {
-		c.tokenRepository, err = c.initTokenRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenRepository", err)
-		}
+	return c.tokenRepository.get(func() (authUseCase.TokenRepository, error) {
+		return c.initTokenRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenRepository, nil
 }
 
 // AuditLogRepository returns the audit log repository.
 func (c *Container) AuditLogRepository(ctx context.Context) (authUseCase.AuditLogRepository, error) {
-	var err error
-	c.auditLogRepositoryInit.Do(func() {
-		c.auditLogRepository, err = c.initAuditLogRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("auditLogRepository", err)
-		}
+	return c.auditLogRepository.get(func() (authUseCase.AuditLogRepository, error) {
+		return c.initAuditLogRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("auditLogRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.auditLogRepository, nil
 }
 
 // TokenUseCase returns the token use case.
 func (c *Container) TokenUseCase(ctx context.Context) (authUseCase.TokenUseCase, error) {
-	var err error
-	c.tokenUseCaseInit.Do(func() {
-		c.tokenUseCase, err = c.initTokenUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenUseCase", err)
-		}
+	return c.tokenUseCase.get(func() (authUseCase.TokenUseCase, error) {
+		return c.initTokenUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenUseCase, nil
 }
 
 // AuditLogUseCase returns the audit log use case.
 func (c *Container) AuditLogUseCase(ctx context.Context) (authUseCase.AuditLogUseCase, error) {
-	var err error
-	c.auditLogUseCaseInit.Do(func() {
-		c.auditLogUseCase, err = c.initAuditLogUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("auditLogUseCase", err)
-		}
+	return c.auditLogUseCase.get(func() (authUseCase.AuditLogUseCase, error) {
+		return c.initAuditLogUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("auditLogUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.auditLogUseCase, nil
 }
 
 // ClientHandler returns the HTTP handler for client management operations.
 func (c *Container) ClientHandler(ctx context.Context) (*authHTTP.ClientHandler, error) {
-	var err error
-	c.clientHandlerInit.Do(func() {
-		c.clientHandler, err = c.initClientHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("clientHandler", err)
-		}
+	return c.clientHandler.get(func() (*authHTTP.ClientHandler, error) {
+		return c.initClientHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("clientHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.clientHandler, nil
 }
 
 // TokenHandler returns the HTTP handler for token operations.
 func (c *Container) TokenHandler(ctx context.Context) (*authHTTP.TokenHandler, error) {
-	var err error
-	c.tokenHandlerInit.Do(func() {
-		c.tokenHandler, err = c.initTokenHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenHandler", err)
-		}
+	return c.tokenHandler.get(func() (*authHTTP.TokenHandler, error) {
+		return c.initTokenHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenHandler, nil
 }
 
 // AuditLogHandler returns the HTTP handler for audit log operations.
 func (c *Container) AuditLogHandler(ctx context.Context) (*authHTTP.AuditLogHandler, error) {
-	var err error
-	c.auditLogHandlerInit.Do(func() {
-		c.auditLogHandler, err = c.initAuditLogHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("auditLogHandler", err)
-		}
+	return c.auditLogHandler.get(func() (*authHTTP.AuditLogHandler, error) {
+		return c.initAuditLogHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("auditLogHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.auditLogHandler, nil
 }
 
 // initSecretService creates the secret service for authentication.
@@ -357,7 +258,5 @@ func (c *Container) initAuditLogHandler(ctx context.Context) (*authHTTP.AuditLog
 		return nil, fmt.Errorf("failed to get audit log use case for audit log handler: %w", err)
 	}
 
-	logger := c.Logger()
-
-	return authHTTP.NewAuditLogHandler(auditLogUseCase, logger), nil
+	return authHTTP.NewAuditLogHandler(auditLogUseCase, c.Logger()), nil
 }

--- a/internal/app/di_crypto.go
+++ b/internal/app/di_crypto.go
@@ -9,20 +9,9 @@ import (
 
 // Keyring returns the envelope-encryption keyring shared by all features.
 func (c *Container) Keyring(ctx context.Context) (keyring.Keyring, error) {
-	var err error
-	c.keyringInit.Do(func() {
-		c.keyring, err = c.initKeyring(ctx)
-		if err != nil {
-			c.initErrors.Store("keyring", err)
-		}
+	return c.keyring.get(func() (keyring.Keyring, error) {
+		return c.initKeyring(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("keyring"); ok {
-		return nil, val.(error)
-	}
-	return c.keyring, nil
 }
 
 func (c *Container) initKeyring(ctx context.Context) (keyring.Keyring, error) {
@@ -39,20 +28,9 @@ func (c *Container) initKeyring(ctx context.Context) (keyring.Keyring, error) {
 
 // MasterKeyChain returns the master key chain loaded from environment variables.
 func (c *Container) MasterKeyChain(ctx context.Context) (*keyring.MasterKeyChain, error) {
-	var err error
-	c.masterKeyChainInit.Do(func() {
-		c.masterKeyChain, err = c.initMasterKeyChain(ctx)
-		if err != nil {
-			c.initErrors.Store("masterKeyChain", err)
-		}
+	return c.masterKeyChain.get(func() (*keyring.MasterKeyChain, error) {
+		return c.initMasterKeyChain(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("masterKeyChain"); ok {
-		return nil, val.(error)
-	}
-	return c.masterKeyChain, nil
 }
 
 func (c *Container) initMasterKeyChain(ctx context.Context) (*keyring.MasterKeyChain, error) {
@@ -74,20 +52,9 @@ func (c *Container) KeySigner(ctx context.Context) (keyring.KeySigner, error) {
 
 // KekUseCase returns the KEK use case.
 func (c *Container) KekUseCase(ctx context.Context) (keyring.KekUseCase, error) {
-	var err error
-	c.kekUseCaseInit.Do(func() {
-		c.kekUseCase, err = c.initKekUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("kekUseCase", err)
-		}
+	return c.kekUseCase.get(func() (keyring.KekUseCase, error) {
+		return c.initKekUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("kekUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.kekUseCase, nil
 }
 
 func (c *Container) initKekUseCase(ctx context.Context) (keyring.KekUseCase, error) {

--- a/internal/app/di_secrets.go
+++ b/internal/app/di_secrets.go
@@ -11,56 +11,23 @@ import (
 
 // SecretRepository returns the secret repository.
 func (c *Container) SecretRepository(ctx context.Context) (secretsUseCase.SecretRepository, error) {
-	var err error
-	c.secretRepositoryInit.Do(func() {
-		c.secretRepository, err = c.initSecretRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("secretRepository", err)
-		}
+	return c.secretRepository.get(func() (secretsUseCase.SecretRepository, error) {
+		return c.initSecretRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("secretRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.secretRepository, nil
 }
 
 // SecretUseCase returns the secret use case.
 func (c *Container) SecretUseCase(ctx context.Context) (secretsUseCase.SecretUseCase, error) {
-	var err error
-	c.secretUseCaseInit.Do(func() {
-		c.secretUseCase, err = c.initSecretUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("secretUseCase", err)
-		}
+	return c.secretUseCase.get(func() (secretsUseCase.SecretUseCase, error) {
+		return c.initSecretUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("secretUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.secretUseCase, nil
 }
 
 // SecretHandler returns the HTTP handler for secret management operations.
 func (c *Container) SecretHandler(ctx context.Context) (*secretsHTTP.SecretHandler, error) {
-	var err error
-	c.secretHandlerInit.Do(func() {
-		c.secretHandler, err = c.initSecretHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("secretHandler", err)
-		}
+	return c.secretHandler.get(func() (*secretsHTTP.SecretHandler, error) {
+		return c.initSecretHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("secretHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.secretHandler, nil
 }
 
 func (c *Container) initSecretRepository(ctx context.Context) (secretsUseCase.SecretRepository, error) {

--- a/internal/app/di_tokenization.go
+++ b/internal/app/di_tokenization.go
@@ -12,113 +12,47 @@ import (
 func (c *Container) TokenizationKeyRepository(
 	ctx context.Context,
 ) (tokenizationUseCase.TokenizationKeyRepository, error) {
-	var err error
-	c.tokenizationKeyRepositoryInit.Do(func() {
-		c.tokenizationKeyRepository, err = c.initTokenizationKeyRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenizationKeyRepository", err)
-		}
+	return c.tokenizationKeyRepository.get(func() (tokenizationUseCase.TokenizationKeyRepository, error) {
+		return c.initTokenizationKeyRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenizationKeyRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenizationKeyRepository, nil
 }
 
 func (c *Container) TokenizationTokenRepository(
 	ctx context.Context,
 ) (tokenizationUseCase.TokenRepository, error) {
-	var err error
-	c.tokenizationTokenRepositoryInit.Do(func() {
-		c.tokenizationTokenRepository, err = c.initTokenizationTokenRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenizationTokenRepository", err)
-		}
+	return c.tokenizationTokenRepository.get(func() (tokenizationUseCase.TokenRepository, error) {
+		return c.initTokenizationTokenRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenizationTokenRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenizationTokenRepository, nil
 }
 
 func (c *Container) TokenizationKeyUseCase(
 	ctx context.Context,
 ) (tokenizationUseCase.TokenizationKeyUseCase, error) {
-	var err error
-	c.tokenizationKeyUseCaseInit.Do(func() {
-		c.tokenizationKeyUseCase, err = c.initTokenizationKeyUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenizationKeyUseCase", err)
-		}
+	return c.tokenizationKeyUseCase.get(func() (tokenizationUseCase.TokenizationKeyUseCase, error) {
+		return c.initTokenizationKeyUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenizationKeyUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenizationKeyUseCase, nil
 }
 
 func (c *Container) TokenizationUseCase(
 	ctx context.Context,
 ) (tokenizationUseCase.TokenizationUseCase, error) {
-	var err error
-	c.tokenizationUseCaseInit.Do(func() {
-		c.tokenizationUseCase, err = c.initTokenizationUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenizationUseCase", err)
-		}
+	return c.tokenizationUseCase.get(func() (tokenizationUseCase.TokenizationUseCase, error) {
+		return c.initTokenizationUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenizationUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenizationUseCase, nil
 }
 
 func (c *Container) TokenizationKeyHandler(
 	ctx context.Context,
 ) (*tokenizationHTTP.TokenizationKeyHandler, error) {
-	var err error
-	c.tokenizationKeyHandlerInit.Do(func() {
-		c.tokenizationKeyHandler, err = c.initTokenizationKeyHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenizationKeyHandler", err)
-		}
+	return c.tokenizationKeyHandler.get(func() (*tokenizationHTTP.TokenizationKeyHandler, error) {
+		return c.initTokenizationKeyHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenizationKeyHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenizationKeyHandler, nil
 }
 
 func (c *Container) TokenizationHandler(ctx context.Context) (*tokenizationHTTP.TokenizationHandler, error) {
-	var err error
-	c.tokenizationHandlerInit.Do(func() {
-		c.tokenizationHandler, err = c.initTokenizationHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("tokenizationHandler", err)
-		}
+	return c.tokenizationHandler.get(func() (*tokenizationHTTP.TokenizationHandler, error) {
+		return c.initTokenizationHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("tokenizationHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.tokenizationHandler, nil
 }
 
 func (c *Container) initTokenizationKeyRepository(

--- a/internal/app/di_transit.go
+++ b/internal/app/di_transit.go
@@ -10,71 +10,27 @@ import (
 )
 
 func (c *Container) TransitKeyRepository(ctx context.Context) (transitUseCase.TransitKeyRepository, error) {
-	var err error
-	c.transitKeyRepositoryInit.Do(func() {
-		c.transitKeyRepository, err = c.initTransitKeyRepository(ctx)
-		if err != nil {
-			c.initErrors.Store("transitKeyRepository", err)
-		}
+	return c.transitKeyRepository.get(func() (transitUseCase.TransitKeyRepository, error) {
+		return c.initTransitKeyRepository(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("transitKeyRepository"); ok {
-		return nil, val.(error)
-	}
-	return c.transitKeyRepository, nil
 }
 
 func (c *Container) TransitKeyUseCase(ctx context.Context) (transitUseCase.TransitKeyUseCase, error) {
-	var err error
-	c.transitKeyUseCaseInit.Do(func() {
-		c.transitKeyUseCase, err = c.initTransitKeyUseCase(ctx)
-		if err != nil {
-			c.initErrors.Store("transitKeyUseCase", err)
-		}
+	return c.transitKeyUseCase.get(func() (transitUseCase.TransitKeyUseCase, error) {
+		return c.initTransitKeyUseCase(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("transitKeyUseCase"); ok {
-		return nil, val.(error)
-	}
-	return c.transitKeyUseCase, nil
 }
 
 func (c *Container) TransitKeyHandler(ctx context.Context) (*transitHTTP.TransitKeyHandler, error) {
-	var err error
-	c.transitKeyHandlerInit.Do(func() {
-		c.transitKeyHandler, err = c.initTransitKeyHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("transitKeyHandler", err)
-		}
+	return c.transitKeyHandler.get(func() (*transitHTTP.TransitKeyHandler, error) {
+		return c.initTransitKeyHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("transitKeyHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.transitKeyHandler, nil
 }
 
 func (c *Container) CryptoHandler(ctx context.Context) (*transitHTTP.CryptoHandler, error) {
-	var err error
-	c.cryptoHandlerInit.Do(func() {
-		c.cryptoHandler, err = c.initCryptoHandler(ctx)
-		if err != nil {
-			c.initErrors.Store("cryptoHandler", err)
-		}
+	return c.cryptoHandler.get(func() (*transitHTTP.CryptoHandler, error) {
+		return c.initCryptoHandler(ctx)
 	})
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := c.initErrors.Load("cryptoHandler"); ok {
-		return nil, val.(error)
-	}
-	return c.cryptoHandler, nil
 }
 
 func (c *Container) initTransitKeyRepository(

--- a/internal/app/once.go
+++ b/internal/app/once.go
@@ -1,0 +1,20 @@
+package app
+
+import "sync"
+
+// once is a generic lazy-init helper that captures both value and error from a
+// single initialisation call. It replaces the pattern of pairing sync.Once with
+// a sync.Map to propagate errors to concurrent callers.
+//
+// Thread safety: sync.Once guarantees that fn runs exactly once and that its
+// side-effects are visible to all goroutines that call get after fn returns.
+type once[T any] struct {
+	sync.Once
+	val T
+	err error
+}
+
+func (o *once[T]) get(fn func() (T, error)) (T, error) {
+	o.Do(func() { o.val, o.err = fn() })
+	return o.val, o.err
+}


### PR DESCRIPTION
## Summary

- Introduce `internal/app/once[T]` — a 20-line generic that captures both value and error from a single lazy-init call, replacing the pattern of pairing `sync.Once` with a `sync.Map` to thread errors to concurrent callers
- Convert all 30 fallible components in the DI container from a 2-field + 12-line accessor to a single `once[T]` field + 3-line accessor
- Delete `sync.Map initErrors` and all `Store`/`Load` calls from the container

Net change: **−371 lines** (507 deleted, 136 inserted across 7 files).

The 4 infallible singletons (`logger`, `kmsService`, `secretService`, `tokenService`) keep their existing `sync.Once` form — `di_test.go` accesses `container.logger` directly.

## Test plan

- [x] All 1276 unit tests pass with `-race`
- [x] `go build ./...` succeeds
- [x] `TestContainerInitializationErrors` and `TestContainerSyncMapConcurrency` confirm error propagation and concurrent safety still hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)