### PR TITLE
refactor(http): deepen cursor pagination behind Paginate helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Folded the `Algorithm` return value into `TransitKey.Algorithm` so `GetTransitKey` and `Get` return `(*TransitKey, error)` instead of a three-value tuple; replaced `crypto/domain.Algorithm` with `keyring.Algorithm` across transit and tokenization layers. No behavior change.
 - Collapsed `internal/crypto/{domain,repository,service,usecase}` into `internal/keyring`; all types, stores, cipher primitives, KMS adapter, and KEK use case now live in a single package. No behavior change.
 - Replaced seven shallow metrics decorator structs with a single `BusinessMetricsMiddleware` applied per-route in the HTTP server and a `metrics.Track` helper for CLI commands; added `NopBusinessMetrics` so the DI container always returns a valid recorder instead of branching on `MetricsEnabled`. No behavior change.
+- Collapsed the cursor-pagination over-fetch convention (fetch `limit+1`, trim, lift the next cursor) behind a generic `httputil.Paginate` helper; the five List handlers now supply only a fetch closure and a cursor-field extractor. No HTTP contract change.
 
 ## [0.28.0] - 2026-03-23
 

--- a/internal/auth/http/audit_log_handler.go
+++ b/internal/auth/http/audit_log_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	authDomain "github.com/allisson/secrets/internal/auth/domain"
 	"github.com/allisson/secrets/internal/auth/http/dto"
 	authUseCase "github.com/allisson/secrets/internal/auth/usecase"
 	"github.com/allisson/secrets/internal/httputil"
@@ -100,27 +101,23 @@ func (h *AuditLogHandler) ListHandler(c *gin.Context) {
 		return
 	}
 
-	// Call use case with limit + 1 to detect if there are more results
-	auditLogs, err := h.auditLogUseCase.ListCursor(
-		c.Request.Context(),
-		afterID,
-		limit+1,
-		createdAtFrom,
-		createdAtTo,
-		clientID,
+	auditLogs, nextCursor, err := httputil.Paginate(
+		func(l int) ([]*authDomain.AuditLog, error) {
+			return h.auditLogUseCase.ListCursor(
+				c.Request.Context(),
+				afterID,
+				l,
+				createdAtFrom,
+				createdAtTo,
+				clientID,
+			)
+		},
+		limit,
+		func(a *authDomain.AuditLog) string { return a.ID.String() },
 	)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return
-	}
-
-	// Determine if there are more results and set next cursor
-	var nextCursor *string
-	if len(auditLogs) > limit {
-		// More results exist, use the last visible item's ID as cursor
-		auditLogs = auditLogs[:limit]
-		cursorValue := auditLogs[len(auditLogs)-1].ID.String()
-		nextCursor = &cursorValue
 	}
 
 	// Map to response

--- a/internal/auth/http/client_handler.go
+++ b/internal/auth/http/client_handler.go
@@ -203,20 +203,16 @@ func (h *ClientHandler) ListHandler(c *gin.Context) {
 		return
 	}
 
-	// Call use case with limit + 1 to detect if there are more results
-	clients, err := h.clientUseCase.ListCursor(c.Request.Context(), afterID, limit+1)
+	clients, nextCursor, err := httputil.Paginate(
+		func(l int) ([]*authDomain.Client, error) {
+			return h.clientUseCase.ListCursor(c.Request.Context(), afterID, l)
+		},
+		limit,
+		func(client *authDomain.Client) string { return client.ID.String() },
+	)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return
-	}
-
-	// Determine if there are more results and set next cursor
-	var nextCursor *string
-	if len(clients) > limit {
-		// More results exist, use the last visible item's ID as cursor
-		clients = clients[:limit]
-		cursorValue := clients[len(clients)-1].ID.String()
-		nextCursor = &cursorValue
 	}
 
 	// Map to response

--- a/internal/httputil/pagination.go
+++ b/internal/httputil/pagination.go
@@ -49,6 +49,31 @@ func ParseUUIDCursorPagination(
 	return afterCursor, limit, nil
 }
 
+// Paginate applies the over-fetch-by-one convention for cursor pagination.
+// It calls fetch with limit+1 to detect whether more rows exist; if an extra
+// row came back it trims the page to limit and returns the cursor of the last
+// visible row (via cursorOf), otherwise next is nil. The whole convention —
+// the +1, the trim, and the cursor extraction — lives here so call sites only
+// supply the fetch and the cursor field.
+func Paginate[T any](
+	fetch func(limit int) ([]T, error),
+	limit int,
+	cursorOf func(T) string,
+) (page []T, next *string, err error) {
+	rows, err := fetch(limit + 1)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(rows) > limit {
+		rows = rows[:limit]
+		cursor := cursorOf(rows[len(rows)-1])
+		next = &cursor
+	}
+
+	return rows, next, nil
+}
+
 // ParseStringCursorPagination parses cursor-based pagination parameters for string-based cursors.
 // It accepts a cursor parameter name (e.g., "after_path", "after_name") and returns the parsed string cursor and limit.
 // The cursor is optional (nil if not provided). The limit defaults to 50 and is clamped to 1000.

--- a/internal/httputil/pagination_test.go
+++ b/internal/httputil/pagination_test.go
@@ -1,6 +1,7 @@
 package httputil_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -238,4 +239,71 @@ func TestParseStringCursorPagination(t *testing.T) {
 // stringPtr returns a pointer to a string value
 func stringPtr(s string) *string {
 	return &s
+}
+
+func TestPaginate(t *testing.T) {
+	type row struct{ name string }
+	cursorOf := func(r row) string { return r.name }
+
+	t.Run("empty result yields no cursor", func(t *testing.T) {
+		page, next, err := httputil.Paginate(
+			func(int) ([]row, error) { return nil, nil },
+			3,
+			cursorOf,
+		)
+		assert.NoError(t, err)
+		assert.Empty(t, page)
+		assert.Nil(t, next)
+	})
+
+	t.Run("fewer than limit yields no cursor", func(t *testing.T) {
+		page, next, err := httputil.Paginate(
+			func(int) ([]row, error) { return []row{{"a"}, {"b"}}, nil },
+			3,
+			cursorOf,
+		)
+		assert.NoError(t, err)
+		assert.Len(t, page, 2)
+		assert.Nil(t, next)
+	})
+
+	t.Run("exactly limit yields no cursor", func(t *testing.T) {
+		page, next, err := httputil.Paginate(
+			func(int) ([]row, error) { return []row{{"a"}, {"b"}, {"c"}}, nil },
+			3,
+			cursorOf,
+		)
+		assert.NoError(t, err)
+		assert.Len(t, page, 3)
+		assert.Nil(t, next)
+	})
+
+	t.Run("over-fetch trims to limit and sets cursor from last visible row", func(t *testing.T) {
+		var requested int
+		page, next, err := httputil.Paginate(
+			func(l int) ([]row, error) {
+				requested = l
+				return []row{{"a"}, {"b"}, {"c"}}, nil
+			},
+			2,
+			cursorOf,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, requested, "fetch must be called with limit+1")
+		assert.Len(t, page, 2)
+		assert.Equal(t, []row{{"a"}, {"b"}}, page)
+		assert.Equal(t, stringPtr("b"), next)
+	})
+
+	t.Run("fetch error propagates", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		page, next, err := httputil.Paginate(
+			func(int) ([]row, error) { return nil, wantErr },
+			3,
+			cursorOf,
+		)
+		assert.ErrorIs(t, err, wantErr)
+		assert.Nil(t, page)
+		assert.Nil(t, next)
+	})
 }

--- a/internal/secrets/http/secret_handler.go
+++ b/internal/secrets/http/secret_handler.go
@@ -186,20 +186,16 @@ func (h *SecretHandler) ListHandler(c *gin.Context) {
 		return
 	}
 
-	// Call use case with limit + 1 to detect if there are more results
-	secrets, err := h.secretUseCase.ListCursor(c.Request.Context(), afterPath, limit+1)
+	secrets, nextCursor, err := httputil.Paginate(
+		func(l int) ([]*secretsDomain.Secret, error) {
+			return h.secretUseCase.ListCursor(c.Request.Context(), afterPath, l)
+		},
+		limit,
+		func(s *secretsDomain.Secret) string { return s.Path },
+	)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return
-	}
-
-	// Determine if there are more results and set next cursor
-	var nextCursor *string
-	if len(secrets) > limit {
-		// More results exist, use the last visible item's path as cursor
-		secrets = secrets[:limit]
-		cursorValue := secrets[len(secrets)-1].Path
-		nextCursor = &cursorValue
 	}
 
 	// Map to response

--- a/internal/tokenization/http/tokenization_key_handler.go
+++ b/internal/tokenization/http/tokenization_key_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/allisson/secrets/internal/httputil"
+	tokenizationDomain "github.com/allisson/secrets/internal/tokenization/domain"
 	"github.com/allisson/secrets/internal/tokenization/http/dto"
 	tokenizationUseCase "github.com/allisson/secrets/internal/tokenization/usecase"
 	customValidation "github.com/allisson/secrets/internal/validation"
@@ -199,20 +200,16 @@ func (h *TokenizationKeyHandler) ListHandler(c *gin.Context) {
 		return
 	}
 
-	// Call use case with limit + 1 to detect if there are more results
-	keys, err := h.keyUseCase.ListCursor(c.Request.Context(), afterName, limit+1)
+	keys, nextCursor, err := httputil.Paginate(
+		func(l int) ([]*tokenizationDomain.TokenizationKey, error) {
+			return h.keyUseCase.ListCursor(c.Request.Context(), afterName, l)
+		},
+		limit,
+		func(k *tokenizationDomain.TokenizationKey) string { return k.Name },
+	)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return
-	}
-
-	// Determine if there are more results and set next cursor
-	var nextCursor *string
-	if len(keys) > limit {
-		// More results exist, use the last visible item's name as cursor
-		keys = keys[:limit]
-		cursorValue := keys[len(keys)-1].Name
-		nextCursor = &cursorValue
 	}
 
 	// Map to response

--- a/internal/transit/http/transit_key_handler.go
+++ b/internal/transit/http/transit_key_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/allisson/secrets/internal/httputil"
+	transitDomain "github.com/allisson/secrets/internal/transit/domain"
 	"github.com/allisson/secrets/internal/transit/http/dto"
 	transitUseCase "github.com/allisson/secrets/internal/transit/usecase"
 	customValidation "github.com/allisson/secrets/internal/validation"
@@ -155,20 +156,16 @@ func (h *TransitKeyHandler) ListHandler(c *gin.Context) {
 		return
 	}
 
-	// Call use case with limit + 1 to detect if there are more results
-	transitKeys, err := h.transitKeyUseCase.ListCursor(c.Request.Context(), afterName, limit+1)
+	transitKeys, nextCursor, err := httputil.Paginate(
+		func(l int) ([]*transitDomain.TransitKey, error) {
+			return h.transitKeyUseCase.ListCursor(c.Request.Context(), afterName, l)
+		},
+		limit,
+		func(k *transitDomain.TransitKey) string { return k.Name },
+	)
 	if err != nil {
 		httputil.HandleErrorGin(c, err, h.logger)
 		return
-	}
-
-	// Determine if there are more results and set next cursor
-	var nextCursor *string
-	if len(transitKeys) > limit {
-		// More results exist, use the last visible item's name as cursor
-		transitKeys = transitKeys[:limit]
-		cursorValue := transitKeys[len(transitKeys)-1].Name
-		nextCursor = &cursorValue
 	}
 
 	// Map to response


### PR DESCRIPTION
## Summary
- Add generic `httputil.Paginate[T](fetch, limit, cursorOf) (page, next, err)` that owns the full cursor-pagination over-fetch convention: call `fetch(limit+1)`, trim to `limit`, and lift the next cursor off the last visible row.
- Refactor all five List handlers (secrets, client, audit-log, transit, tokenization) onto it, deleting the duplicated `limit+1` / `if len > limit` / cursor block from each. The audit-log handler's extra filter args are captured in its fetch closure.
- The helper stays pure (no gin/DTO dependency) — handlers keep their own DTO mapping and JSON write.

## Why
The off-by-one logic was copy-pasted across five handlers, with each picking its own cursor field (`.Path`, `.Name`, `.ID`). It now lives in one place with a direct table test, instead of being implicitly re-proven through five handler suites.

## Test plan
- [x] `make build`
- [x] `make test` — full race-enabled suite, 0 failures
- [x] New table test in `pagination_test.go`: empty, fewer-than-limit, exactly-limit, over-fetch (asserts fetch called with `limit+1`, page trimmed, cursor = last visible row), and fetch-error propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)